### PR TITLE
Clearing methods for parameters and setBaseUri(URI) method in reqSpecBuilder

### DIFF
--- a/rest-assured/src/main/groovy/com/jayway/restassured/internal/RequestSpecificationImpl.groovy
+++ b/rest-assured/src/main/groovy/com/jayway/restassured/internal/RequestSpecificationImpl.groovy
@@ -318,6 +318,12 @@ class RequestSpecificationImpl implements FilterableRequestSpecification, Groovy
     return parameter(parameterName, parameterValues)
   }
 
+  def RequestSpecification clearParam(String parameterName) {
+    notNull parameterName, "parameterName"
+    requestParameters.remove(parameterName)
+    return this
+  }
+
   def RequestSpecification parameter(String parameterName, Collection<?> parameterValues) {
     notNull parameterName, "parameterName"
     notNull parameterValues, "parameterValues"
@@ -338,6 +344,12 @@ class RequestSpecificationImpl implements FilterableRequestSpecification, Groovy
 
   def RequestSpecification queryParam(String parameterName, Collection<?> parameterValues) {
     return queryParameter(parameterName, parameterValues)
+  }
+
+  def RequestSpecification clearQueryParam(String parameterName) {
+    notNull parameterName, "parameterName"
+    queryParameters.remove(parameterName)
+    return this
   }
 
   def RequestSpecification parameter(String parameterName, Object... parameterValues) {
@@ -385,6 +397,12 @@ class RequestSpecificationImpl implements FilterableRequestSpecification, Groovy
 
   def RequestSpecification formParam(String parameterName, Collection<?> parameterValues) {
     return formParameter(parameterName, parameterValues)
+  }
+
+  def RequestSpecification clearFormParam(String parameterName) {
+    notNull parameterName, "parameterName"
+    formParameters.remove(parameterName)
+    return this
   }
 
   def RequestSpecification formParameters(String firstParameterName, Object firstParameterValue, Object... parameterNameValuePairs) {

--- a/rest-assured/src/main/java/com/jayway/restassured/builder/RequestSpecBuilder.java
+++ b/rest-assured/src/main/java/com/jayway/restassured/builder/RequestSpecBuilder.java
@@ -422,6 +422,18 @@ public class RequestSpecBuilder {
     }
 
     /**
+     * Method to remove parameter added with {@link #addParameter(String, Object...)} from map.
+     * Removes all values of this parameter
+     *
+     * @param parameterName   The parameter key
+     * @return The request specification builder
+     */
+    public RequestSpecBuilder clearParam(String parameterName) {
+        spec.clearParam(parameterName);
+        return this;
+    }
+
+    /**
      * Add query parameters to be sent with the request as a Map. This method is the same as {@link #addParameters(java.util.Map)}
      * for all HTTP methods except POST where this method can be used to differentiate between form and query params.
      *
@@ -496,6 +508,20 @@ public class RequestSpecBuilder {
         spec.queryParam(parameterName, parameterValues);
         return this;
     }
+
+
+    /**
+     * Method to remove parameter added with {@link #addQueryParameter(String, Object...)} from map.
+     * Removes all values of this parameter
+     *
+     * @param parameterName   The parameter key
+     * @return The request specification builder
+     */
+    public RequestSpecBuilder clearQueryParam(String parameterName) {
+        spec.clearQueryParam(parameterName);
+        return this;
+    }
+
 
     /**
      * Add query parameters to be sent with the request as a Map. This method is the same as {@link #addParameters(java.util.Map)}
@@ -572,6 +598,21 @@ public class RequestSpecBuilder {
         spec.formParam(parameterName, parameterValues);
         return this;
     }
+
+
+    /**
+     * Method to remove parameter added with {@link #addFormParameter(String, Object...)} from map.
+     * Removes all values of this parameter
+     *
+     * @param parameterName   The parameter key
+     * @return The request specification builder
+     */
+    public RequestSpecBuilder clearFormParam(String parameterName) {
+        spec.clearFormParam(parameterName);
+        return this;
+    }
+
+
 
     /**
      * Specify a path parameter. Path parameters are used to improve readability of the request path. E.g. instead

--- a/rest-assured/src/test/groovy/com/jayway/restassured/ParameterMapBuilderTest.groovy
+++ b/rest-assured/src/test/groovy/com/jayway/restassured/ParameterMapBuilderTest.groovy
@@ -47,4 +47,28 @@ class ParameterMapBuilderTest {
     assertEquals "value1", map.get("key1")
     assertEquals "value2", map.get("key2")
   }
+
+  @Test
+  def void shouldClearParamOnClearParamMethod() throws Exception {
+    requestBuilder.parameters("key1", "value1");
+    def map = requestBuilder.clearParam("key1").requestParameters
+
+    assertEquals 0, map.size()
+  }
+
+  @Test
+  def void shouldClearQueryParamOnClearQueryParamMethod() throws Exception {
+    requestBuilder.queryParameters("key1", "value1");
+    def map = requestBuilder.clearQueryParam("key1").queryParameters
+
+    assertEquals 0, map.size()
+  }
+
+  @Test
+  def void shouldClearFormParamOnClearFormParamMethod() throws Exception {
+    requestBuilder.queryParameters("key1", "value1");
+    def map = requestBuilder.clearFormParam("key1").formParameters
+
+    assertEquals 0, map.size()
+  }
 }


### PR DESCRIPTION
Now you can't manage already added parameters on request spec builder, so for changing only one parameter you should rewrite whole builder from start. Clearing parameters can be useful if you use api-specific wrapper around this builder. 
With this PR it will be possible to store only builder, without maps for each parameter type in such wrappers.

with `setBaseUri(URI)` method you shouldn't do `someURI.toString()` in every call
