### PR TITLE
fix #791: check cookies of HttpServletResponse (additionally to the Set-Cookie header)

### DIFF
--- a/modules/spring-mock-mvc/src/main/java/io/restassured/module/mockmvc/internal/MockMvcRequestSenderImpl.java
+++ b/modules/spring-mock-mvc/src/main/java/io/restassured/module/mockmvc/internal/MockMvcRequestSenderImpl.java
@@ -149,6 +149,27 @@ class MockMvcRequestSenderImpl implements MockMvcRequestSender, MockMvcRequestAs
         return new Headers(headers);
     }
 
+    private Cookies convertCookies(javax.servlet.http.Cookie[] servletCookies) {
+        List<Cookie> cookies = new ArrayList<Cookie>();
+        for (javax.servlet.http.Cookie servletCookie : servletCookies) {
+            Cookie.Builder cookieBuilder = new Cookie.Builder(servletCookie.getName(), servletCookie.getValue());
+            if (servletCookie.getComment() != null) {
+                cookieBuilder.setComment(servletCookie.getComment());
+            }
+            if (servletCookie.getDomain() != null) {
+                cookieBuilder.setDomain(servletCookie.getDomain());
+            }
+            if (servletCookie.getPath() != null) {
+                cookieBuilder.setPath(servletCookie.getPath());
+            }
+            cookieBuilder.setMaxAge(servletCookie.getMaxAge());
+            cookieBuilder.setVersion(servletCookie.getVersion());
+            cookieBuilder.setSecured(servletCookie.getSecure());
+            cookies.add(cookieBuilder.build());
+        }
+        return new Cookies(cookies);
+    }
+
     @SuppressWarnings("unchecked")
     private MockMvcResponse performRequest(MockHttpServletRequestBuilder requestBuilder) {
         MockHttpServletResponse response;
@@ -191,6 +212,7 @@ class MockMvcRequestSenderImpl implements MockMvcRequestSender, MockMvcRequestAs
             restAssuredResponse.setFilterContextProperties(new HashMap() {{
                 put(TimingFilter.RESPONSE_TIME_MILLISECONDS, responseTime);
             }});
+            restAssuredResponse.setCookies(convertCookies(response.getCookies()));
 
             if (responseSpecification != null) {
                 responseSpecification.validate(ResponseConverter.toStandardResponse(restAssuredResponse));
@@ -351,6 +373,7 @@ class MockMvcRequestSenderImpl implements MockMvcRequestSender, MockMvcRequestAs
                 if (cookie.hasVersion()) {
                     servletCookie.setVersion(cookie.getVersion());
                 }
+                servletCookie.setSecure(cookie.isSecured());
                 request.cookie(servletCookie);
             }
         }

--- a/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/CookieTest.java
+++ b/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/CookieTest.java
@@ -103,6 +103,21 @@ public class CookieTest {
                 body("cookieValue1", equalTo("John Doe")).
                 body("cookieValue2", equalTo("rest assured"));
     }
+
+    @Test public void
+    can_receive_cookies() {
+        RestAssuredMockMvc.given().
+                queryParam("cookieName1", "name").
+                queryParam("cookieValue1", "John Doe").
+                queryParam("cookieName2", "project").
+                queryParam("cookieValue2", "rest assured").
+        when().
+                get("/setCookies").
+        then().
+                statusCode(200).
+                cookie("name", "John Doe").
+                cookie("project", "rest assured");
+    }
 }
 
 // @formatter:on

--- a/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/http/CookieController.java
+++ b/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/http/CookieController.java
@@ -18,7 +18,11 @@ package io.restassured.module.mockmvc.http;
 
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
@@ -28,5 +32,14 @@ public class CookieController {
     @RequestMapping(value = "/cookie", method = GET, produces = APPLICATION_JSON_VALUE)
     public @ResponseBody String cookie(@CookieValue("cookieName1") String cookieValue1, @CookieValue(value = "cookieName2", required = false) String cookieValue2) {
         return "{\"cookieValue1\" : \"" + cookieValue1 + "\", \"cookieValue2\" : \"" + cookieValue2 + "\"}";
+    }
+
+    @RequestMapping(value = "/setCookies", method = GET, produces = APPLICATION_JSON_VALUE)
+    public @ResponseBody String setCookies(HttpServletResponse response,
+                     @RequestParam("cookieName1") String cookieName1, @RequestParam("cookieValue1") String cookieValue1,
+                     @RequestParam("cookieName2") String cookieName2, @RequestParam("cookieValue2") String cookieValue2) {
+        response.addCookie(new Cookie(cookieName1, cookieValue1));
+        response.addCookie(new Cookie(cookieName2, cookieValue2));
+        return "{}";
     }
 }

