### PR TITLE
Issue 205 - Fix bug where KeyStoreImpl was removing Client Certs

### DIFF
--- a/rest-assured/src/main/groovy/com/jayway/restassured/authentication/CertAuthScheme.groovy
+++ b/rest-assured/src/main/groovy/com/jayway/restassured/authentication/CertAuthScheme.groovy
@@ -20,11 +20,16 @@ package com.jayway.restassured.authentication
 
 import com.jayway.restassured.internal.http.HTTPBuilder
 
+import java.security.KeyStore
+
 class CertAuthScheme implements AuthenticationScheme {
   def String certURL
   def String password
+  def String certType = KeyStore.getDefaultType()
+  def int port = 433
+  def KeystoreProvider trustStoreProvider
 
   @Override void authenticate(HTTPBuilder httpBuilder) {
-     httpBuilder.auth.certificate(certURL, password)
+     httpBuilder.auth.certificate(certURL, password, certType, port, trustStoreProvider)
   }
 }

--- a/rest-assured/src/main/groovy/com/jayway/restassured/authentication/KeystoreProvider.java
+++ b/rest-assured/src/main/groovy/com/jayway/restassured/authentication/KeystoreProvider.java
@@ -1,0 +1,19 @@
+package com.jayway.restassured.authentication;
+
+import java.security.KeyStore;
+
+/**
+ * Date: 22/04/2013
+ * Time: 13:55
+ */
+public interface KeystoreProvider {
+    /**
+     * @return If this KeystoreSpec can build a keystore
+     */
+    Boolean canBuild();
+
+    /**
+     * @return the Keystore represented by this keystore spec
+     */
+    KeyStore build();
+}

--- a/rest-assured/src/main/groovy/com/jayway/restassured/internal/NoKeystoreSpecImpl.groovy
+++ b/rest-assured/src/main/groovy/com/jayway/restassured/internal/NoKeystoreSpecImpl.groovy
@@ -18,10 +18,22 @@
 
 package com.jayway.restassured.internal
 
+import com.jayway.restassured.authentication.KeystoreProvider
 import com.jayway.restassured.internal.http.HTTPBuilder
+import sun.reflect.generics.reflectiveObjects.NotImplementedException
 
-class NoKeystoreSpecImpl implements KeystoreSpec {
+import java.security.KeyStore
+
+class NoKeystoreSpecImpl implements KeystoreSpec, KeystoreProvider {
 
   void apply(HTTPBuilder builder, int port) {
+  }
+
+  def Boolean canBuild() {
+    return false
+  }
+
+  def KeyStore build() {
+    throw new NotImplementedException()
   }
 }


### PR DESCRIPTION
Hi,

We were facing [Issue 205](https://code.google.com/p/rest-assured/issues/detail?id=205) and have made the following change to resolve this issue.
#### Problem

_I need to use `CertAuthScheme` to set a keystore with client certs to authenticate myself, but also need to set a truststore to define which servers I trust._

Setting a truststore by calling either `RestAssured.keystore()` or `reqSpecBuilder.setkeystore()` calls [schemeRegistry.register(scheme)](https://github.com/jayway/rest-assured/blob/master/rest-assured/src/main/groovy/com/jayway/restassured/internal/KeystoreSpecImpl.groovy#L54) which removes the certs setup by `AuthConfig` which also calls [schemeRegistry.register(scheme)](https://github.com/jayway/rest-assured/blob/master/rest-assured/src/main/java/com/jayway/restassured/internal/http/AuthConfig.java#L101)

(`register(scheme)` whacks the last scheme registered)
#### Solution

I was hoping that `SchemeRegistry` would allow us to get the `KeyStore` and `TrustStore` previously set and amend them, however I couldn't find a way to do this.

Instead, `CertAuthScheme` now is able to build the TrustStore, if one has been configured via `RestAssured.keystore()` or `reqSpecBuilder.setkeystore()` and adds both this TrustStore and the client cert.

Authentication now happens after setting truststore so `KeystoreSpecImpl` doesn't whack the client certs.

I've also externalised the port and cert type, but they still default to `443` and `KeyStore.getDefaultType()` for backwards compatibility.
#### Usage

This code now works as expected

```
    RequestSpecBuilder request = ...
    request.setKeystore("truststore.jks", "password");

    CertAuthScheme scheme = new CertAuthScheme();
    scheme.setCertURL("clientcert.p12");
    scheme.setCertType("pkcs12");
    scheme.setPassword("password");
    scheme.setPort(8443);
    request.setAuthentication(scheme);
```
