### PR TITLE
[Feature] Type instead of Class has been added for mapping

### DIFF
--- a/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/CustomObjectMappingITest.java
+++ b/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/CustomObjectMappingITest.java
@@ -31,6 +31,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.lang.reflect.Type;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.google.gson.FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES;
@@ -121,6 +122,19 @@ public class CustomObjectMappingITest extends WithJetty {
         assertThat(returnedMessage.getMessage(), equalTo("A message"));
     }
 
+    @Test
+    public void
+    using_as_specified_object() {
+        final Message message = new Message();
+        message.setMessage("A message");
+        RestAssured.config = RestAssuredConfig.config().objectMapperConfig(new ObjectMapperConfig(GSON));
+
+        final String returnedMessage = given().body(message).when().post("/reflect")
+                .as(Message.class).getMessage();
+
+        assertThat(returnedMessage, equalTo("A message"));
+    }
+
     @Test public void
     using_custom_object_mapper_factory() {
         final Greeting greeting = new Greeting();
@@ -128,7 +142,7 @@ public class CustomObjectMappingITest extends WithJetty {
         greeting.setLastName("Doe");
         RestAssured.config = RestAssuredConfig.config().objectMapperConfig(objectMapperConfig().gsonObjectMapperFactory(
                 new GsonObjectMapperFactory() {
-                    public Gson create(Class cls, String charset) {
+                    public Gson create(Type cls, String charset) {
                         return new GsonBuilder().setFieldNamingPolicy(LOWER_CASE_WITH_UNDERSCORES).create();
                     }
                 }

--- a/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/TypeObjectExceptionMappingITest.java
+++ b/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/TypeObjectExceptionMappingITest.java
@@ -1,0 +1,26 @@
+package io.restassured.itest.java;
+
+import com.google.gson.reflect.TypeToken;
+import io.restassured.itest.java.objects.Greeting;
+import io.restassured.itest.java.support.WithJetty;
+import org.junit.Test;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.mapper.ObjectMapperType.JAXB;
+
+public class TypeObjectExceptionMappingITest extends WithJetty {
+
+    @Test(expected = RuntimeException.class)
+    public void shouldSeeExceptionWhenMappingTypeForJAXB() {
+        final Greeting greeting = new Greeting();
+        greeting.setFirstName("John");
+        greeting.setLastName("Doe");
+        Type type = new TypeToken<Map<String, String>>() {
+        }.getType();
+        given().contentType("application/xml").body(greeting, JAXB).post("/reflect").as(type, JAXB);
+    }
+
+}

--- a/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/TypeObjectMappingITest.java
+++ b/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/TypeObjectMappingITest.java
@@ -1,0 +1,52 @@
+package io.restassured.itest.java;
+
+import com.google.gson.reflect.TypeToken;
+import io.restassured.RestAssured;
+import io.restassured.config.ObjectMapperConfig;
+import io.restassured.config.RestAssuredConfig;
+import io.restassured.itest.java.objects.Message;
+import io.restassured.itest.java.support.WithJetty;
+import io.restassured.mapper.ObjectMapperType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.mapper.ObjectMapperType.GSON;
+import static io.restassured.mapper.ObjectMapperType.JACKSON_1;
+import static io.restassured.mapper.ObjectMapperType.JACKSON_2;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+@RunWith(Parameterized.class)
+public class TypeObjectMappingITest extends WithJetty {
+
+    @Parameterized.Parameter
+    public ObjectMapperType mapperType;
+
+    @SuppressWarnings("unchecked")
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object[]> getParameters() {
+        return Arrays.asList(new Object[][]{
+                {GSON},
+                {JACKSON_1},
+                {JACKSON_2}
+        });
+    }
+
+    @Test
+    public void shouldUseMapTypeWithObjectMappers() {
+        String expected = "A message";
+        final Message message = new Message();
+        message.setMessage(expected);
+        RestAssured.config = RestAssuredConfig.config().objectMapperConfig(new ObjectMapperConfig(mapperType));
+        Type type = new TypeToken<Map<String, String>>(){}.getType();
+        final Map<String, String> returnedMessage = given().body(message).when().post("/reflect").as(type);
+        assertThat(returnedMessage.get("message"), equalTo(expected));
+    }
+}

--- a/json-path/src/main/groovy/io/restassured/internal/path/json/mapping/JsonPathJackson1ObjectDeserializer.groovy
+++ b/json-path/src/main/groovy/io/restassured/internal/path/json/mapping/JsonPathJackson1ObjectDeserializer.groovy
@@ -23,6 +23,8 @@ import io.restassured.mapper.factory.Jackson1ObjectMapperFactory
 import io.restassured.path.json.mapping.JsonPathObjectDeserializer
 import org.codehaus.jackson.type.JavaType
 
+import java.lang.reflect.Type
+
 class JsonPathJackson1ObjectDeserializer implements JsonPathObjectDeserializer {
 
     private final Jackson1ObjectMapperFactory factory;
@@ -31,7 +33,7 @@ class JsonPathJackson1ObjectDeserializer implements JsonPathObjectDeserializer {
         this.factory = factory
     }
 
-    private org.codehaus.jackson.map.ObjectMapper createJacksonObjectMapper(Class cls, String charset) {
+    private org.codehaus.jackson.map.ObjectMapper createJacksonObjectMapper(Type cls, String charset) {
         return factory.create(cls, charset)
     }
 

--- a/json-path/src/main/groovy/io/restassured/internal/path/json/mapping/JsonPathJackson2ObjectDeserializer.groovy
+++ b/json-path/src/main/groovy/io/restassured/internal/path/json/mapping/JsonPathJackson2ObjectDeserializer.groovy
@@ -20,9 +20,11 @@ package io.restassured.internal.path.json.mapping
 
 import com.fasterxml.jackson.databind.JavaType
 import com.fasterxml.jackson.databind.ObjectMapper
-import io.restassured.path.json.mapping.JsonPathObjectDeserializer
 import io.restassured.mapper.ObjectDeserializationContext
 import io.restassured.mapper.factory.Jackson2ObjectMapperFactory
+import io.restassured.path.json.mapping.JsonPathObjectDeserializer
+
+import java.lang.reflect.Type
 
 class JsonPathJackson2ObjectDeserializer implements JsonPathObjectDeserializer {
 
@@ -32,7 +34,7 @@ class JsonPathJackson2ObjectDeserializer implements JsonPathObjectDeserializer {
         this.factory = factory
     }
 
-    private ObjectMapper createJackson2ObjectMapper(Class cls, String charset) {
+    private ObjectMapper createJackson2ObjectMapper(Type cls, String charset) {
         return factory.create(cls, charset)
     }
 

--- a/json-path/src/main/java/io/restassured/mapper/factory/DefaultGsonObjectMapperFactory.java
+++ b/json-path/src/main/java/io/restassured/mapper/factory/DefaultGsonObjectMapperFactory.java
@@ -18,11 +18,13 @@ package io.restassured.mapper.factory;
 
 import com.google.gson.Gson;
 
+import java.lang.reflect.Type;
+
 /**
  * Simply creates a new Gson instance.
  */
 public class DefaultGsonObjectMapperFactory implements GsonObjectMapperFactory {
-    public Gson create(Class cls, String charset) {
+    public Gson create(Type cls, String charset) {
         return new Gson();
     }
 }

--- a/json-path/src/main/java/io/restassured/mapper/factory/DefaultJackson1ObjectMapperFactory.java
+++ b/json-path/src/main/java/io/restassured/mapper/factory/DefaultJackson1ObjectMapperFactory.java
@@ -18,11 +18,13 @@ package io.restassured.mapper.factory;
 
 import org.codehaus.jackson.map.ObjectMapper;
 
+import java.lang.reflect.Type;
+
 /**
  * Simply creates a new Jackson 1.0 ObjectMapper
  */
 public class DefaultJackson1ObjectMapperFactory implements Jackson1ObjectMapperFactory {
-    public ObjectMapper create(Class cls, String charset) {
+    public ObjectMapper create(Type cls, String charset) {
         return new ObjectMapper();
     }
 }

--- a/json-path/src/main/java/io/restassured/mapper/factory/DefaultJackson2ObjectMapperFactory.java
+++ b/json-path/src/main/java/io/restassured/mapper/factory/DefaultJackson2ObjectMapperFactory.java
@@ -19,11 +19,13 @@ package io.restassured.mapper.factory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import java.lang.reflect.Type;
+
 /**
  * Simply creates a new Jackson 2.0 ObjectMapper
  */
 public class DefaultJackson2ObjectMapperFactory implements Jackson2ObjectMapperFactory {
-    public ObjectMapper create(Class cls, String charset) {
+    public ObjectMapper create(Type cls, String charset) {
         return new ObjectMapper().findAndRegisterModules();
     }
 }

--- a/rest-assured-common/src/main/groovy/io/restassured/internal/mapper/ObjectDeserializationContextImpl.groovy
+++ b/rest-assured-common/src/main/groovy/io/restassured/internal/mapper/ObjectDeserializationContextImpl.groovy
@@ -22,10 +22,12 @@ package io.restassured.internal.mapper
 import io.restassured.mapper.DataToDeserialize
 import io.restassured.mapper.ObjectDeserializationContext
 
+import java.lang.reflect.Type
+
 class ObjectDeserializationContextImpl implements ObjectDeserializationContext {
 
     def DataToDeserialize dataToDeserialize
-    def Class<?> type
+    def Type type
     def charset
 
     @Override
@@ -34,7 +36,7 @@ class ObjectDeserializationContextImpl implements ObjectDeserializationContext {
     }
 
     @Override
-    Class<?> getType() {
+    Type getType() {
         return type
     }
 

--- a/rest-assured-common/src/main/java/io/restassured/mapper/ObjectDeserializationContext.java
+++ b/rest-assured-common/src/main/java/io/restassured/mapper/ObjectDeserializationContext.java
@@ -16,6 +16,8 @@
 
 package io.restassured.mapper;
 
+import java.lang.reflect.Type;
+
 /**
  * Class containing details needed for deserializing a response to a Java class.
  */
@@ -29,7 +31,7 @@ public interface ObjectDeserializationContext {
     /**
      * @return The expected type of the object to deserialize
      */
-    Class<?> getType();
+    Type getType();
 
     /**
      * If a charset is specified in the content-type then this method will return that charset otherwise

--- a/rest-assured-common/src/main/java/io/restassured/mapper/factory/ObjectMapperFactory.java
+++ b/rest-assured-common/src/main/java/io/restassured/mapper/factory/ObjectMapperFactory.java
@@ -16,6 +16,8 @@
 
 package io.restassured.mapper.factory;
 
+import java.lang.reflect.Type;
+
 /**
  * The base interface for object mapper factories.
  * @param <T> The type of the created object mapper.
@@ -29,5 +31,5 @@ public interface ObjectMapperFactory<T> {
      * @param charset The charset
      * @return An object mapper instance
      */
-    T create(Class cls, String charset);
+    T create(Type cls, String charset);
 }

--- a/rest-assured/src/main/groovy/io/restassured/internal/RestAssuredResponseOptionsGroovyImpl.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/RestAssuredResponseOptionsGroovyImpl.groovy
@@ -47,6 +47,7 @@ import io.restassured.response.ResponseBodyData
 import io.restassured.response.ResponseOptions
 import org.apache.commons.lang3.StringUtils
 
+import java.lang.reflect.Type
 import java.nio.charset.Charset
 import java.util.concurrent.TimeUnit
 
@@ -213,7 +214,7 @@ class RestAssuredResponseOptionsGroovyImpl {
     }
   }
 
-  def <T> T "as"(Class<T> cls, ResponseBodyData responseBodyData) {
+  def <T> T "as"(Type cls, ResponseBodyData responseBodyData) {
     def charset = findCharset();
     String contentTypeToChose = findContentType {
       throw new IllegalStateException("""Cannot parse content to $cls because no content-type was present in the response and no default parser has been set.\nYou can specify a default parser using e.g.:\nRestAssured.defaultParser = Parser.JSON;\n
@@ -222,13 +223,13 @@ or you can specify an explicit ObjectMapper using as($cls, <ObjectMapper>);""")
     return ObjectMapping.deserialize(responseBodyData, cls, contentTypeToChose, defaultContentType, charset, null, config.getObjectMapperConfig())
   }
 
-  def <T> T "as"(Class<T> cls, ObjectMapperType mapperType, ResponseBodyData responseBodyData) {
+  def <T> T "as"(Type cls, ObjectMapperType mapperType, ResponseBodyData responseBodyData) {
     notNull mapperType, "Object mapper type"
     def charset = findCharset()
     return ObjectMapping.deserialize(responseBodyData, cls, null, defaultContentType, charset, mapperType, config.getObjectMapperConfig())
   }
 
-  def <T> T "as"(Class<T> cls, ObjectMapper mapper) {
+  def <T> T "as"(Type cls, ObjectMapper mapper) {
     notNull mapper, "Object mapper"
     def ctx = createObjectMapperDeserializationContext(cls)
     return mapper.deserialize(ctx) as T
@@ -517,7 +518,7 @@ You can specify a default parser using e.g.:\nRestAssured.defaultParser = Parser
     }
   }
 
-  private ObjectMapperDeserializationContext createObjectMapperDeserializationContext(Class cls) {
+  private ObjectMapperDeserializationContext createObjectMapperDeserializationContext(Type cls) {
     def ctx = new ObjectMapperDeserializationContextImpl()
     ctx.type = cls
     ctx.charset = findCharset()

--- a/rest-assured/src/main/groovy/io/restassured/internal/mapping/ObjectMapping.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/mapping/ObjectMapping.groovy
@@ -32,6 +32,8 @@ import io.restassured.mapper.factory.Jackson2ObjectMapperFactory
 import io.restassured.response.ResponseBodyData
 import org.apache.commons.lang3.Validate
 
+import java.lang.reflect.Type
+
 import static ContentType.ANY
 import static io.restassured.internal.assertion.AssertParameter.notNull
 import static io.restassured.mapper.resolver.ObjectMapperResolver.*
@@ -40,7 +42,7 @@ import static org.apache.commons.lang3.StringUtils.containsIgnoreCase
 class ObjectMapping {
 
   public
-  static <T> T deserialize(ResponseBodyData response, Class<T> cls, String contentType, String defaultContentType, String charset, ObjectMapperType mapperType,
+  static <T> T deserialize(ResponseBodyData response, Type cls, String contentType, String defaultContentType, String charset, ObjectMapperType mapperType,
                            ObjectMapperConfig objectMapperConfig) {
     Validate.notNull(objectMapperConfig, "String mapper configuration wasn't found, cannot deserialize.")
     def deserializationCtx = deserializationContext(response, cls, contentType, charset)
@@ -202,7 +204,7 @@ class ObjectMapping {
     new Jackson2Mapper(factory).deserialize(ctx)
   }
 
-  private static ObjectMapperDeserializationContext deserializationContext(ResponseBodyData responseData, Class cls, contentType, charset) {
+  private static ObjectMapperDeserializationContext deserializationContext(ResponseBodyData responseData, Type cls, contentType, charset) {
     def ctx = new ObjectMapperDeserializationContextImpl()
     ctx.type = cls
     ctx.charset = charset

--- a/rest-assured/src/main/java/io/restassured/internal/RestAssuredResponseOptionsImpl.java
+++ b/rest-assured/src/main/java/io/restassured/internal/RestAssuredResponseOptionsImpl.java
@@ -33,6 +33,7 @@ import io.restassured.response.ResponseBody;
 import io.restassured.response.ResponseOptions;
 
 import java.io.InputStream;
+import java.lang.reflect.Type;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -169,6 +170,18 @@ public class RestAssuredResponseOptionsImpl<R extends ResponseOptions<R>> implem
     }
 
     public <T> T as(Class<T> cls, ObjectMapper mapper) {
+        return groovyResponse.as(cls, mapper);
+    }
+
+    public <T> T as(Type cls) {
+        return groovyResponse.as(cls, this);
+    }
+
+    public <T> T as(Type cls, ObjectMapperType mapperType) {
+        return groovyResponse.as(cls, mapperType, this);
+    }
+
+    public <T> T as(Type cls, ObjectMapper mapper) {
         return groovyResponse.as(cls, mapper);
     }
 

--- a/rest-assured/src/main/java/io/restassured/response/ResponseBodyExtractionOptions.java
+++ b/rest-assured/src/main/java/io/restassured/response/ResponseBodyExtractionOptions.java
@@ -23,6 +23,8 @@ import io.restassured.path.json.config.JsonPathConfig;
 import io.restassured.path.xml.XmlPath;
 import io.restassured.path.xml.config.XmlPathConfig;
 
+import java.lang.reflect.Type;
+
 public interface ResponseBodyExtractionOptions extends ResponseBodyData {
     /**
      * Get the body and map it to a Java object. For JSON responses this requires that you have either
@@ -54,6 +56,37 @@ public interface ResponseBodyExtractionOptions extends ResponseBodyData {
      * @return The object
      */
     <T> T as(Class<T> cls, ObjectMapper mapper);
+
+    /**
+     * Get the body and map it to a Java type with specified type. For JSON responses this requires that you have either
+     * <ol>
+     * <li>Jackson, or</li>
+     * <li>Gson</li>
+     * </ol>
+     * in the classpath or for XML responses it requires JAXB to be in the classpath.
+     * <br/>
+     * It also requires that the response content-type is either JSON or XML or that a default parser has been been set.
+     * You can also force a specific object mapper using {@link #as(Type, ObjectMapper)}.
+     *
+     * @return The object
+     */
+    <T> T as(Type cls);
+
+    /**
+     * Get the body and map it to a Java type with specified type using a specific object mapper type. It will use the supplied
+     * mapper regardless of the response content-type.
+     *
+     * @return The object
+     */
+    <T> T as(Type cls, ObjectMapperType mapperType);
+
+    /**
+     * Get the body and map it to a Java type using a specific object mapper. It will use the supplied
+     * mapper regardless of the response content-type.
+     *
+     * @return The object
+     */
+    <T> T as(Type cls, ObjectMapper mapper);
 
     /**
      * Get a JsonPath view of the response body. This will let you use the JsonPath syntax to get values from the response.

--- a/xml-path/src/main/java/io/restassured/mapper/factory/DefaultJAXBObjectMapperFactory.java
+++ b/xml-path/src/main/java/io/restassured/mapper/factory/DefaultJAXBObjectMapperFactory.java
@@ -18,14 +18,18 @@ package io.restassured.mapper.factory;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
+import java.lang.reflect.Type;
 
 /**
  * Simply creates a new JAXBContext based on the supplied class.
  */
 public class DefaultJAXBObjectMapperFactory implements JAXBObjectMapperFactory {
-    public JAXBContext create(Class cls, String charset) {
+    public JAXBContext create(Type cls, String charset) {
         try {
-            return JAXBContext.newInstance(cls);
+            if (cls instanceof Class) {
+                return JAXBContext.newInstance((Class<?>) cls);
+            }
+            throw new RuntimeException("JAXB does not support type" + cls);
         } catch (JAXBException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
Added `.as()` method to map any `Type`. It is more general solution than `Class<T>` so now we are able to use Gson, Jackson and Jackson2 by default which was not supported by Rest-assured. 
Added necessary tests.