### PR TITLE
fix for ignored proxy system properties in 1.5

### DIFF
--- a/rest-assured/src/main/groovy/com/jayway/restassured/internal/RequestSpecificationImpl.groovy
+++ b/rest-assured/src/main/groovy/com/jayway/restassured/internal/RequestSpecificationImpl.groovy
@@ -43,6 +43,7 @@ import org.apache.http.entity.HttpEntityWrapper
 
 import org.apache.http.entity.mime.MultipartEntity
 import org.apache.http.message.BasicHeader
+import org.apache.http.impl.conn.ProxySelectorRoutePlanner
 import static com.jayway.restassured.assertion.AssertParameter.notNull
 import com.jayway.restassured.response.*
 import com.jayway.restassured.specification.*
@@ -702,7 +703,10 @@ class RequestSpecificationImpl implements FilterableRequestSpecification {
         return super.parseResponse(resp, contentType)
       }
     };
-
+  
+    // make client aware of JRE proxy settings http://freeside.co/betamax/
+    http.client.routePlanner = new ProxySelectorRoutePlanner(
+        http.client.connectionManager.schemeRegistry, ProxySelector.default)
     applyRestAssuredConfig(http)
     registerRestAssuredEncoders(http);
     RestAssuredParserRegistry.responseSpecification = responseSpecification


### PR DESCRIPTION
Hi guys,
what do you think about this fix regarding HTTP proxy handling? In rest-assured 1.5 you use the apache httpclient which by default ignores proxy settings.

As described here http://hc.apache.org/httpcomponents-client-ga/tutorial/html/connmgmt.html#d5e582 in the HttpClient Tutorial: "The DefaultHttpRoutePlanner implementation does not make use of any Java system properties, nor any system or browser proxy settings."

So I changed it in RequestSpecificationImpl.groovy. I did it here because I couldn't figure out how to configure RestAssured properly using those configuration methods. I used a hint from http://freeside.co/betamax/#groovy_httpbuilder .

Best regards, Wolfram
