### PR TITLE
Fix for #979 Removing Authorization header when setting auth().none()

### DIFF
--- a/rest-assured/src/main/groovy/io/restassured/internal/AuthenticationSpecificationImpl.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/AuthenticationSpecificationImpl.groovy
@@ -28,6 +28,7 @@ import static io.restassured.internal.assertion.AssertParameter.notNull
  * Specify an authentication scheme to use when sending a request.
  */
 class AuthenticationSpecificationImpl implements AuthenticationSpecification {
+  private static final String AUTHORIZATION_HEADER_NAME = "Authorization"
   private RequestSpecification requestSpecification;
 
   AuthenticationSpecificationImpl(RequestSpecification requestSpecification) {
@@ -167,6 +168,7 @@ class AuthenticationSpecificationImpl implements AuthenticationSpecification {
   def RequestSpecification none() {
     requestSpecification.authenticationScheme = new ExplicitNoAuthScheme();
     requestSpecification.filters.removeAll { it instanceof AuthFilter }
+    requestSpecification.removeHeader(AUTHORIZATION_HEADER_NAME)
     return requestSpecification
   }
 


### PR DESCRIPTION
I don't know if this is the most generic way to do it but seams to work. This is the only auth header that I noticed so I guess it's safe to do it like this. If you have any other suggestions I'm open for discussion. 