### PR TITLE
treat text/json as JSON content type

### DIFF
--- a/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/AcceptHeaderITest.java
+++ b/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/AcceptHeaderITest.java
@@ -109,7 +109,7 @@ public class AcceptHeaderITest extends WithJetty {
         then().
                 body(equalTo("hello world"));
 
-        assertThat(headers.getValue(), contains("application/json, application/javascript, text/javascript"));
+        assertThat(headers.getValue(), contains("application/json, application/javascript, text/javascript, text/json"));
     }
 
     @Test public void
@@ -134,6 +134,6 @@ public class AcceptHeaderITest extends WithJetty {
         then().
                 body(equalTo("hello world"));
 
-        assertThat(headers.getValue(), contains("application/json, application/javascript, text/javascript", "text/jux"));
+        assertThat(headers.getValue(), contains("application/json, application/javascript, text/javascript, text/json", "text/jux"));
     }
 }

--- a/rest-assured/src/main/java/io/restassured/http/ContentType.java
+++ b/rest-assured/src/main/java/io/restassured/http/ContentType.java
@@ -66,7 +66,7 @@ public enum ContentType {
      * <li><code>text/javascript</code></li>
      * </ul>
      */
-    JSON("application/json", "application/javascript", "text/javascript"),
+    JSON("application/json", "application/javascript", "text/javascript", "text/json"),
     /**
      * <ul>
      * <li><code>application/xml</code></li>


### PR DESCRIPTION
We have a legacy application that is returning JSON but declares the content type as `text/json`. 
Although `text/json` is not a standard MIME type, adding support `ContentType.JSON` would make the code consistent - the [Parser](https://github.com/rest-assured/rest-assured/blob/7cc7503b66d17fffa7d6f8442e3838a9b0d5f7b8/rest-assured/src/main/java/io/restassured/parsing/Parser.java#L29) is already taking it into account, while [ContentType](https://github.com/rest-assured/rest-assured/blob/13b5af0822a3366dcc67f5beeb22e8fdb3eafc1a/rest-assured/src/main/java/io/restassured/http/ContentType.java#L69) does not.

See also:
* https://stackoverflow.com/questions/477816/what-is-the-correct-json-content-type#answer-2590013