### PR TITLE
Upgrading Apache HTTP Client to v4.5.3

### DIFF
--- a/rest-assured/pom.xml
+++ b/rest-assured/pom.xml
@@ -17,7 +17,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <properties>
-        <httpclient.version>4.5.2</httpclient.version>
+        <httpclient.version>4.5.3</httpclient.version>
     </properties>
     <parent>
         <groupId>io.rest-assured</groupId>


### PR DESCRIPTION
In using RA on my current project, I've noticed an issue with two-way SSL and a seeming root cause with Apache HTTP Client v4.5.2.  Upgrade to 4.5.3 works perfectly.  

There do seem to be some tickets in the HTTP Client changelog of note - a bit over my head, though: https://archive.apache.org/dist/httpcomponents/httpclient/RELEASE_NOTES-4.5.x.txt