### PR TITLE
ResponseSpecification: Don't join root and path with '.' if path starts with array indexing

### DIFF
--- a/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/RootPathITest.java
+++ b/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/RootPathITest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import static io.restassured.RestAssured.*;
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
 public class RootPathITest extends WithJetty {
@@ -68,6 +68,15 @@ public class RootPathITest extends WithJetty {
                  body(".author.size()", equalTo(4)).
         when().
                  get("/jsonStore");
+    }
+
+    @Test
+    public void specifyingRootPathAndBodyThatStartsWithArrayIndexingWorks() throws Exception {
+        expect().
+                 root("store.book").
+                 body("[0].category", either(equalTo("reference")).or(equalTo("fiction"))).
+        when().
+                get("/jsonStore");
     }
 
     @Test

--- a/rest-assured/src/main/groovy/io/restassured/internal/ResponseSpecificationImpl.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/ResponseSpecificationImpl.groovy
@@ -604,7 +604,7 @@ class ResponseSpecificationImpl implements FilterableResponseSpecification {
     if (bodyRootPath != null && bodyRootPath != EMPTY) {
       if (bodyRootPath.endsWith(DOT) && key.startsWith(DOT)) {
         return bodyRootPath + substringAfter(key, DOT);
-      } else if (!bodyRootPath.endsWith(DOT) && !key.startsWith(DOT)) {
+      } else if (!bodyRootPath.endsWith(DOT) && !key.startsWith(DOT) && !key.startsWith("[")) {
         return bodyRootPath + DOT + key
       }
       return bodyRootPath + key


### PR DESCRIPTION
This is the same bug that was fixed in #727 except for ResponseSpecificationImpl.

