### PR TITLE
Allow disabling the server hostname check when using SSL

### DIFF
--- a/rest-assured/src/main/groovy/com/jayway/restassured/authentication/CertAuthScheme.groovy
+++ b/rest-assured/src/main/groovy/com/jayway/restassured/authentication/CertAuthScheme.groovy
@@ -25,9 +25,10 @@ class CertAuthScheme implements AuthenticationScheme {
     def String certType = KeyStore.getDefaultType()
     def int port = 443
     def KeystoreProvider trustStoreProvider
+    def boolean checkServerHostname = true
 
     @Override
     void authenticate(HTTPBuilder httpBuilder) {
-        httpBuilder.auth.certificate(certURL, password, certType, port, trustStoreProvider)
+        httpBuilder.auth.certificate(certURL, password, certType, port, trustStoreProvider, checkServerHostname)
     }
 }

--- a/rest-assured/src/main/java/com/jayway/restassured/RestAssured.java
+++ b/rest-assured/src/main/java/com/jayway/restassured/RestAssured.java
@@ -1280,12 +1280,28 @@ public class RestAssured {
      * @param trustStoreProvider The provider
      */
     public static AuthenticationScheme certificate(String certURL, String password, String certType, int port, KeystoreProvider trustStoreProvider) {
+        return certificate(certURL, password, certType, port, trustStoreProvider, true);
+    }
+
+    /**
+     * Sets a certificate to be used for SSL authentication. See {@link Class#getResource(String)} for how to get a URL from a resource
+     * on the classpath.
+     *
+     * @param certURL             URL to a JKS keystore where the certificate is stored.
+     * @param password            password to decrypt the keystore
+     * @param certType            The certificate type
+     * @param port                The SSL port
+     * @param trustStoreProvider  The provider
+     * @param checkServerHostname Whether to check that the server hostname matches the certificate subject
+     */
+    public static AuthenticationScheme certificate(String certURL, String password, String certType, int port, KeystoreProvider trustStoreProvider, boolean checkServerHostname) {
         final CertAuthScheme scheme = new CertAuthScheme();
         scheme.setCertURL(certURL);
         scheme.setPassword(password);
         scheme.setCertType(certType);
         scheme.setPort(port);
         scheme.setTrustStoreProvider(trustStoreProvider);
+        scheme.setCheckServerHostname(checkServerHostname);
         return scheme;
     }
 

--- a/rest-assured/src/main/java/com/jayway/restassured/internal/http/AuthConfig.java
+++ b/rest-assured/src/main/java/com/jayway/restassured/internal/http/AuthConfig.java
@@ -86,7 +86,7 @@ public class AuthConfig {
 
     /**
      * Sets a certificate to be used for SSL authentication. See {@link Class#getResource(String)} for how to get a URL from a resource
-     * on the classpath.
+     * on the classpath. The hostname of the server will be checked against the certificate subject.
      *
      * @param certURL            URL to a JKS keystore where the certificate is stored.
      * @param password           password to decrypt the keystore
@@ -95,6 +95,21 @@ public class AuthConfig {
      * @param trustStoreProvider The provider
      */
     public void certificate(String certURL, String password, String certType, int port, KeystoreProvider trustStoreProvider) {
+        certificate(certURL, password, certType, port, trustStoreProvider, true);
+    }
+
+    /**
+     * Sets a certificate to be used for SSL authentication. See {@link Class#getResource(String)} for how to get a URL from a resource
+     * on the classpath.
+     *
+     * @param certURL             URL to a JKS keystore where the certificate is stored.
+     * @param password            password to decrypt the keystore
+     * @param certType            The certificate type
+     * @param port                The SSL port
+     * @param trustStoreProvider  The provider
+     * @param checkServerHostname Whether to check if the certificate subject matches the server hostname
+     */
+    public void certificate(String certURL, String password, String certType, int port, KeystoreProvider trustStoreProvider, boolean checkServerHostname) {
         try {
             KeyStore keyStore = KeyStore.getInstance(certType);
             InputStream jksStream = new URL(certURL).openStream();
@@ -112,7 +127,7 @@ public class AuthConfig {
 
             }
 
-            ssl.setHostnameVerifier(SSLSocketFactory.STRICT_HOSTNAME_VERIFIER);
+            ssl.setHostnameVerifier(checkServerHostname ? SSLSocketFactory.STRICT_HOSTNAME_VERIFIER : SSLSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
 
             SchemeRegistry registry = builder.getClient().getConnectionManager().getSchemeRegistry();
             registry.register(new Scheme("https", ssl, port));


### PR DESCRIPTION
When running tests over HTTPS on changing machines, having a certificate
matching the hostname of each machine quickly becomes cumbersome. It
was already possible to accept a certificate signed by any authority by
adding it to the keystore, but RestAssured would not let us disable the
hostname check.

This commit adds a new form of RestAssured.certificate() with a boolean
parameter allowing to turn the hostname check on or off. By default, the
check is still on, to preserve backwards compatibility.
