### PR TITLE
Issue 337: Extract charset out of the correct key=value pair.

### DIFF
--- a/rest-assured/src/main/groovy/com/jayway/restassured/internal/http/CharsetExtractor.groovy
+++ b/rest-assured/src/main/groovy/com/jayway/restassured/internal/http/CharsetExtractor.groovy
@@ -33,7 +33,7 @@ class CharsetExtractor {
             contentType.split(";").each {
                 if(StringUtils.containsIgnoreCase(contentType, CHARSET)) {
                     def questionMark = it.split("=")
-                    if(questionMark != null && questionMark.length == 2) {
+                    if(questionMark != null && questionMark.length == 2 && questionMark[0].trim().equals("charset")) {
                         foundCharset = questionMark[1]?.trim();
                     }
                 }

--- a/rest-assured/src/test/groovy/com/jayway/restassured/internal/http/CharsetExtractorTest.groovy
+++ b/rest-assured/src/test/groovy/com/jayway/restassured/internal/http/CharsetExtractorTest.groovy
@@ -1,0 +1,23 @@
+package com.jayway.restassured.internal.http
+
+import org.junit.Test
+
+import static org.junit.Assert.assertEquals
+
+class CharsetExtractorTest {
+
+    @Test
+    def void shouldExtractCharsetFromTheMiddleOfTheDeclaration() throws Exception {
+        assertEquals "UTF-8", CharsetExtractor.getCharsetFromContentType("application/ld+json; charset=UTF-8; qs=0.5")
+    }
+
+    @Test
+    def void shouldExtractCharsetFromTheEndOfTheDeclaration() throws Exception {
+        assertEquals "UTF-8", CharsetExtractor.getCharsetFromContentType("application/ld+json; qs=0.5; charset=UTF-8")
+    }
+
+    @Test
+    def void shouldExtractNullCharsetWhenNotPresent() throws Exception {
+        assertEquals null, CharsetExtractor.getCharsetFromContentType("application/ld+json; qs=0.5")
+    }
+}


### PR DESCRIPTION
This makes sure that if the content type line contains more than one key=value pair, charset is extracted from the right one.
