### PR TITLE
Added OSGi support

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -30,6 +30,7 @@
         <module>scalatra-example</module>
         <module>scalatra-webapp</module>
         <module>rest-assured-itest-java</module>
+        <module>rest-assured-itest-java-osgi</module>
         <module>spring-mvc-webapp</module>
         <module>scala-example</module>
         <module>scala-mock-mvc-example</module>

--- a/examples/rest-assured-itest-java-osgi/pom.xml
+++ b/examples/rest-assured-itest-java-osgi/pom.xml
@@ -1,13 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>io.rest-assured</groupId>
-        <artifactId>rest-assured-parent</artifactId>
+        <groupId>io.rest-assured.examples</groupId>
+        <artifactId>example-parent</artifactId>
         <version>3.1.2-SNAPSHOT</version>
     </parent>
+    <modelVersion>4.0.0</modelVersion>
+
     <artifactId>rest-assured-itest-java-osgi</artifactId>
-    <name>REST Assured Java OSGi integration tests</name>
-    <description>REST Assured Java OSGi integration tests. Here you'll find an integration test proving that Rest Assured is OSGi-compatible.
+    <name>REST Assured Java integration tests</name>
+    <description>REST Assured Java integration tests. Here you'll find various examples of how to use rest-assured.
     </description>
 
     <properties>
@@ -76,6 +94,15 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.servicemix.tooling</groupId>
                 <artifactId>depends-maven-plugin</artifactId>

