### PR TITLE
Upgrading json-schema-validator to 2.2.10 due to date-time validation

### DIFF
--- a/modules/json-schema-validator/pom.xml
+++ b/modules/json-schema-validator/pom.xml
@@ -33,9 +33,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.github.fge</groupId>
+            <groupId>com.github.java-json-tools</groupId>
             <artifactId>json-schema-validator</artifactId>
-            <version>2.2.6</version>
+            <version>2.2.10</version>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
date-time string format validation rejects valid timestamps
This problem has already been reported and fixed on json-schema-validator 2.2.10.

See java-json-tools/json-schema-validator#143.