### PR TITLE
#781: Fix: Mismatch description from Matcher is ignored for status code

### DIFF
--- a/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/ErrorMessageITest.java
+++ b/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/ErrorMessageITest.java
@@ -73,7 +73,7 @@ public class ErrorMessageITest extends WithJetty {
     error_message_look_ok_when_mixing_body_and_status_code_errors() {
         exception.expect(AssertionError.class);
         exception.expectMessage("3 expectations failed.\n" +
-                "Expected status code <201> doesn't match actual status code <200>.\n" +
+                "Expected status code <201> but was <200>.\n" +
                 "\n" +
                 "JSON path lotto.lottoId doesn't match.\n" +
                 "Expected: a value less than <2>\n" +

--- a/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/GivenWhenThenErrorITest.java
+++ b/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/GivenWhenThenErrorITest.java
@@ -46,7 +46,7 @@ public class GivenWhenThenErrorITest extends WithJetty {
     @Test public void
     throws_assertion_error_when_a_status_assertion_is_incorrect() {
         exception.expect(AssertionError.class);
-        exception.expectMessage("Expected status code <202> doesn't match actual status code <200>.");
+        exception.expectMessage("Expected status code <202> but was <200>.");
 
         given().
                 param("firstName", "John").

--- a/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/GivenWhenThenResponseSpecITest.java
+++ b/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/GivenWhenThenResponseSpecITest.java
@@ -34,7 +34,7 @@ public class GivenWhenThenResponseSpecITest extends WithJetty {
     simple_given_when_then_works() {
         exception.expect(AssertionError.class);
         exception.expectMessage("2 expectations failed.\n" +
-                "Expected status code <201> doesn't match actual status code <200>.\n" +
+                "Expected status code <201> but was <200>.\n" +
                 "\n" +
                 "JSON path greeting doesn't match.\n" +
                 "Expected: Greetings John Doo\n" +

--- a/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/JSONGetITest.java
+++ b/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/JSONGetITest.java
@@ -161,7 +161,7 @@ public class JSONGetITest extends WithJetty {
         // Given
         exception.expect(AssertionError.class);
         exception.expectMessage(equalTo("1 expectation failed.\n" +
-                "Expected status code <300> doesn't match actual status code <200>.\n"));
+                "Expected status code <300> but was <200>.\n"));
 
         // When
         expect().response().statusCode(300).and().body("lotto.lottoId", equalTo(5)).when().get("/lotto");

--- a/rest-assured/src/main/groovy/io/restassured/internal/ResponseSpecificationImpl.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/ResponseSpecificationImpl.groovy
@@ -23,6 +23,7 @@ import io.restassured.function.RestAssuredFunction
 import io.restassured.http.ContentType
 import io.restassured.internal.MapCreator.CollisionStrategy
 import io.restassured.internal.log.LogRepository
+import io.restassured.internal.util.MatcherErrorMessageBuilder
 import io.restassured.parsing.Parser
 import io.restassured.response.Response
 import io.restassured.specification.*
@@ -525,7 +526,10 @@ class ResponseSpecificationImpl implements FilterableResponseSpecification {
       if (expectedStatusCode != null) {
         def actualStatusCode = response.getStatusCode()
         if (!expectedStatusCode.matches(actualStatusCode)) {
-          def errorMessage = String.format("Expected status code %s doesn't match actual status code <%s>.\n", expectedStatusCode.toString(), actualStatusCode)
+
+          def errorMessage = new MatcherErrorMessageBuilder<Integer, Matcher<Integer>>("status code")
+                  .buildError(actualStatusCode, expectedStatusCode)
+
           errors << [success: false, errorMessage: errorMessage];
         }
       }

--- a/rest-assured/src/main/java/io/restassured/internal/util/MatcherErrorMessageBuilder.java
+++ b/rest-assured/src/main/java/io/restassured/internal/util/MatcherErrorMessageBuilder.java
@@ -1,0 +1,24 @@
+package io.restassured.internal.util;
+
+import org.hamcrest.Matcher;
+import org.hamcrest.StringDescription;
+
+public class MatcherErrorMessageBuilder<T, M extends Matcher<T>> {
+
+    private final String name;
+
+    public MatcherErrorMessageBuilder(String name) {
+        this.name = name;
+    }
+
+    public String buildError(T actual, M matcher) {
+        final StringDescription descriptionBuilder = new StringDescription();
+        descriptionBuilder.appendText("Expected ").appendText(name).appendText(" ");
+        matcher.describeTo(descriptionBuilder);
+        descriptionBuilder.appendText(" but ");
+        matcher.describeMismatch(actual, descriptionBuilder);
+
+        final String description = descriptionBuilder.toString().replaceAll("[.\\n]+$", "");
+        return description + ".\n";
+    }
+}

--- a/rest-assured/src/test/java/io/restassured/internal/util/MatcherErrorMessageBuilderTests.java
+++ b/rest-assured/src/test/java/io/restassured/internal/util/MatcherErrorMessageBuilderTests.java
@@ -1,0 +1,76 @@
+package io.restassured.internal.util;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class MatcherErrorMessageBuilderTests {
+
+    @Test
+    public void shouldIncludeMismatchedDescription() {
+
+        final Integer expectedStatusCode = 200;
+        final String body = "There was an error.";
+
+        final TypeSafeMatcher<Integer> matcher = new TypeSafeMatcher<Integer>() {
+            @Override
+            protected boolean matchesSafely(Integer integer) {
+                return integer.equals(expectedStatusCode);
+            }
+
+            public void describeTo(Description description) {
+                description.appendText("to equal ").appendValue(expectedStatusCode);
+            }
+
+            @Override
+            protected void describeMismatchSafely(Integer actual, Description mismatchDescription) {
+                mismatchDescription
+                        .appendText("was ")
+                        .appendValue(actual)
+                        .appendText(" with body: ")
+                        .appendText(body);
+            }
+        };
+
+        final MatcherErrorMessageBuilder<Integer, Matcher<Integer>> builder = new MatcherErrorMessageBuilder<Integer, Matcher<Integer>>("status code");
+        final String error = builder.buildError(500, matcher);
+
+        assertEquals("Expected status code to equal <200> but was <500> with body: There was an error.\n", error);
+    }
+
+    @Test
+    public void shouldPrintNicelyWithoutMismatchDescription() {
+        final Integer expectedStatusCode = 200;
+        final TypeSafeMatcher<Integer> matcher = new TypeSafeMatcher<Integer>() {
+            @Override
+            protected boolean matchesSafely(Integer integer) {
+                return integer.equals(expectedStatusCode);
+            }
+
+            public void describeTo(Description description) {
+                description
+                        .appendText("to equal ")
+                        .appendValue(expectedStatusCode);
+            }
+        };
+
+        final MatcherErrorMessageBuilder<Integer, Matcher<Integer>> builder = new MatcherErrorMessageBuilder<Integer, Matcher<Integer>>("status code");
+        final String error = builder.buildError(500, matcher);
+
+        assertEquals("Expected status code to equal <200> but was <500>.\n", error);
+    }
+
+    @Test
+    public void shouldPrintNicelyWithDefaultEqualMatcher() {
+
+        final Integer expectedStatusCode = 200;
+        final MatcherErrorMessageBuilder<Integer, Matcher<Integer>> builder = new MatcherErrorMessageBuilder<Integer, Matcher<Integer>>("status code");
+        final String error = builder.buildError(500, Matchers.equalTo(expectedStatusCode));
+
+        assertEquals("Expected status code <200> but was <500>.\n", error);
+    }
+}


### PR DESCRIPTION
Created a reusable error message builder to enable consistent handling in the future and enable unit testing.

This PR only affects the error message produced when status code is mismatching to maintain scope.