### PR TITLE
fix - issue 305 - split query params and values by '=' with max count 2

### DIFF
--- a/examples/rest-assured-itest-java/src/test/java/com/jayway/restassured/itest/java/URLITest.java
+++ b/examples/rest-assured-itest-java/src/test/java/com/jayway/restassured/itest/java/URLITest.java
@@ -730,7 +730,7 @@ public class URLITest extends WithJetty {
     }
 
     /**
-     * See issue 304
+     * See issue 304 & 305
      */
     @Test
     public void fullyQualifiedUrlIsHandledCorrectlyInLog() throws Exception {
@@ -750,10 +750,10 @@ public class URLITest extends WithJetty {
                  statusCode(200).
                  body(equalTo("changed")).
         when().
-                get("http://ya.ru/bla/?param");
+                get("http://ya.ru/bla/?param=value=");
 
         // Then
-        assertThat(loggedRequestPathIn(writer), equalTo("http://ya.ru/bla/?param"));
+        assertThat(loggedRequestPathIn(writer), equalTo("http://ya.ru/bla/?param=value%3D"));
     }
 
     @Test

--- a/rest-assured/src/main/groovy/com/jayway/restassured/internal/RequestSpecificationImpl.groovy
+++ b/rest-assured/src/main/groovy/com/jayway/restassured/internal/RequestSpecificationImpl.groovy
@@ -888,7 +888,7 @@ class RequestSpecificationImpl implements FilterableRequestSpecification, Groovy
       if (!StringUtils.isBlank(queryParamsDefinedInPath)) {
         def splittedQueryParams = StringUtils.split(queryParamsDefinedInPath, "&");
         splittedQueryParams.each { queryNameWithPotentialValue ->
-          def String[] splitted = StringUtils.split(queryNameWithPotentialValue, "=")
+          def String[] splitted = StringUtils.split(queryNameWithPotentialValue, "=", 2)
           def queryParamHasValue = splitted.size() > 1
           if (queryParamHasValue) {
             def value = StringUtils.join(splitted[1..splitted.size() - 1], "="); // If there are several "=" in the URL the merge them


### PR DESCRIPTION
http://code.google.com/p/rest-assured/issues/detail?id=305