--- a/rest-assured/src/main/groovy/io/restassured/assertion/CookieMatcher.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/assertion/CookieMatcher.groovy
@@ -36,14 +36,23 @@ class CookieMatcher {
 
 
 
-    def validateCookie(List<String> cookies) {
+    def validateCookies(List<String> headerWithCookieList, Cookies responseCookies) {
         def success = true
         def errorMessage = ""
-        if(!cookies) {
+        if(!headerWithCookieList && !responseCookies.exist()) {
             success = false
             errorMessage = "No cookies defined in the response\n"
         } else {
-            def raCookies = getCookies(cookies)
+            Cookies cookiesInHeader = getCookies(headerWithCookieList)
+            List<Cookie> mergedCookies = []
+            mergedCookies += cookiesInHeader
+            for (Cookie responseCookie: responseCookies) {
+                if (!cookiesInHeader.hasCookieWithName(responseCookie.getName())) {
+                    mergedCookies << responseCookie
+                }
+            }
+
+            def raCookies = new Cookies(mergedCookies)
             def cookie = raCookies.get(cookieName)
             if (cookie == null) {
                 String cookiesAsString = raCookies.toString()

--- a/rest-assured/src/main/groovy/io/restassured/internal/ResponseSpecificationImpl.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/ResponseSpecificationImpl.groovy
@@ -559,8 +559,9 @@ class ResponseSpecificationImpl implements FilterableResponseSpecification {
       })
 
       validations.addAll(cookieAssertions.collect { matcher ->
-        def cookies = response.getHeaders().getValues("Set-Cookie")
-        matcher.validateCookie(cookies)
+        def headerWithCookieList = response.getHeaders().getValues("Set-Cookie")
+        def responseCookies = response.getDetailedCookies()
+        matcher.validateCookies(headerWithCookieList, responseCookies)
       })
       validations
     }

--- a/rest-assured/src/test/java/io/restassured/assertion/CookieMatcherMessagesTest.java
+++ b/rest-assured/src/test/java/io/restassured/assertion/CookieMatcherMessagesTest.java
@@ -1,5 +1,6 @@
 package io.restassured.assertion;
 
+import io.restassured.http.Cookies;
 import org.hamcrest.Description;
 import org.hamcrest.Matchers;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
@@ -26,7 +27,7 @@ public class CookieMatcherMessagesTest {
         cookieMatcher.setCookieName("DEVICE_ID");
         cookieMatcher.setMatcher(Matchers.containsString("X"));
 
-        Map<String, Object> result = (Map<String, Object>) cookieMatcher.validateCookie(Arrays.asList(cookies));
+        Map<String, Object> result = (Map<String, Object>) cookieMatcher.validateCookies(Arrays.asList(cookies), new Cookies());
         assertThat((Boolean)result.get("success"), equalTo(false));
         assertThat(result.get("errorMessage").toString(), equalTo("Expected cookie \"DEVICE_ID\" was not a string containing \"X\", was \"123\".\n"));
     }
@@ -38,7 +39,7 @@ public class CookieMatcherMessagesTest {
         cookieMatcher.setCookieName("DEVICE_ID");
         cookieMatcher.setMatcher(new ContainsXMatcher());
 
-        Map<String, Object> result = (Map<String, Object>) cookieMatcher.validateCookie(Arrays.asList(cookies));
+        Map<String, Object> result = (Map<String, Object>) cookieMatcher.validateCookies(Arrays.asList(cookies), new Cookies());
         assertThat((Boolean)result.get("success"), equalTo(false));
         assertThat(result.get("errorMessage").toString(), equalTo("Expected cookie \"DEVICE_ID\" was not containing 'X', \"123\" not containing 'X'.\n"));
     }


### PR DESCRIPTION
at the moment only the Set-Cookies header is examined for cookie validations. this PR fills the restAssuredResponse.cookies field and merges the cookies from the Set-Cookies header with the cookies from the httpServletResponse.getCookies() for validations (`CookieMatcher`).