### PR TITLE
Use getClass().getResource() instead of URL to get certificate.

### DIFF
--- a/rest-assured/src/main/groovy/com/jayway/restassured/authentication/CertAuthScheme.groovy
+++ b/rest-assured/src/main/groovy/com/jayway/restassured/authentication/CertAuthScheme.groovy
@@ -20,7 +20,7 @@ import com.jayway.restassured.internal.http.HTTPBuilder
 import java.security.KeyStore
 
 class CertAuthScheme implements AuthenticationScheme {
-    def String certURL
+    def String certPath
     def String password
     def String certType = KeyStore.getDefaultType()
     def int port = 433
@@ -28,6 +28,6 @@ class CertAuthScheme implements AuthenticationScheme {
 
     @Override
     void authenticate(HTTPBuilder httpBuilder) {
-        httpBuilder.auth.certificate(certURL, password, certType, port, trustStoreProvider)
+        httpBuilder.auth.certificate(certPath, password, certType, port, trustStoreProvider)
     }
 }

--- a/rest-assured/src/main/groovy/com/jayway/restassured/internal/AuthenticationSpecificationImpl.groovy
+++ b/rest-assured/src/main/groovy/com/jayway/restassured/internal/AuthenticationSpecificationImpl.groovy
@@ -72,25 +72,25 @@ class AuthenticationSpecificationImpl implements AuthenticationSpecification {
      *     Uses keystore: <code>KeyStore.getDefaultType()</code>.
      * </p>
      *
-     * @param certURL URL to a JKS keystore where the certificate is stored.
+     * @param certPath           Location where the certificate is stored.
      * @param password password to decrypt the keystore
      * @return The request com.jayway.restassured.specification
      * @see #certificate(java.lang.String, java.lang.String, java.lang.String, int, com.jayway.restassured.authentication.KeystoreProvider)
      */
-    def RequestSpecification certificate(String certURL, String password) {
-        return certificate(certURL, password, KeyStore.getDefaultType(), 443)
+    def RequestSpecification certificate(String certPath, String password) {
+        return certificate(certPath, password, KeyStore.getDefaultType(), 443)
     }
 
-    def RequestSpecification certificate(String certURL, String password, String certType, int port) {
-        return certificate(certURL, password, certType, port, new NoKeystoreSpecImpl())
+    def RequestSpecification certificate(String certPath, String password, String certType, int port) {
+        return certificate(certPath, password, certType, port, new NoKeystoreSpecImpl())
     }
 
-    def RequestSpecification certificate(String certURL, String password, String certType, int port, KeystoreProvider trustStoreProvider) {
-        notNull certURL, "certURL"
+    def RequestSpecification certificate(String certPath, String password, String certType, int port, KeystoreProvider trustStoreProvider) {
+        notNull certPath, "certPath"
         notNull password, "password"
         notNull certType, "Certification type"
 
-        requestSpecification.authenticationScheme = new CertAuthScheme(certURL: certURL, password: password, certType: certType,
+        requestSpecification.authenticationScheme = new CertAuthScheme(certPath: certPath, password: password, certType: certType,
                 port: port, trustStoreProvider: trustStoreProvider)
         return requestSpecification
     }

--- a/rest-assured/src/main/java/com/jayway/restassured/RestAssured.java
+++ b/rest-assured/src/main/java/com/jayway/restassured/RestAssured.java
@@ -993,12 +993,13 @@ public class RestAssured {
      * Uses keystore provider: <code>none</code><br/>
      * </p>
      *
-     * @param certURL URL to a JKS keystore where the certificate is stored.
+     * @param certPath           Location where the certificate is stored.
+     * @param password           password to decrypt the keystore
      * @return The request com.jayway.restassured.specification
      */
-    public static AuthenticationScheme certificate(String certURL, String password) {
+    public static AuthenticationScheme certificate(String certPath, String password) {
         final CertAuthScheme scheme = new CertAuthScheme();
-        scheme.setCertURL(certURL);
+        scheme.setCertPath(certPath);
         scheme.setPassword(password);
         return scheme;
     }
@@ -1007,15 +1008,15 @@ public class RestAssured {
      * Sets a certificate to be used for SSL authentication. See {@link Class#getResource(String)} for how to get a URL from a resource
      * on the classpath.
      *
-     * @param certURL            URL to a JKS keystore where the certificate is stored.
+     * @param certPath           Location where the certificate is stored.
      * @param password           password to decrypt the keystore
-     * @param certType           The certificate type
+     * @param certType           The certificate type (eg jks or pkcs12)
      * @param port               The SSL port
      * @param trustStoreProvider The provider
      */
-    public static AuthenticationScheme certificate(String certURL, String password, String certType, int port, KeystoreProvider trustStoreProvider) {
+    public static AuthenticationScheme certificate(String certPath, String password, String certType, int port, KeystoreProvider trustStoreProvider) {
         final CertAuthScheme scheme = new CertAuthScheme();
-        scheme.setCertURL(certURL);
+        scheme.setCertPath(certPath);
         scheme.setPassword(password);
         scheme.setCertType(certType);
         scheme.setPort(port);
@@ -1027,13 +1028,13 @@ public class RestAssured {
      * Sets a certificate to be used for SSL authentication. See {@link Class#getResource(String)} for how to get a URL from a resource
      * on the classpath.
      *
-     * @param certURL  URL to a JKS keystore where the certificate is stored.
-     * @param password password to decrypt the keystore
-     * @param certType The certificate type
-     * @param port     The SSL port
+     * @param certPath           Location where the certificate is stored.
+     * @param password           password to decrypt the keystore
+     * @param certType           The certificate type (eg jks or pkcs12)
+     * @param port               The SSL port
      */
-    public static AuthenticationScheme certificate(String certURL, String password, String certType, int port) {
-        return certificate(certURL, password, certType, port);
+    public static AuthenticationScheme certificate(String certPath, String password, String certType, int port) {
+        return certificate(certPath, password, certType, port);
     }
 
     /**

--- a/rest-assured/src/main/java/com/jayway/restassured/internal/http/AuthConfig.java
+++ b/rest-assured/src/main/java/com/jayway/restassured/internal/http/AuthConfig.java
@@ -88,16 +88,16 @@ public class AuthConfig {
      * Sets a certificate to be used for SSL authentication. See {@link Class#getResource(String)} for how to get a URL from a resource
      * on the classpath.
      *
-     * @param certURL            URL to a JKS keystore where the certificate is stored.
+     * @param certPath           Location where the certificate is stored.
      * @param password           password to decrypt the keystore
-     * @param certType           The certificate type
+     * @param certType           The certificate type (eg jks or pkcs12)
      * @param port               The SSL port
      * @param trustStoreProvider The provider
      */
-    public void certificate(String certURL, String password, String certType, int port, KeystoreProvider trustStoreProvider) {
+    public void certificate(String certPath, String password, String certType, int port, KeystoreProvider trustStoreProvider) {
         try {
             KeyStore keyStore = KeyStore.getInstance(certType);
-            InputStream jksStream = new URL(certURL).openStream();
+            InputStream jksStream = getClass().getResource(certPath).openStream();
             try {
                 keyStore.load(jksStream, password.toCharArray());
             } finally {

--- a/rest-assured/src/main/java/com/jayway/restassured/specification/AuthenticationSpecification.java
+++ b/rest-assured/src/main/java/com/jayway/restassured/specification/AuthenticationSpecification.java
@@ -71,35 +71,35 @@ public interface AuthenticationSpecification {
      * Uses keystore provider: <code>none</code><br/>
      * </p>
      *
-     * @param certURL  URL to a JKS keystore where the certificate is stored.
+     * @param certPath           Location where the certificate is stored.
      * @param password password to decrypt the keystore
      * @return The request com.jayway.restassured.specification
      * @see #certificate(java.lang.String, java.lang.String, java.lang.String, int, com.jayway.restassured.authentication.KeystoreProvider)
      */
-    RequestSpecification certificate(String certURL, String password);
+    RequestSpecification certificate(String certPath, String password);
 
     /**
      * Sets a certificate to be used for SSL authentication. See {@link Class#getResource(String)} for how to get a URL from a resource
      * on the classpath.
      *
-     * @param certURL  URL to a JKS keystore where the certificate is stored.
+     * @param certPath           Location where the certificate is stored.
      * @param password password to decrypt the keystore
      * @param certType The certificate type
      * @param port     The SSL port
      */
-    RequestSpecification certificate(String certURL, String password, String certType, int port);
+    RequestSpecification certificate(String certPath, String password, String certType, int port);
 
     /**
      * Sets a certificate to be used for SSL authentication. See {@link Class#getResource(String)} for how to get a URL from a resource
      * on the classpath.
      *
-     * @param certURL            URL to a JKS keystore where the certificate is stored.
+     * @param certPath           Location where the certificate is stored.
      * @param password           password to decrypt the keystore
      * @param certType           The certificate type
      * @param port               The SSL port
      * @param trustStoreProvider The provider
      */
-    RequestSpecification certificate(String certURL, String password, String certType, int port, KeystoreProvider trustStoreProvider);
+    RequestSpecification certificate(String certPath, String password, String certType, int port, KeystoreProvider trustStoreProvider);
 
     /**
      * Excerpt from the HttpBuilder docs:<br>


### PR DESCRIPTION
Following on from pull request [14](https://github.com/jayway/rest-assured/pull/14) this makes specifying the location of a certificate a bit nicer.

```
scheme.setCertPath("/soapui.p12");
```

Instead of

```
 scheme.setCertURL("file:///my/project/src/test/resources/soapui.p12");
```
