### PR TITLE
Allow keystore and truststore passwords to differ

### DIFF
--- a/rest-assured/src/main/java/io/restassured/config/SSLConfig.java
+++ b/rest-assured/src/main/java/io/restassured/config/SSLConfig.java
@@ -396,7 +396,7 @@ public class SSLConfig implements Config {
      * @return The password to the trust store
      */
     public String getTrustStorePassword() {
-        return keyStorePassword;
+        return trustStorePassword;
     }
 
     /**


### PR DESCRIPTION
This pull request fixes a typo in `SSLConfig.java` which was included in commit a0adf58ba907ceaf5fe6076ea00589cc5c9c4b7e (splitting of keystore and trust store).

In the current `master` branch, when have an SSLConfig object and attempt to retrieve the trust store password, the key store password is returned intead.

This means it's not possible to use a keystore and truststore with different passwords. You will get a "Keystore was tampered with, or password incorrect" error if you attempt to do so, because the configured trust store password is never used.

This is not picked up in tests, as "test1234" is used as a password with some consistency.