### PR TITLE
#720 

### DIFF
--- a/rest-assured/src/main/groovy/io/restassured/internal/RequestSpecificationImpl.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/RequestSpecificationImpl.groovy
@@ -1173,7 +1173,7 @@ class RequestSpecificationImpl implements FilterableRequestSpecification, Groovy
     setRequestHeadersToHttpBuilder(http)
 
     if (cookies.exist()) {
-      http.getHeaders() << [Cookie: cookies.collect { it.toString() }.join("; ")]
+      http.getHeaders() << [Cookie: cookies.collect { it.name + "=" + it.value }.join("; ")]
     }
 
     // Allow returning a the response


### PR DESCRIPTION
This is a fix for https://github.com/rest-assured/rest-assured/issues/720

Do you have some tests already that verify integration between REST-assured `RequestSpecificationImpl` and Apache HTTP Client? Basically, the tests that verify that REST-Assured requests are properly translated into HTTP Requests.