### PR TITLE
#717

### DIFF
--- a/rest-assured/src/main/groovy/io/restassured/assertion/CookieMatcher.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/assertion/CookieMatcher.groovy
@@ -23,6 +23,7 @@ import io.restassured.http.Cookies
 import org.apache.commons.lang3.StringUtils
 import org.apache.http.client.utils.DateUtils
 import org.hamcrest.Matcher
+import org.hamcrest.StringDescription
 
 import static io.restassured.http.Cookie.*
 import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase
@@ -32,6 +33,8 @@ class CookieMatcher {
 
     def cookieName
     def Matcher<String> matcher
+
+
 
     def validateCookie(List<String> cookies) {
         def success = true
@@ -50,12 +53,26 @@ class CookieMatcher {
                 def value = cookie.getValue()
                 if(!matcher.matches(value)) {
                     success = false
-                    errorMessage = "Expected cookie \"$cookieName\" was not $matcher, was \"$value\".\n"
+                    def expectedDescription = getExpectedDescription(matcher)
+                    def mismatchDescription = getMismatchDescription(matcher, value)
+                    errorMessage = "Expected cookie \"$cookieName\" was $expectedDescription, $mismatchDescription\".\n"
 
                 }
             }
         }
         [success: success, errorMessage: errorMessage]
+    }
+
+    public static String getExpectedDescription(Matcher matcher) {
+        def expectedDescription = new StringDescription()
+        matcher.describeTo(expectedDescription)
+        return expectedDescription.toString()
+    }
+
+    public static String getMismatchDescription(Matcher matcher, value) {
+        def mismatchDescription = new StringDescription()
+        matcher.describeMismatch(value, mismatchDescription)
+        return mismatchDescription.toString()
     }
 
     public static Cookies getCookies(headerWithCookieList) {
@@ -122,4 +139,6 @@ class CookieMatcher {
             }
         }
     }
+
+
 }

--- a/rest-assured/src/test/java/io/restassured/assertion/CookieMatcherMessagesTest.java
+++ b/rest-assured/src/test/java/io/restassured/assertion/CookieMatcherMessagesTest.java
@@ -1,0 +1,67 @@
+package io.restassured.assertion;
+
+import org.codehaus.groovy.runtime.GStringImpl;
+import org.hamcrest.Description;
+import org.hamcrest.Matchers;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * @author Maciej Gawinecki
+ */
+public class CookieMatcherMessagesTest {
+
+    String[] cookies = new String[]{"DEVICE_ID=123; Domain=.test.com; Expires=Thu, 12-Oct-2023 09:34:31 GMT; Path=/; Secure; HttpOnly;"};
+
+    @Test
+    public void shouldPrintValidErrorMessageForStandardMatchers() {
+
+        CookieMatcher cookieMatcher = new CookieMatcher();
+        cookieMatcher.setCookieName("DEVICE_ID");
+        cookieMatcher.setMatcher(Matchers.containsString("X"));
+
+        Map<String, Object> result = (Map<String, Object>) cookieMatcher.validateCookie(Arrays.asList(cookies));
+        assertThat((Boolean)result.get("success"), equalTo(false));
+        assertThat(((GStringImpl)result.get("errorMessage")).toString(), equalTo("Expected cookie \"DEVICE_ID\" was a string containing \"X\", was \"123\"\".\n"));
+    }
+
+    @Test
+    public void shouldPrintValidErrorMessageForCustomMatcher() {
+
+        CookieMatcher cookieMatcher = new CookieMatcher();
+        cookieMatcher.setCookieName("DEVICE_ID");
+        cookieMatcher.setMatcher(new ContainsXMatcher());
+
+        Map<String, Object> result = (Map<String, Object>) cookieMatcher.validateCookie(Arrays.asList(cookies));
+        assertThat((Boolean)result.get("success"), equalTo(false));
+        assertThat(((GStringImpl)result.get("errorMessage")).toString(), equalTo("Expected cookie \"DEVICE_ID\" was containing 'X', was \"123\" not containing 'X'\".\n"));
+    }
+
+
+    static class ContainsXMatcher extends TypeSafeDiagnosingMatcher<String> {
+
+        @Override
+        protected boolean matchesSafely(String actual, Description mismatchDescription) {
+
+            // Not this method will be called twice due to https://github.com/hamcrest/JavaHamcrest/issues/144
+
+            if (actual.contains("X")) {
+                return true;
+            }
+
+            mismatchDescription.appendValue(actual).appendText(" not containing 'X'");
+            return false;
+        }
+
+        public void describeTo(Description description) {
+            description.appendText("containing 'X'");
+        }
+    }
+
+}


### PR DESCRIPTION
Fix for issue #717: Mismatch description from TypeSafeDiagnosingMatcher is ignored.

The fix is in groovy and test the test is in Java, so it does not read nicely. Let me know if you want to get it improved.