### PR TITLE
Fixed queryParam doesn't include in MockMvcRequest URI

### DIFF
--- a/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/QueryParamTest.java
+++ b/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/QueryParamTest.java
@@ -17,6 +17,7 @@
 package io.restassured.module.mockmvc;
 
 import io.restassured.module.mockmvc.http.GreetingController;
+import io.restassured.module.mockmvc.http.QueryParamController;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -35,5 +36,20 @@ public class QueryParamTest {
                 body("id", equalTo(1)).
                 body("content", equalTo("Hello, John!"));
     }
+
+    @Test
+    public void query_param() throws Exception {
+        RestAssuredMockMvc.given().
+                standaloneSetup(new QueryParamController()).
+                queryParam("name", "John").
+                queryParam("message", "Good!").
+        when().
+                get("/queryParam").
+        then().log().all().
+                body("name", equalTo("Hello, John!")).
+                body("message", equalTo("Good!")).
+                body("_link", equalTo("http://localhost/queryParam?name=John&message=Good!"));
+    }
+
 // @formatter:on
 }

--- a/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/http/QueryParamController.java
+++ b/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/http/QueryParamController.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.restassured.module.mockmvc.http;
+
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+
+@Controller
+public class QueryParamController {
+
+    private static final String template = "Hello, %s!";
+
+    @RequestMapping(value = "/queryParam", method = GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    public @ResponseBody String queryParam(@RequestParam("name") String name, @RequestParam("message") String message) {
+        return "{ \"name\" : \"" + String.format(template, name) + "\"," +
+                " \"message\" : \"" + message + "\", " +
+                " \"_link\" : \"" + ServletUriComponentsBuilder.fromCurrentRequest().build().toString() + "\" }";
+    }
+}


### PR DESCRIPTION
https://github.com/rest-assured/rest-assured/issues/699
Build URI with queryParams for MockHttpServletRequestBuilder.
queryParams for request.getQueryString(); not parameters
