### PR TITLE
SSLConfig correction

### DIFF
--- a/rest-assured/src/main/java/io/restassured/config/SSLConfig.java
+++ b/rest-assured/src/main/java/io/restassured/config/SSLConfig.java
@@ -428,10 +428,10 @@ public class SSLConfig implements Config {
     }
 
     /**
-     * @return The trust store
+     * @return The key store
      */
     public KeyStore getKeyStore() {
-        return trustStore;
+        return keyStore;
     }
 
     /**


### PR DESCRIPTION
This pull request is another fix to the `SSLConfig` class. Currently, `getKeyStore()` is returning `trustStore`, rather than `keyStore`.

Related:
- #754
