### PR TITLE
Get sni working

### DIFF
--- a/rest-assured/src/main/groovy/io/restassured/internal/TrustAndKeystoreSpecImpl.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/TrustAndKeystoreSpecImpl.groovy
@@ -51,7 +51,7 @@ class TrustAndKeystoreSpecImpl implements TrustAndKeystoreSpec {
       factory.setHostnameVerifier(x509HostnameVerifier ?: ALLOW_ALL_HOSTNAME_VERIFIER)
     }
     int portToUse = this.port == -1 ? port : this.port
-    builder.client.connectionManager.schemeRegistry.register(new Scheme("https", portToUse, factory)
+    builder.httpClientBuilder.connectionManager.schemeRegistry.register(new Scheme("https", portToUse, factory)
     )
   }
 

--- a/rest-assured/src/main/java/io/restassured/internal/http/AuthConfig.java
+++ b/rest-assured/src/main/java/io/restassured/internal/http/AuthConfig.java
@@ -31,8 +31,10 @@ import org.apache.http.HttpRequest;
 import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
 import org.apache.http.conn.ssl.SSLSocketFactory;
 import org.apache.http.conn.ssl.X509HostnameVerifier;
+import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.RequestWrapper;
 import org.apache.http.protocol.ExecutionContext;
 import org.apache.http.protocol.HttpContext;
