### PR TITLE
Fix double negative in Exception message

### DIFF
--- a/rest-assured/src/main/groovy/io/restassured/internal/mapping/ObjectMapping.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/mapping/ObjectMapping.groovy
@@ -79,7 +79,7 @@ class ObjectMapping {
         }
       }
     }
-    throw new IllegalStateException(String.format("Cannot parse object because no supported Content-Type was not specified in response. Content-Type was '%s'.", contentType))
+    throw new IllegalStateException(String.format("Cannot parse object because no supported Content-Type was specified in response. Content-Type was '%s'.", contentType))
   }
 
   private


### PR DESCRIPTION
Remove second negative from exception message "... no supported Content-Type was not specified... ".