--- a/examples/rest-assured-itest-java-osgi/pom.xml
+++ b/examples/rest-assured-itest-java-osgi/pom.xml
@@ -1,0 +1,110 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.rest-assured</groupId>
+        <artifactId>rest-assured-parent</artifactId>
+        <version>3.1.2-SNAPSHOT</version>
+    </parent>
+    <artifactId>rest-assured-itest-java-osgi</artifactId>
+    <name>REST Assured Java OSGi integration tests</name>
+    <description>REST Assured Java OSGi integration tests. Here you'll find an integration test proving that Rest Assured is OSGi-compatible.
+    </description>
+
+    <properties>
+        <animal.sniffer.skip>true</animal.sniffer.skip>
+        <pax-exam.version>4.12.0</pax-exam.version>
+        <surefire.version>2.18</surefire.version>
+    </properties>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>json-path</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-atinject_1.0_spec</artifactId>
+            <version>1.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.exam</groupId>
+            <artifactId>pax-exam-junit4</artifactId>
+            <scope>test</scope>
+            <version>${pax-exam.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.exam</groupId>
+            <artifactId>pax-exam-inject</artifactId>
+            <version>${pax-exam.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.exam</groupId>
+            <artifactId>pax-exam-container-forked</artifactId>
+            <version>${pax-exam.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.exam</groupId>
+            <artifactId>pax-exam-link-mvn</artifactId>
+            <version>${pax-exam.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.framework</artifactId>
+            <version>6.0.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+        <groupId>org.ops4j.pax.swissbox</groupId>
+        <artifactId>pax-swissbox-framework</artifactId>
+        <version>1.8.3</version>
+        <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.url</groupId>
+            <artifactId>pax-url-wrap</artifactId>
+            <version>2.5.4</version>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.servicemix.tooling</groupId>
+                <artifactId>depends-maven-plugin</artifactId>
+                <version>1.3.1</version>
+                <executions>
+                    <execution>
+                        <id>generate-depends-file</id>
+                        <goals>
+                            <goal>generate-depends-file</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <forkCount>1</forkCount>
+                    <reuseForks>false</reuseForks>
+                    <excludes>
+                        <exclude>none</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/rest-assured-itest-java-osgi/pom.xml
+++ b/examples/rest-assured-itest-java-osgi/pom.xml
@@ -20,11 +20,6 @@
 
         <dependency>
             <groupId>io.rest-assured</groupId>
-            <artifactId>json-path</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -66,10 +61,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-        <groupId>org.ops4j.pax.swissbox</groupId>
-        <artifactId>pax-swissbox-framework</artifactId>
-        <version>1.8.3</version>
-        <scope>test</scope>
+            <groupId>org.ops4j.pax.swissbox</groupId>
+            <artifactId>pax-swissbox-framework</artifactId>
+            <version>1.8.3</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.ops4j.pax.url</groupId>

--- a/examples/rest-assured-itest-java-osgi/src/test/java/io/restassured/test/osgi/JsonPathOSGiITest.java
+++ b/examples/rest-assured-itest-java-osgi/src/test/java/io/restassured/test/osgi/JsonPathOSGiITest.java
@@ -1,0 +1,73 @@
+package io.restassured.test.osgi;
+
+/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+ */
+
+import io.restassured.path.json.JsonPath;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.ops4j.pax.exam.CoreOptions.junitBundles;
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+import static org.ops4j.pax.exam.CoreOptions.systemProperty;
+import static org.ops4j.pax.exam.CoreOptions.wrappedBundle;
+
+@RunWith(PaxExam.class)
+/**
+ * This test aims to prove that json-path is available as a valid OSGi bundle.
+ */
+public class JsonPathOSGiITest {
+
+    @Configuration
+    public static Option[] configure() throws Exception {
+        return new Option[]
+                {
+                        mavenBundle("org.apache.servicemix.bundles", "org.apache.servicemix.bundles.hamcrest", "1.3_1"),
+                        junitBundles(),
+                        systemProperty("pax.exam.osgi.unresolved.fail").value("true"),
+                        systemProperty("org.ops4j.pax.logging.DefaultServiceLog.level").value("INFO"),
+
+                        /* Transitive dependencies needed in the Pax Exam container.
+                        Some of these need to be wrapped because they are not available as OSGi bundles */
+                        mavenBundle("org.apache.commons", "commons-lang3").versionAsInProject(),
+                        wrappedBundle(mavenBundle().groupId("org.codehaus.groovy").artifactId("groovy-all").version("2.4.12")),
+
+                        /* Rest Assured dependencies needed in the Pax Exam container to be able to execute the tests below */
+                        mavenBundle("io.rest-assured", "json-path").versionAsInProject(),
+                        mavenBundle("io.rest-assured", "rest-assured-common").versionAsInProject()
+                };
+    }
+
+    @Test
+    public void jsonPath() {
+        final String JSON = "{\n" +
+                "\"lotto\":{\n" +
+                " \"lottoId\":5,\n" +
+                "}\n" +
+                "}";
+        JsonPath jsonPath = new JsonPath(JSON).setRoot("lotto");
+
+        assertThat(jsonPath.getInt("lottoId"), equalTo(5));
+    }
+}

--- a/examples/rest-assured-itest-java-osgi/src/test/java/io/restassured/test/osgi/RestAssuredOSGiITest.java
+++ b/examples/rest-assured-itest-java-osgi/src/test/java/io/restassured/test/osgi/RestAssuredOSGiITest.java
@@ -1,0 +1,74 @@
+package io.restassured.test.osgi;
+
+/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+ */
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+
+import java.net.UnknownHostException;
+
+import static io.restassured.RestAssured.given;
+import static org.ops4j.pax.exam.CoreOptions.junitBundles;
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+import static org.ops4j.pax.exam.CoreOptions.systemProperty;
+import static org.ops4j.pax.exam.CoreOptions.wrappedBundle;
+
+@RunWith(PaxExam.class)
+/**
+ * This test aims to prove that Rest Assured is available as a valid OSGi bundle.
+ */
+public class RestAssuredOSGiITest {
+
+    @Configuration
+    public static Option[] configure() throws Exception {
+        return new Option[]
+                {
+                        mavenBundle("org.apache.servicemix.bundles", "org.apache.servicemix.bundles.hamcrest", "1.3_1"),
+                        junitBundles(),
+                        systemProperty("pax.exam.osgi.unresolved.fail").value("true"),
+                        systemProperty("org.ops4j.pax.logging.DefaultServiceLog.level").value("INFO"),
+
+                        /* Transitive dependencies needed in the Pax Exam container.
+                        Some of these need to be wrapped because they are not available as OSGi bundles */
+                        mavenBundle("org.apache.commons", "commons-lang3").versionAsInProject(),
+                        wrappedBundle(mavenBundle().groupId("org.ccil.cowan.tagsoup").artifactId("tagsoup").versionAsInProject()),
+                        wrappedBundle(mavenBundle("org.apache.httpcomponents", "httpclient").versionAsInProject()),
+                        wrappedBundle(mavenBundle("org.apache.httpcomponents", "httpmime").versionAsInProject()),
+                        wrappedBundle(mavenBundle("org.apache.httpcomponents", "httpcore").versionAsInProject()),
+                        wrappedBundle(mavenBundle("javax.xml.bind", "jaxb-api").versionAsInProject()),
+                        wrappedBundle(mavenBundle().groupId("org.codehaus.groovy").artifactId("groovy-all").version("2.4.12")),
+
+                        /* Rest Assured dependencie needed in the Pax Exam container to be able to execute the test below */
+                        mavenBundle("io.rest-assured", "rest-assured").versionAsInProject()
+                };
+    }
+
+    @Test(expected = UnknownHostException.class)
+    public void restAssured() {
+        given().
+                when().
+                get("http://dummy").
+                then().
+                statusCode(200);
+    }
+}

--- a/examples/rest-assured-itest-java-osgi/src/test/java/io/restassured/test/osgi/XmlPathOSGiITest.java
+++ b/examples/rest-assured-itest-java-osgi/src/test/java/io/restassured/test/osgi/XmlPathOSGiITest.java
@@ -1,0 +1,77 @@
+package io.restassured.test.osgi;
+
+/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+ */
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+
+import java.util.UUID;
+
+import static io.restassured.path.xml.XmlPath.from;
+import static org.junit.Assert.assertThat;
+import static org.ops4j.pax.exam.CoreOptions.junitBundles;
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+import static org.ops4j.pax.exam.CoreOptions.systemProperty;
+import static org.ops4j.pax.exam.CoreOptions.wrappedBundle;
+
+@RunWith(PaxExam.class)
+/**
+ * This test aims to prove that xml-path is available as a valid OSGi bundle.
+ */
+public class XmlPathOSGiITest {
+
+    @Configuration
+    public static Option[] configure() throws Exception {
+        return new Option[]
+                {
+                        mavenBundle("org.apache.servicemix.bundles", "org.apache.servicemix.bundles.hamcrest", "1.3_1"),
+                        junitBundles(),
+                        systemProperty("pax.exam.osgi.unresolved.fail").value("true"),
+                        systemProperty("org.ops4j.pax.logging.DefaultServiceLog.level").value("INFO"),
+
+                        /* Transitive dependencies needed in the Pax Exam container.
+                        Some of these need to be wrapped because they are not available as OSGi bundles */
+                        mavenBundle("org.apache.commons", "commons-lang3").versionAsInProject(),
+                        wrappedBundle(mavenBundle().groupId("org.ccil.cowan.tagsoup").artifactId("tagsoup").versionAsInProject()),
+                        wrappedBundle(mavenBundle("javax.xml.bind", "jaxb-api").versionAsInProject()),
+                        wrappedBundle(mavenBundle().groupId("org.codehaus.groovy").artifactId("groovy-all").version("2.4.12")),
+
+                        /* Rest Assured dependencies needed in the Pax Exam container to be able to execute the tests below */
+                        mavenBundle("io.rest-assured", "xml-path").versionAsInProject(),
+                        mavenBundle("io.rest-assured", "rest-assured-common").versionAsInProject()
+                };
+    }
+
+    @Test
+    public void getUUIDParsesAStringResultToUUID() throws Exception {
+        final String UUID_XML = "<some>\n" +
+                "  <thing id=\"1\">db24eeeb-7fe5-41d3-8f06-986b793ecc91</thing>\n" +
+                "  <thing id=\"2\">d69ded28-d75c-460f-9cbe-1412c60ed4cc</thing>\n" +
+                "</some>";
+
+        final UUID uuid = from(UUID_XML).getUUID("some.thing[0]");
+
+        assertThat(uuid, Matchers.equalTo(UUID.fromString("db24eeeb-7fe5-41d3-8f06-986b793ecc91")));
+    }
+}

--- a/json-path/pom.xml
+++ b/json-path/pom.xml
@@ -24,6 +24,7 @@
     </parent>
     <groupId>io.rest-assured</groupId>
     <artifactId>json-path</artifactId>
+    <packaging>bundle</packaging>
     <version>3.1.2-SNAPSHOT</version>
     <name>json-path</name>
     <url>http://maven.apache.org</url>
@@ -37,6 +38,19 @@
                 <groupId>org.codehaus.gmaven</groupId>
                 <artifactId>gmaven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Export-Package>io.restassured.*</Export-Package>
+                        <Import-Package>*</Import-Package>
+                        <Private-Package></Private-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,6 @@
         <jackson2.version>2.7.3</jackson2.version>
         <maven-javadoc.version>2.9.1</maven-javadoc.version>
         <surefire.version>2.22.0</surefire.version>
-        <surefire.version>2.22.0</surefire.version>
     </properties>
     <scm>
         <url>http://github.com/jayway/rest-assured/tree/${scm.branch}</url>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,8 @@
         <jackson1.version>1.9.11</jackson1.version>
         <jackson2.version>2.7.3</jackson2.version>
         <maven-javadoc.version>2.9.1</maven-javadoc.version>
+        <surefire.version>2.22.0</surefire.version>
+        <surefire.version>2.22.0</surefire.version>
     </properties>
     <scm>
         <url>http://github.com/jayway/rest-assured/tree/${scm.branch}</url>
@@ -168,6 +170,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.version}</version>
                 <configuration>
                     <excludes>
                         <exclude>**/itest/**</exclude>
@@ -193,6 +196,10 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/rest-assured-common/pom.xml
+++ b/rest-assured-common/pom.xml
@@ -24,6 +24,7 @@
     </parent>
     <groupId>io.rest-assured</groupId>
     <artifactId>rest-assured-common</artifactId>
+    <packaging>bundle</packaging>
     <version>3.1.2-SNAPSHOT</version>
     <name>rest-assured-common</name>
     <url>http://maven.apache.org</url>
@@ -37,6 +38,18 @@
             <plugin>
                 <groupId>org.codehaus.gmaven</groupId>
                 <artifactId>gmaven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Export-Package>io.restassured.*</Export-Package>
+                        <Import-Package>*</Import-Package>
+                        <Private-Package></Private-Package>
+                    </instructions>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/rest-assured/pom.xml
+++ b/rest-assured/pom.xml
@@ -28,7 +28,7 @@
     <groupId>io.rest-assured</groupId>
     <artifactId>rest-assured</artifactId>
     <version>3.1.2-SNAPSHOT</version>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
 
     <name>REST Assured</name>
     <description>Java DSL for easy testing of REST services</description>
@@ -39,6 +39,19 @@
             <plugin>
                 <groupId>org.codehaus.gmaven</groupId>
                 <artifactId>gmaven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>3.5.1</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Export-Package>io.restassured.*</Export-Package>
+                        <Import-Package>*</Import-Package>
+                        <Private-Package></Private-Package>
+                    </instructions>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/xml-path/pom.xml
+++ b/xml-path/pom.xml
@@ -24,12 +24,25 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>xml-path</artifactId>
+    <packaging>bundle</packaging>
 
     <build>
         <plugins>
             <plugin>
                 <groupId>org.codehaus.gmaven</groupId>
                 <artifactId>gmaven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Export-Package>io.restassured.*</Export-Package>
+                        <Import-Package>*</Import-Package>
+                        <Private-Package></Private-Package>
+                    </instructions>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
I've OSGi-ed the 4 main modules of Rest Assured and added some integration tests to check the correct OSGi behaviour (using the techniques you already know form awaitility).

This makes https://github.com/ops4j/org.ops4j.pax.tipi/tree/master/rest-assured-3.0.2 obsolete. I've tried using the new OSGi-ed version in a project of my own and the tests were succesful.

Please have a look ..