### PR TITLE
Support for Given When Then cucumber tests

### DIFF
--- a/rest-assured/src/main/groovy/com/jayway/restassured/internal/ResponseSpecificationImpl.groovy
+++ b/rest-assured/src/main/groovy/com/jayway/restassured/internal/ResponseSpecificationImpl.groovy
@@ -66,6 +66,10 @@ class ResponseSpecificationImpl implements FilterableResponseSpecification {
         }
     }
 
+    def void validate(Response response) {
+      assertionClosure.validate(response)
+    }
+
     def ResponseSpecification content(Matcher matcher, Matcher...additionalMatchers) {
         notNull(matcher, "matcher")
         bodyMatchers << new BodyMatcher(key: null, matcher: matcher, rpr: rpr)

--- a/rest-assured/src/main/java/com/jayway/restassured/specification/ResponseSpecification.java
+++ b/rest-assured/src/main/java/com/jayway/restassured/specification/ResponseSpecification.java
@@ -18,6 +18,7 @@ package com.jayway.restassured.specification;
 
 import com.jayway.restassured.http.ContentType;
 import com.jayway.restassured.parsing.Parser;
+import com.jayway.restassured.response.Response;
 import org.hamcrest.Matcher;
 
 import java.util.List;
@@ -42,6 +43,13 @@ public interface ResponseSpecification extends RequestSender {
      * @return the response specification
      */
     ResponseSpecification content(Matcher<?> matcher, Matcher<?>...additionalMatchers);
+
+
+    /**
+     * Validates the specified response against this ResponseSpecification
+     * @param response
+     */
+    void validate(Response response);
 
     /**
      * Expect that the JSON or XML response content conforms to one or more Hamcrest matchers.<br>


### PR DESCRIPTION
We have been using rest-assured with cucumber and were looking to use the useful expectations provided by `ResponseSpecBuilder`, but after a request has been made. This was to help us in combination with cucumbers given-when-then syntax. See [this post](https://groups.google.com/forum/#!topic/rest-assured/NhkWN9jrGhY) on the mailing list.

To achieve this we've made this change to allow us to make assertions with `ResponseSpecBuilder` after an HTTP request has been made.

Example of how we are using it:

Given I am user `A`
When I call API `B`
Then I should receive a valid response `C`

```
@When("^When I call API B$")
public void makeCall() throws Throwable {
    ResponseSpecification resSpec = new ResSpecBuilder().build();
    response = given(reqSpec, resSpec).get("http://example/api/call");
}

@Then("^I should receive a valid response C$")
public void doAssertions() throws Throwable {
    new ResSpecBuilder()
        .expectBody("data", equalTo(23))
        .build();
        .validate(response)
}
```

Note: Above example uses an empty `ResponseSpecification` when actually making the call. When we want to have more than one `Then` steps that call `ResponseSpecification#validate()` more then once, then we must instead pass a `ResponseSpecification` such as `new ResSpecBuilder().expectBody(Matchers.anything())` otherwise we get an error saying we are attempting to read the stream twice. It's not a big deal - I think related to this change: https://github.com/jayway/rest-assured/blob/master/changelog.txt#L269 (Issue 109)
