### PR TITLE
Fix for #912, Set authentication once to set in SecurityContextHolder and Principal in method parameter

### DIFF
--- a/modules/spring-mock-mvc/src/main/java/io/restassured/module/mockmvc/internal/MockMvcRequestSenderImpl.java
+++ b/modules/spring-mock-mvc/src/main/java/io/restassured/module/mockmvc/internal/MockMvcRequestSenderImpl.java
@@ -180,7 +180,8 @@ class MockMvcRequestSenderImpl implements MockMvcRequestSender, MockMvcRequestAs
 
         if (isSpringSecurityInClasspath() && authentication instanceof org.springframework.security.core.Authentication) {
             org.springframework.security.core.context.SecurityContextHolder.getContext().setAuthentication((org.springframework.security.core.Authentication) authentication);
-        } else if (authentication instanceof Principal) {
+        }
+        if (authentication instanceof Principal) {
             requestBuilder.principal((Principal) authentication);
         }
 

--- a/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/SecuredControllerTest.java
+++ b/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/SecuredControllerTest.java
@@ -81,6 +81,19 @@ public class SecuredControllerTest {
     }
 
     @Test public void
+    spring_security_set_authentication_also_set_principal() {
+        RestAssuredMockMvc.given().
+                standaloneSetup(new SecuredController()).
+                auth().authentication(new TestingAuthenticationToken(new User("authorized_user", "password", Collections.<GrantedAuthority>emptyList()), "")).
+                param("name", "Johan").
+        when().
+                get("/setAuthenticationSetBoth").
+        then().
+                statusCode(200).
+                body("content", equalTo("Hello, Johan!"));
+    }
+
+    @Test public void
     spring_context_holder_is_cleared_after_test() {
         RestAssuredMockMvc.given().
                 standaloneSetup(new SecuredController()).

--- a/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/http/SecuredController.java
+++ b/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/http/SecuredController.java
@@ -51,4 +51,13 @@ public class SecuredController {
 
         return new Greeting(counter.incrementAndGet(), String.format(template, name));
     }
+
+    @RequestMapping(value = "/setAuthenticationSetBoth", method = GET)
+    public @ResponseBody Greeting setAuthenticationSetBoth(@RequestParam(value = "name", required = false, defaultValue = "World") String name, Principal principal) {
+        if (!SecurityContextHolder.getContext().getAuthentication().equals(principal)) {
+            throw new IllegalArgumentException("Authentication not equal principal!");
+        }
+
+        return new Greeting(counter.incrementAndGet(), String.format(template, name));
+    }
 }


### PR DESCRIPTION
Once we set the authentication, for example: 

https://github.com/rest-assured/rest-assured/blob/d3a34e9a6bb72cd37f509e1dc12eafbd66642b71/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/SecuredControllerTest.java#L72-L75

We should be able to retrieve it through:

1. SecurityContextHolder.getContext().getAuthentication()
2. @GetMapping public void someMethod(Principal principal) 

no. 2 should automatically apply since Authentication extends Principal

Looking at the code, it appears we just need to change the "else if" to a separate "if" statement.

https://github.com/rest-assured/rest-assured/blob/d3a34e9a6bb72cd37f509e1dc12eafbd66642b71/modules/spring-mock-mvc/src/main/java/io/restassured/module/mockmvc/internal/MockMvcRequestSenderImpl.java#L181-L185

I can create a pull request and update some test, but the [SecuredControllerTest](https://github.com/rest-assured/rest-assured/blob/master/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/SecuredControllerTest.java) seems to separate this out deliberately?

Perhaps @johanhaleby can comment?