### PR TITLE
Feature Request to add BigInteger NumberReturnType support for JsonPa…

### DIFF
--- a/json-path/src/main/groovy/com/jayway/restassured/internal/path/json/ConfigurableJsonSlurper.groovy
+++ b/json-path/src/main/groovy/com/jayway/restassured/internal/path/json/ConfigurableJsonSlurper.groovy
@@ -50,17 +50,18 @@ class ConfigurableJsonSlurper {
         JsonToken.metaClass.getValue = {->
             def result = original.invoke(delegate)
           NumberReturnType numberReturnType = numberReturnType.get()
-          if ((numberReturnType == NumberReturnType.FLOAT_AND_DOUBLE ||
-                  numberReturnType == NumberReturnType.DOUBLE)
-                  && result instanceof BigDecimal) {
-                // Convert big decimal to float or double
-                if (result > Float.MAX_VALUE || numberReturnType == NumberReturnType.DOUBLE) {
-                    result = result.doubleValue();
-                } else {
-                    result = result.floatValue();
-                }
-            }
-            result
+          if (numberReturnType.isFloatOrDouble() && result instanceof BigDecimal) {
+              // Convert big decimal to float or double
+              if (result > Float.MAX_VALUE || numberReturnType == NumberReturnType.DOUBLE) {
+                  result = result.doubleValue();
+              } else {
+                  result = result.floatValue();
+              }
+          } else if (NumberReturnType.BIG_INTEGER.equals(numberReturnType)
+                        && (result instanceof Integer || result instanceof Long)) {
+              result = new BigInteger(result.toString());
+          }
+          result
         }
     }
 

--- a/json-path/src/main/java/com/jayway/restassured/path/json/config/JsonPathConfig.java
+++ b/json-path/src/main/java/com/jayway/restassured/path/json/config/JsonPathConfig.java
@@ -250,7 +250,16 @@ public class JsonPathConfig {
 
 
     /**
-     * Specifies what kind of numbers to return
+     * Specifies what kind of numbers to return. <br>
+     *
+     * To specify the return type of decimal numbers parsed from the json, use the following:
+     * <ul>
+     * <li>FLOAT_AND_DOUBLE</li> <li>BIG_DECIMAL</li> <li>DOUBLE</li>
+     * </ul>
+     * To specify the return type of non-decimal numbers in the json, use the following:
+     * <ul>
+ *     <li>BIG_INTEGER</li>
+     * </ul>
      */
     public enum NumberReturnType {
         /**
@@ -264,6 +273,21 @@ public class JsonPathConfig {
         /**
          * Convert all non-integer numbers to doubles
          */
-        DOUBLE
+        DOUBLE,
+        /**
+         * Converts all non-decimal numbers to BigInteger
+         */
+        BIG_INTEGER;
+
+        /**
+         * Returns a boolean indicating whether this type is included in those that deal with floats
+         * or doubles exclusive of BigDecimal.
+         * @return
+         */
+        public final boolean isFloatOrDouble() {
+            return this.equals(FLOAT_AND_DOUBLE)
+                   || this.equals(DOUBLE);
+        }
+
     }
 }

--- a/json-path/src/test/java/com/jayway/restassured/path/json/JsonPathNumberTest.java
+++ b/json-path/src/test/java/com/jayway/restassured/path/json/JsonPathNumberTest.java
@@ -20,25 +20,49 @@ import com.jayway.restassured.path.json.config.JsonPathConfig;
 import org.junit.Test;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 
 import static com.jayway.restassured.path.json.config.JsonPathConfig.NumberReturnType.BIG_DECIMAL;