@@ -84,10 +86,12 @@ public class AuthConfig {
      * @param pass
      */
     public void basic(String host, int port, String user, String pass) {
-        builder.getClient().getCredentialsProvider().setCredentials(
+        CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+        credentialsProvider.setCredentials(
                 new AuthScope(host, port),
                 new UsernamePasswordCredentials(user, pass)
         );
+        builder.getHttpClientBuilder().setDefaultCredentialsProvider(credentialsProvider);
     }
 
     /**
@@ -148,9 +152,9 @@ public class AuthConfig {
      */
     public void oauth(String consumerKey, String consumerSecret,
                       String accessToken, String secretToken) {
-        this.builder.client.removeRequestInterceptorByClass(OAuthSigner.class);
+        //this.builder.httpClientBuilder.removeRequestInterceptorByClass(OAuthSigner.class);
         if (consumerKey != null) {
-            this.builder.client.addRequestInterceptor(new OAuthSigner(
+            this.builder.httpClientBuilder.addInterceptorFirst(new OAuthSigner(
                     consumerKey, consumerSecret, accessToken, secretToken, OAuthSignature.HEADER,
                     raOAuthConfig.shouldAddEmptyAccessOAuthTokenToBaseString()));
         }
@@ -159,9 +163,9 @@ public class AuthConfig {
 
     public void oauth(String consumerKey, String consumerSecret,
                       String accessToken, String secretToken, OAuthSignature signature) {
-        this.builder.client.removeRequestInterceptorByClass(OAuthSigner.class);
+        //this.builder.httpClientBuilder.removeRequestInterceptorByClass(OAuthSigner.class);
         if (consumerKey != null) {
-            this.builder.client.addRequestInterceptor(new OAuthSigner(
+            this.builder.httpClientBuilder.addInterceptorFirst(new OAuthSigner(
                     consumerKey, consumerSecret, accessToken, secretToken,
                     signature, raOAuthConfig.shouldAddEmptyAccessOAuthTokenToBaseString()));
         }
@@ -183,16 +187,16 @@ public class AuthConfig {
      * @since 0.5.1
      */
     public void oauth2(String accessToken) {
-        this.builder.client.removeRequestInterceptorByClass(OAuthSigner.class);
+        //this.builder.httpClientBuilder.removeRequestInterceptorByClass(OAuthSigner.class);
         if (accessToken != null) {
-            this.builder.client.addRequestInterceptor(new OAuthSigner(accessToken, OAuthSignature.HEADER));
+            this.builder.httpClientBuilder.addInterceptorFirst(new OAuthSigner(accessToken, OAuthSignature.HEADER));
         }
     }
 
     public void oauth2(String accessToken, OAuthSignature signature) {
-        this.builder.client.removeRequestInterceptorByClass(OAuthSigner.class);
+        //this.builder.httpClientBuilder.removeRequestInterceptorByClass(OAuthSigner.class);
         if (accessToken != null) {
-            this.builder.client.addRequestInterceptor(new OAuthSigner(accessToken, signature));
+            this.builder.httpClientBuilder.addInterceptorFirst(new OAuthSigner(accessToken, signature));
         }
     }
 

--- a/rest-assured/src/main/java/io/restassured/internal/http/ContentEncodingRegistry.java
+++ b/rest-assured/src/main/java/io/restassured/internal/http/ContentEncodingRegistry.java
@@ -20,6 +20,7 @@ import io.restassured.config.DecoderConfig;
 import io.restassured.internal.http.ContentEncoding.Type;
 import org.apache.http.client.HttpClient;
 import org.apache.http.impl.client.AbstractHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -60,20 +61,20 @@ public class ContentEncodingRegistry {
      * types.  This method is called by HTTPBuilder and probably should not need
      * be modified by sub-classes.
      *
-     * @param client    client on which to set the request and response interceptors
+     * @param clientBuilder httpClientBuilder on which to set the request and response interceptors
      * @param encodings encoding name (either a {@link ContentEncoding.Type} or
      *                  a <code>content-encoding</code> string.
      */
-    void setInterceptors(final AbstractHttpClient client, Object... encodings) {
+    void setInterceptors(final HttpClientBuilder clientBuilder, Object... encodings) {
         // remove any encoding interceptors that are already set
-        client.removeRequestInterceptorByClass(ContentEncoding.RequestInterceptor.class);
-        client.removeResponseInterceptorByClass(ContentEncoding.ResponseInterceptor.class);
+        //clientBuilder.removeRequestInterceptorByClass(ContentEncoding.RequestInterceptor.class);
+        //clientBuilder.removeResponseInterceptorByClass(ContentEncoding.ResponseInterceptor.class);
 
         for (Object encName : encodings) {
             ContentEncoding enc = availableEncoders.get(encName.toString());
             if (enc == null) continue;
-            client.addRequestInterceptor(enc.getRequestInterceptor());
-            client.addResponseInterceptor(enc.getResponseInterceptor());
+            clientBuilder.addInterceptorFirst(enc.getRequestInterceptor());
+            clientBuilder.addInterceptorFirst(enc.getResponseInterceptor());
         }
     }
 }

--- a/rest-assured/src/main/java/io/restassured/specification/FilterableRequestSpecification.java
+++ b/rest-assured/src/main/java/io/restassured/specification/FilterableRequestSpecification.java
@@ -23,6 +23,7 @@ import io.restassured.http.Cookie;
 import io.restassured.http.Cookies;
 import io.restassured.http.Headers;
 import org.apache.http.client.HttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 
 import java.util.List;
 import java.util.Map;
@@ -175,6 +176,8 @@ public interface FilterableRequestSpecification extends RequestSpecification {
      * @return The underlying http client. Only use this for advanced configuration which is not accessible from Rest Assured! By default an instance of {@link org.apache.http.impl.client.AbstractHttpClient} is used by REST Assured.
      */
     HttpClient getHttpClient();
+
+    HttpClientBuilder getHttpClientBuilder();
 
     /**
      * @return The defined proxy specification or <code>null</code> if undefined.

--- a/rest-assured/src/test/java/io/restassured/http/SniSSLTest.java
+++ b/rest-assured/src/test/java/io/restassured/http/SniSSLTest.java
@@ -1,0 +1,18 @@
+package io.restassured.http;
+
+import io.restassured.RestAssured;
+import org.junit.Test;
+
+import static io.restassured.RestAssured.given;
+
+public class SniSSLTest {
+
+    /**
+     * https://github.com/rest-assured/rest-assured/issues/548
+     */
+    @Test
+    public void validateSniWorks() {
+        RestAssured.baseURI = "https://sni.velox.ch"; // sample server with SNI configured
+        given().expect().statusCode(200).with().get("/");
+    }
+}


### PR DESCRIPTION
This is an initial pass at getting SNI working, as well as migrating to HttpClientBuilder instead of AbstractHttpClient

Addresses
- https://github.com/rest-assured/rest-assured/issues/497
- https://github.com/rest-assured/rest-assured/issues/548

This is not backwards compatible.