### PR TITLE
Tentative fix for #77 and #154

### DIFF
--- a/rest-assured/src/main/java/com/jayway/restassured/builder/RequestSpecBuilder.java
+++ b/rest-assured/src/main/java/com/jayway/restassured/builder/RequestSpecBuilder.java
@@ -17,6 +17,7 @@
 package com.jayway.restassured.builder;
 
 import com.jayway.restassured.authentication.AuthenticationScheme;
+import com.jayway.restassured.config.AcceptEncodingConfig;
 import com.jayway.restassured.config.RestAssuredConfig;
 import com.jayway.restassured.filter.Filter;
 import com.jayway.restassured.http.ContentType;
@@ -1009,6 +1010,22 @@ public class RequestSpecBuilder {
      */
     public RequestSpecBuilder setSessionId(String sessionIdName, String sessionIdValue) {
         spec.sessionId(sessionIdName, sessionIdValue);
+        return this;
+    }
+    
+    /**
+     * Set the "Accept-Encoding" header value for this request. It'll override the default value from the configuration.
+     * You can configure the default "Accept-Encoding" value by using:
+     * <pre>
+     *     RestAssured.config = newConfig().acceptEncodingConfig(AcceptEncodingConfig.getXXX());
+     * </pre>
+     * and then you can use the {@link RequestSpecBuilder#setAcceptEncoding(AcceptEncodingConfig)} method to set the "Accept-Encoding" header value without specifying it for each request.
+     *
+     * @param acceptEncodingConfig  The AcceptEncoding configuration
+     * @return The request specification
+     */
+    public RequestSpecBuilder setAcceptEncoding(AcceptEncodingConfig acceptEncodingConfig) {
+        spec.acceptEncoding(acceptEncodingConfig);
         return this;
     }
 

--- a/rest-assured/src/main/java/com/jayway/restassured/config/AcceptEncodingConfig.java
+++ b/rest-assured/src/main/java/com/jayway/restassured/config/AcceptEncodingConfig.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.jayway.restassured.config;
+
+import com.jayway.restassured.internal.http.ContentEncoding;
+import java.util.Arrays;
+
+/**
+ * Configure the "Accept-Encoding" header for REST Assured.
+ * Here you can define a default "Accept-Encoding" value that'll be used for each request.
+ */
+public class AcceptEncodingConfig {
+    /** Default "Accept-Encoding" header in requests is "gzip,deflate". */
+    public static final AcceptEncodingConfig DEFAULT = new AcceptEncodingConfig(ContentEncoding.Type.GZIP, ContentEncoding.Type.DEFLATE);
+    /** Configuration for no "Accept-Encoding" header in requests. */
+    public static final AcceptEncodingConfig NONE = new AcceptEncodingConfig();
+    /** "Accept-Encoding" header in requests is "gzip". */
+    public static final AcceptEncodingConfig GZIP = new AcceptEncodingConfig(ContentEncoding.Type.GZIP);
+    /** "Accept-Encoding" header in requests is "compress". */
+    public static final AcceptEncodingConfig COMPRESS = new AcceptEncodingConfig(ContentEncoding.Type.COMPRESS);
+    /** "Accept-Encoding" header in requests is "deflate". */
+    public static final AcceptEncodingConfig DEFLATE = new AcceptEncodingConfig(ContentEncoding.Type.DEFLATE);
+    
+    private final ContentEncoding.Type[] acceptEncodings;
+    
+    private AcceptEncodingConfig(ContentEncoding.Type... acceptEncodings) {
+        this.acceptEncodings = acceptEncodings;
+    }
+    
+    /**
+     * Returns the list of the "Accept-Encoding" header values.
+     * @return 
+     */
+    protected ContentEncoding.Type[] getAcceptedEncodings() {
+        return Arrays.copyOf(acceptEncodings, acceptEncodings.length);
+    }
+    
+    @Override
+    public String toString() {
+        StringBuilder result = new StringBuilder();
+        for (int i = 0; i < acceptEncodings.length; i++) {
+            result.append(acceptEncodings[i].name().toLowerCase());
+            if (i < acceptEncodings.length - 1) {
+                result.append(",");
+            }
+        }
+        return result.toString();
+    }
+}

--- a/rest-assured/src/main/java/com/jayway/restassured/config/RestAssuredConfig.java
+++ b/rest-assured/src/main/java/com/jayway/restassured/config/RestAssuredConfig.java
@@ -40,18 +40,19 @@ public class RestAssuredConfig {
     private final ObjectMapperConfig objectMapperConfig;
     private final ConnectionConfig connectionConfig;
     private final JsonPathConfig jsonPathConfig;
+    private final AcceptEncodingConfig acceptEncodingConfig;
 
     /**
      * Create a new RestAssuredConfiguration with the default configurations.
      */
     public RestAssuredConfig() {
         this(new RedirectConfig(), new HttpClientConfig(), new LogConfig(), new EncoderConfig(), new DecoderConfig(),
-                new SessionConfig(), new ObjectMapperConfig(), new ConnectionConfig(), new JsonPathConfig());
+                new SessionConfig(), new ObjectMapperConfig(), new ConnectionConfig(), new JsonPathConfig(), AcceptEncodingConfig.DEFAULT);
     }
 
     /**
      * Create a new RestAssuredConfiguration with the supplied {@link RedirectConfig}, {@link HttpClientConfig}, {@link LogConfig}, 
-     * {@link EncoderConfig}, {@link DecoderConfig}, {@link SessionConfig}, {@link ObjectMapperConfig} and {@link ConnectionConfig}.
+     * {@link EncoderConfig}, {@link DecoderConfig}, {@link SessionConfig}, {@link ObjectMapperConfig}, {@link ConnectionConfig} and {@link AcceptEncodingConfig}.
      */
     public RestAssuredConfig(RedirectConfig redirectConfig,
                              HttpClientConfig httpClientConfig,
@@ -61,7 +62,8 @@ public class RestAssuredConfig {
                              SessionConfig sessionConfig,
                              ObjectMapperConfig objectMapperConfig,
                              ConnectionConfig connectionConfig,
-                             JsonPathConfig jsonPathConfig) {
+                             JsonPathConfig jsonPathConfig,
+                             AcceptEncodingConfig acceptEncodingConfig) {
         notNull(redirectConfig, "Redirect Config");
         notNull(httpClientConfig, "HTTP Client Config");
         notNull(logConfig, "Log config");
@@ -71,6 +73,7 @@ public class RestAssuredConfig {
         notNull(objectMapperConfig, "Object mapper config");
         notNull(connectionConfig, "Connection config");
         notNull(jsonPathConfig, "JsonPath config");
+        notNull(acceptEncodingConfig, "AcceptEncoding config");
         this.httpClientConfig = httpClientConfig;
         this.redirectConfig = redirectConfig;
         this.logConfig = logConfig;
@@ -80,6 +83,7 @@ public class RestAssuredConfig {
         this.objectMapperConfig = objectMapperConfig;
         this.connectionConfig = connectionConfig;
         this.jsonPathConfig = jsonPathConfig;
+        this.acceptEncodingConfig = acceptEncodingConfig;
     }
 
     /**
@@ -91,7 +95,7 @@ public class RestAssuredConfig {
     public RestAssuredConfig redirect(RedirectConfig redirectConfig) {
         notNull(redirectConfig, "Redirect config");
         return new RestAssuredConfig(redirectConfig, httpClientConfig, logConfig, encoderConfig, decoderConfig, sessionConfig,
-                objectMapperConfig, connectionConfig, jsonPathConfig);
+                objectMapperConfig, connectionConfig, jsonPathConfig, acceptEncodingConfig);
     }
 
     /**
@@ -103,7 +107,7 @@ public class RestAssuredConfig {
     public RestAssuredConfig httpClient(HttpClientConfig httpClientConfig) {
         notNull(httpClientConfig, "HTTP Client Config");
         return new RestAssuredConfig(redirectConfig, httpClientConfig, logConfig, encoderConfig, decoderConfig, sessionConfig,
-                objectMapperConfig, connectionConfig, jsonPathConfig);
+                objectMapperConfig, connectionConfig, jsonPathConfig, acceptEncodingConfig);
     }
 
     /**
@@ -115,7 +119,7 @@ public class RestAssuredConfig {
     public RestAssuredConfig logConfig(LogConfig logConfig) {
         notNull(logConfig, "Log config");
         return new RestAssuredConfig(redirectConfig, httpClientConfig, logConfig, encoderConfig, decoderConfig, sessionConfig,
-                objectMapperConfig, connectionConfig, jsonPathConfig);
+                objectMapperConfig, connectionConfig, jsonPathConfig, acceptEncodingConfig);
     }
 
     /**
@@ -127,7 +131,7 @@ public class RestAssuredConfig {
     public RestAssuredConfig encoderConfig(EncoderConfig encoderConfig) {
         notNull(encoderConfig, "Encoder config");
         return new RestAssuredConfig(redirectConfig, httpClientConfig, logConfig, encoderConfig, decoderConfig, sessionConfig,
-                objectMapperConfig, connectionConfig, jsonPathConfig);
+                objectMapperConfig, connectionConfig, jsonPathConfig, acceptEncodingConfig);
     }
 
     /**
@@ -139,7 +143,7 @@ public class RestAssuredConfig {
     public RestAssuredConfig decoderConfig(DecoderConfig decoderConfig) {
         notNull(decoderConfig, "Decoder config");
         return new RestAssuredConfig(redirectConfig, httpClientConfig, logConfig, encoderConfig, decoderConfig, sessionConfig,
-                objectMapperConfig, connectionConfig, jsonPathConfig);
+                objectMapperConfig, connectionConfig, jsonPathConfig, acceptEncodingConfig);
     }
 
     /**
@@ -151,7 +155,7 @@ public class RestAssuredConfig {
     public RestAssuredConfig sessionConfig(SessionConfig sessionConfig) {
         notNull(sessionConfig, "Session config");
         return new RestAssuredConfig(redirectConfig, httpClientConfig, logConfig, encoderConfig, decoderConfig, sessionConfig,
-                objectMapperConfig, connectionConfig, jsonPathConfig);
+                objectMapperConfig, connectionConfig, jsonPathConfig, acceptEncodingConfig);
     }
 
     /**
@@ -163,7 +167,7 @@ public class RestAssuredConfig {
     public RestAssuredConfig objectMapperConfig(ObjectMapperConfig objectMapperConfig) {
         notNull(objectMapperConfig, "Object mapper config");
         return new RestAssuredConfig(redirectConfig, httpClientConfig, logConfig, encoderConfig, decoderConfig, sessionConfig,
-                objectMapperConfig, connectionConfig, jsonPathConfig);
+                objectMapperConfig, connectionConfig, jsonPathConfig, acceptEncodingConfig);
     }
 
     /**
@@ -175,7 +179,7 @@ public class RestAssuredConfig {
     public RestAssuredConfig connectionConfig(ConnectionConfig connectionConfig) {
         notNull(connectionConfig, "Connection config");
         return new RestAssuredConfig(redirectConfig, httpClientConfig, logConfig, encoderConfig, decoderConfig, sessionConfig,
-                objectMapperConfig, connectionConfig, jsonPathConfig);
+                objectMapperConfig, connectionConfig, jsonPathConfig, acceptEncodingConfig);
     }
 
     /**
@@ -187,9 +191,21 @@ public class RestAssuredConfig {
     public RestAssuredConfig jsonPathConfig(JsonPathConfig jsonPathConfig) {
         notNull(jsonPathConfig, "JsonPath config");
         return new RestAssuredConfig(redirectConfig, httpClientConfig, logConfig, encoderConfig, decoderConfig, sessionConfig,
-                objectMapperConfig, connectionConfig, jsonPathConfig);
+                objectMapperConfig, connectionConfig, jsonPathConfig, acceptEncodingConfig);
     }
-
+    
+    /**
+     * Set the AcceptEncoding config.
+     *
+     * @param acceptEncodingConfig The {@link AcceptEncodingConfig} to set
+     * @return An updated RestAssuredConfiguration
+     */
+    public RestAssuredConfig acceptEncodingConfig(AcceptEncodingConfig acceptEncodingConfig) {
+        notNull(acceptEncodingConfig, "AcceptEncoding config");
+        return new RestAssuredConfig(redirectConfig, httpClientConfig, logConfig, encoderConfig, decoderConfig, sessionConfig,
+                objectMapperConfig, connectionConfig, jsonPathConfig, acceptEncodingConfig);
+    }
+    
     /**
      * Syntactic sugar.
      *
@@ -269,6 +285,13 @@ public class RestAssuredConfig {
      */
     public JsonPathConfig getJsonPathConfig() {
         return jsonPathConfig;
+    }
+    
+    /**
+     * @return The AcceptEncoding Config
+     */
+    public AcceptEncodingConfig getAcceptEncodingConfig() {
+        return acceptEncodingConfig;
     }
 
     /**

--- a/rest-assured/src/main/java/com/jayway/restassured/specification/RequestSpecification.java
+++ b/rest-assured/src/main/java/com/jayway/restassured/specification/RequestSpecification.java
@@ -16,6 +16,7 @@
 
 package com.jayway.restassured.specification;
 
+import com.jayway.restassured.config.AcceptEncodingConfig;
 import com.jayway.restassured.config.RestAssuredConfig;
 import com.jayway.restassured.filter.Filter;
 import com.jayway.restassured.http.ContentType;
@@ -1047,11 +1048,11 @@ public interface RequestSpecification extends RequestSender {
      * <p>
      * Default value for "Accept-Encoding" header is "gzip,deflate".
      * Call this method without any paramater to disable this header.
-     * @param contentEncodingTypes The accepted encodings for the response
+     * @param acceptEncodingConfig The accepted encodings for the response
      * @return The request specification
      * @see ContentEncoding
      */
-    RequestSpecification acceptEncoding(ContentEncoding.Type... contentEncodingTypes);
+    RequestSpecification acceptEncoding(AcceptEncodingConfig acceptEncodingConfig);
     
     /**
      * Specify the content type of the request.


### PR DESCRIPTION
Tentative fix for #77 and #154. The default behaviour ("Accept-Encoding: gzip,deflate") is kept to avoid breaking backward compatibility.
The only problem I see with this fix is that it uses an internal type (com.jayway.restassured.internal.http.ContentEncoding) in the public API of RequestSpecification, but this problem already exists for ObjectMapperType. Maybe this type could be moved outside the internal package ? (I would like to avoid creating a new public "ContentEncoding" that would be a mere copy-paste of the original one)