+import static com.jayway.restassured.path.json.config.JsonPathConfig.NumberReturnType.BIG_INTEGER;
 import static com.jayway.restassured.path.json.config.JsonPathConfig.NumberReturnType.FLOAT_AND_DOUBLE;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 public class JsonPathNumberTest {
 
-    private static final String PRICE = "{\n" +
-            "\n" +
-            "    \"price\":12.1 \n" +
-            "\n" +
-            "}";
+    /**
+     * An expected input which is less than Integer.MAX_VALUE
+     */
+    private static final String EXPECTED_INTEGER = "15303030";
+
+    /**
+     * An expected input which is greater than Integer.MAX_VALUE and less than Long.MAX_VALUE
+     */
+    private static final String EXPECTED_LONG = "13000000000";
+
+    private static final String ORDER_NUMBER_JSON = "{\n" +
+                                                    "\n" +
+                                                    "    \"orderNumber\":"+EXPECTED_INTEGER+" \n" +
+                                                    "\n" +
+                                                    "}";
+
+    private static final String LIGHT_YEARS_TO_COSMIC_HORIZON_JSON = "{\n" +
+                                                                     "\n" +
+                                                                     "    \"lightYearsToCosmicHorizon\":" + EXPECTED_LONG + " \n" +
+                                                                     "\n" +
+                                                                     "}";
+
+    private static final String PRICE_JSON = "{\n" +
+                                             "\n" +
+                                             "    \"price\":12.1 \n" +
+                                             "\n" +
+                                             "}";
 
 
     @Test public void
     json_path_returns_big_decimal_for_json_numbers_when_configured_accordingly() {
         // Given
-        final JsonPath jsonPath = new JsonPath(PRICE).using(new JsonPathConfig(BIG_DECIMAL));
+        final JsonPath jsonPath = new JsonPath(PRICE_JSON).using(new JsonPathConfig(BIG_DECIMAL));
 
         // When
         BigDecimal price = jsonPath.get("price");
@@ -50,13 +74,40 @@ public class JsonPathNumberTest {
     @Test public void
     json_path_returns_float_for_json_numbers_when_configured_accordingly() {
         // Given
-        final JsonPath jsonPath = new JsonPath(PRICE).using(new JsonPathConfig().numberReturnType(FLOAT_AND_DOUBLE));
+        final JsonPath jsonPath = new JsonPath(
+            PRICE_JSON).using(new JsonPathConfig().numberReturnType(FLOAT_AND_DOUBLE));
 
         // When
         float price = (Float) jsonPath.get("price");
 
         // Then
         assertThat(price, equalTo(12.1f));
+    }
+
+    @Test public void
+    json_path_returns_big_integer_for_json_integer_numbers_when_configured_accordingly() {
+        // Given
+        final JsonPath jsonPath = new JsonPath(
+            ORDER_NUMBER_JSON).using(new JsonPathConfig().numberReturnType(BIG_INTEGER));
+
+        // When
+        BigInteger orderNumber = (BigInteger)jsonPath.get("orderNumber");
+
+        // Then
+        assertThat(orderNumber, equalTo(new BigInteger(EXPECTED_INTEGER)));
+    }
+
+    @Test public void
+    json_path_returns_big_integer_for_json_long_numbers_when_configured_accordingly() {
+        // Given
+        final JsonPath jsonPath = new JsonPath(
+            LIGHT_YEARS_TO_COSMIC_HORIZON_JSON).using(new JsonPathConfig().numberReturnType(BIG_INTEGER));
+
+        // When
+        BigInteger orderNumber = (BigInteger)jsonPath.get("lightYearsToCosmicHorizon");
+
+        // Then
+        assertThat(orderNumber, equalTo(new BigInteger(EXPECTED_LONG)));
     }
 
 }


### PR DESCRIPTION
In order to validate any math integers in a json response, you currently need to know the
type ahead of time.  This is not possible if the range extends beyond java.lang.Integer or java.lang.Long.  If someone needs a consistent integer type across their assertions they may configure the JsonPathConfig with the NumberReturnType.BIG_INTEGER.  Since this is a catch all for integers of any size to prevent folding, it should be appropriate for asserting values on numbers that could have a range from very small to extremely large and are not known ahead of time.