### PR TITLE
Proposed fix for issue #861

### DIFF
--- a/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/ContentTypeITest.java
+++ b/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/ContentTypeITest.java
@@ -350,6 +350,22 @@ public class ContentTypeITest extends WithJetty {
     }
 
     @Test public void
+    validates_content_type_json() {
+        given().contentType(ContentType.JSON)
+                .get("/contentTypeAsContentType")
+                .then()
+                .contentType(ContentType.JSON);
+    }
+
+    @Test public void
+    validates_content_type_binary() {
+        given().contentType(ContentType.BINARY)
+                .get("/contentTypeAsContentType")
+                .then()
+                .contentType(ContentType.BINARY);
+    }
+
+    @Test public void
     can_assert_empty_or_null_content_type() {
         given().
                 filter((requestSpec, responseSpec, ctx) -> new ResponseBuilder().setStatusCode(200).setHeader("Some", "Value").setBody("Test").build()).

--- a/examples/scalatra-example/src/main/scala/io/restassured/scalatra/ScalatraRestExample.scala
+++ b/examples/scalatra-example/src/main/scala/io/restassured/scalatra/ScalatraRestExample.scala
@@ -365,6 +365,10 @@ class ScalatraRestExample extends ScalatraServlet {
     request.contentType.getOrElse("null")
   }
 
+  get("/contentTypeAsContentType") {
+    contentType = request.contentType.getOrElse("null")
+  }
+
   post("/textUriList") {
     if (!request.getContentType.contains("text")) {
       status = 400

--- a/rest-assured/src/main/java/io/restassured/http/ContentType.java
+++ b/rest-assured/src/main/java/io/restassured/http/ContentType.java
@@ -164,6 +164,12 @@ public enum ContentType {
             foundContentType = TEXT;
         } else if (contains(HTML.ctStrings, contentType) || endsWithIgnoreCase(contentType, PLUS_HTML)) {
             foundContentType = HTML;
+        } else if (contains(URLENC.ctStrings, contentType)) {
+            foundContentType = URLENC;
+        } else if (contains(BINARY.ctStrings, contentType)) {
+            foundContentType = BINARY;
+        } else if (contains(ANY.ctStrings, contentType)) {
+            foundContentType = ANY;
         } else {
             foundContentType = null;
         }

--- a/rest-assured/src/test/java/io/restassured/http/ContentTypeTest.java
+++ b/rest-assured/src/test/java/io/restassured/http/ContentTypeTest.java
@@ -17,8 +17,14 @@
 package io.restassured.http;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
 import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Collection;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -79,4 +85,36 @@ public class ContentTypeTest {
         // Then
         assertThat(matches, is(false));
     }
+
+    @RunWith(Parameterized.class)
+    public static class ContentTypeFromStringTest {
+        @Parameters(name = "string=''{0}'', expected=''{1}''")
+        public static Collection<Object[]> data() {
+            ArrayList<Object[]> data = new ArrayList<Object[]>();
+
+            for (ContentType ct : ContentType.values()) {
+                for (String cts : ct.getContentTypeStrings()) {
+                    data.add(new Object[]{ct, cts});
+                }
+            }
+
+            return data;
+        }
+
+        @Parameter(0)
+        public ContentType expected;
+
+        @Parameter(1)
+        public String contentTypeString;
+
+        @Test public void
+        should_find_content_type_from_string() {
+            // When
+            ContentType content = ContentType.fromContentType(contentTypeString);
+
+            // Then
+            assertThat(content, is(expected));
+        }
+    }
+
 }


### PR DESCRIPTION
ContentType.fromContentType() did not correctly coerce some content types.

I added an integration test on `contentType(BINARY)` assertion and a unit test on `fromContentType` which should detect bugs when an enum is added to `ContentType`

