### PR TITLE
Ensure RequestSpecBuilder picks up filters from static config (#1012)

### DIFF
--- a/rest-assured/src/main/java/io/restassured/builder/RequestSpecBuilder.java
+++ b/rest-assured/src/main/java/io/restassured/builder/RequestSpecBuilder.java
@@ -76,8 +76,8 @@ public class RequestSpecBuilder {
     private RequestSpecificationImpl spec;
 
     public RequestSpecBuilder() {
-        this.spec = (RequestSpecificationImpl) new RequestSpecificationImpl(baseURI, port, basePath, authentication, Collections.<Filter>emptyList(),
-                null, urlEncodingEnabled, null, new LogRepository(), proxy).config(RestAssured.config());
+        this.spec = (RequestSpecificationImpl) new RequestSpecificationImpl(baseURI, port, basePath, authentication, filters(),
+                requestSpecification, urlEncodingEnabled, config, new LogRepository(), proxy).config(RestAssured.config());
     }
 
     /**

--- a/rest-assured/src/test/java/io/restassured/builder/RequestSpecBuilderTest.java
+++ b/rest-assured/src/test/java/io/restassured/builder/RequestSpecBuilderTest.java
@@ -16,9 +16,16 @@
 
 package io.restassured.builder;
 
+import io.restassured.RestAssured;
+import io.restassured.filter.log.RequestLoggingFilter;
+import io.restassured.internal.RequestSpecificationImpl;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 
 public class RequestSpecBuilderTest {
     @Rule
@@ -28,5 +35,31 @@ public class RequestSpecBuilderTest {
     @Test public void
     request_spec_doesnt_throw_NPE_when_logging_after_creation() {
         new RequestSpecBuilder().build().log().all(true);
+    }
+
+    @Test public void
+    request_spec_picks_up_filters_from_static_config() {
+        RestAssured.filters(new RequestLoggingFilter());
+        try {
+            RequestSpecBuilder builder = new RequestSpecBuilder();
+            RequestSpecificationImpl spec = (RequestSpecificationImpl) builder.build();
+            Assert.assertThat(spec.getDefinedFilters(), hasSize(1));
+        } finally {
+            RestAssured.reset();
+        }
+    }
+
+    @Test public void
+    request_spec_picks_up_headers_from_static_request_spec() {
+        RestAssured.requestSpecification = new RequestSpecBuilder()
+                .addHeader("hello", "world")
+                .build();
+        try {
+            RequestSpecBuilder builder = new RequestSpecBuilder();
+            RequestSpecificationImpl spec = (RequestSpecificationImpl) builder.build();
+            Assert.assertThat(spec.getHeaders().getValue("hello"), equalTo("world"));
+        } finally {
+            RestAssured.reset();
+        }
     }
 }


### PR DESCRIPTION
This PR should resolve #1012 by making sure that filters are passed to RequestSpecificationImpl upon creation.