### PR TITLE
Improvement for #1093 - failure listeners 

### DIFF
--- a/rest-assured/src/main/groovy/io/restassured/internal/LogRequestAndResponseOnFailListener.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/LogRequestAndResponseOnFailListener.groovy
@@ -1,0 +1,43 @@
+package io.restassured.internal
+
+import io.restassured.response.Response
+import io.restassured.specification.RequestSpecification
+import io.restassured.specification.ResponseSpecification
+import org.apache.commons.lang3.StringUtils
+import org.apache.commons.lang3.SystemUtils
+
+/**
+ * Default listener fired when validation fails in ResponseSpecificationImpl.
+ * The listener inspect fields requestLog and responseLog in logRepository. If these fields are not empty,
+ * it means that "log on validation" was enabled and these fields (also streams) were used to store logs temporarily.
+ * Since the execution reached the listener's code, it also means that it is time to log request and response
+ * to actual output stream - which is logRepository.defaultStream()
+ */
+class LogRequestAndResponseOnFailListener implements ResponseValidationFailureListener {
+
+    @Override
+    void onFailure(RequestSpecification requestSpecification,
+                   ResponseSpecification responseSpecification,
+                   Response response) {
+        if (!responseSpecification instanceof ResponseSpecificationImpl) {
+            return
+        }
+        ResponseSpecificationImpl respSpecImpl = (ResponseSpecificationImpl) responseSpecification
+        def logRepository = respSpecImpl.getLogRepository()
+        if (logRepository != null) {
+            def stream = responseSpecification.getConfig().getLogConfig().defaultStream()
+            def requestLog = logRepository.requestLog
+            def responseLog = logRepository.responseLog
+            def requestLogHasText = StringUtils.isNotEmpty(requestLog)
+            if (requestLogHasText) {
+                stream.print(requestLog)
+            }
+            if (StringUtils.isNotEmpty(responseLog)) {
+                if (requestLogHasText) {
+                    stream.print(SystemUtils.LINE_SEPARATOR);
+                }
+                stream.print(responseLog)
+            }
+        }
+    }
+}

--- a/rest-assured/src/main/groovy/io/restassured/internal/ResponseValidationFailureListener.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/ResponseValidationFailureListener.groovy
@@ -1,0 +1,11 @@
+package io.restassured.internal
+
+import io.restassured.response.Response
+import io.restassured.specification.RequestSpecification
+import io.restassured.specification.ResponseSpecification
+
+interface ResponseValidationFailureListener {
+        void onFailure(RequestSpecification requestSpecification,
+                       ResponseSpecification responseSpecification,
+                       Response response)
+}

--- a/rest-assured/src/main/java/io/restassured/config/FailureConfig.java
+++ b/rest-assured/src/main/java/io/restassured/config/FailureConfig.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.restassured.config;
+
+import io.restassured.internal.LogRequestAndResponseOnFailListener;
+import io.restassured.internal.ResponseValidationFailureListener;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Configure the failure listeners. It allows registering instances of {@link io.restassured.internal.ResponseValidationFailureListener}
+ * that are invoked when validation fails for any response with relevant parameters.
+ * Listeners solve the problem when you want to access response after failure - normally it is impossible
+ * because validation failure ends with exception rather then returning anything that could be used to extract
+ * response. So if you need to access data in response, register a listener here.
+ */
+public class FailureConfig implements Config {
+
+    private static ResponseValidationFailureListener DEFAULT_LOG_LISTENER = new LogRequestAndResponseOnFailListener();
+
+    private List<ResponseValidationFailureListener> failureListeners = new ArrayList<ResponseValidationFailureListener>();
+    private final boolean isUserConfigured;
+
+    /**
+     * Configure the default stream to use the System.out stream (default).
+     */
+    public FailureConfig() {
+        this(new ArrayList<ResponseValidationFailureListener>(), false);
+    }
+
+    public FailureConfig(List<ResponseValidationFailureListener> failureListeners) {
+        this(failureListeners, true);
+    }
+
+    private FailureConfig(List<ResponseValidationFailureListener> failureListeners, boolean isUserConfigured) {
+        this.isUserConfigured = isUserConfigured;
+        this.failureListeners.addAll(failureListeners);
+        this.failureListeners.add(DEFAULT_LOG_LISTENER);
+    }
+
+    public boolean isUserConfigured() {
+        return isUserConfigured;
+    }
+
+    public List<ResponseValidationFailureListener> getFailureListeners() {
+        return failureListeners;
+    }
+}

--- a/rest-assured/src/main/java/io/restassured/config/RestAssuredConfig.java
+++ b/rest-assured/src/main/java/io/restassured/config/RestAssuredConfig.java
@@ -40,7 +40,7 @@ public class RestAssuredConfig implements Config {
     public RestAssuredConfig() {
         this(new RedirectConfig(), new HttpClientConfig(), new LogConfig(), new EncoderConfig(), new DecoderConfig(),
                 new SessionConfig(), new ObjectMapperConfig(), new ConnectionConfig(), new JsonConfig(), new XmlConfig(), new SSLConfig(),
-                new MatcherConfig(), new HeaderConfig(), new MultiPartConfig(), new ParamConfig(), new OAuthConfig());
+                new MatcherConfig(), new HeaderConfig(), new MultiPartConfig(), new ParamConfig(), new OAuthConfig(), new FailureConfig());
     }
 
     /**
@@ -64,7 +64,8 @@ public class RestAssuredConfig implements Config {
                              HeaderConfig headerConfig,
                              MultiPartConfig multiPartConfig,
                              ParamConfig paramConfig,
-                             OAuthConfig oAuthConfig) {
+                             OAuthConfig oAuthConfig,
+                             FailureConfig failureConfig) {
         notNull(redirectConfig, "Redirect Config");
         notNull(httpClientConfig, "HTTP Client Config");
         notNull(logConfig, "Log config");
@@ -81,6 +82,7 @@ public class RestAssuredConfig implements Config {
         notNull(multiPartConfig, "Multipart config");
         notNull(paramConfig, "Param config");
         notNull(oAuthConfig, "OAuth config");
+        notNull(failureConfig, "Failre config");
         configs.put(HttpClientConfig.class, httpClientConfig);
         configs.put(RedirectConfig.class, redirectConfig);
         configs.put(LogConfig.class, logConfig);
@@ -97,6 +99,7 @@ public class RestAssuredConfig implements Config {
         configs.put(MultiPartConfig.class, multiPartConfig);
         configs.put(ParamConfig.class, paramConfig);
         configs.put(OAuthConfig.class, oAuthConfig);
+        configs.put(FailureConfig.class, failureConfig);
     }
 
     /**
@@ -110,7 +113,7 @@ public class RestAssuredConfig implements Config {
         return new RestAssuredConfig(redirectConfig, conf(HttpClientConfig.class), conf(LogConfig.class), conf(EncoderConfig.class),
                 conf(DecoderConfig.class), conf(SessionConfig.class), conf(ObjectMapperConfig.class), conf(ConnectionConfig.class),
                 conf(JsonConfig.class), conf(XmlConfig.class), conf(SSLConfig.class), conf(MatcherConfig.class),
-                conf(HeaderConfig.class), conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class));
+                conf(HeaderConfig.class), conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class), new FailureConfig());
     }
 
     /**
@@ -124,7 +127,7 @@ public class RestAssuredConfig implements Config {
         return new RestAssuredConfig(conf(RedirectConfig.class), httpClientConfig, conf(LogConfig.class), conf(EncoderConfig.class),
                 conf(DecoderConfig.class), conf(SessionConfig.class), conf(ObjectMapperConfig.class), conf(ConnectionConfig.class),
                 conf(JsonConfig.class), conf(XmlConfig.class), conf(SSLConfig.class), conf(MatcherConfig.class),
-                conf(HeaderConfig.class), conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class));
+                conf(HeaderConfig.class), conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class), new FailureConfig());
     }
 
     /**
@@ -138,7 +141,7 @@ public class RestAssuredConfig implements Config {
         return new RestAssuredConfig(conf(RedirectConfig.class), conf(HttpClientConfig.class), logConfig, conf(EncoderConfig.class),
                 conf(DecoderConfig.class), conf(SessionConfig.class), conf(ObjectMapperConfig.class), conf(ConnectionConfig.class),
                 conf(JsonConfig.class), conf(XmlConfig.class), conf(SSLConfig.class), conf(MatcherConfig.class),
-                conf(HeaderConfig.class), conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class));
+                conf(HeaderConfig.class), conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class), new FailureConfig());
     }
 
     /**
@@ -152,7 +155,7 @@ public class RestAssuredConfig implements Config {
         return new RestAssuredConfig(conf(RedirectConfig.class), conf(HttpClientConfig.class), conf(LogConfig.class), encoderConfig,
                 conf(DecoderConfig.class), conf(SessionConfig.class), conf(ObjectMapperConfig.class), conf(ConnectionConfig.class),
                 conf(JsonConfig.class), conf(XmlConfig.class), conf(SSLConfig.class), conf(MatcherConfig.class),
-                conf(HeaderConfig.class), conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class));
+                conf(HeaderConfig.class), conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class), new FailureConfig());
     }
 
     /**
@@ -166,7 +169,7 @@ public class RestAssuredConfig implements Config {
         return new RestAssuredConfig(conf(RedirectConfig.class), conf(HttpClientConfig.class), conf(LogConfig.class), conf(EncoderConfig.class),
                 decoderConfig, conf(SessionConfig.class), conf(ObjectMapperConfig.class), conf(ConnectionConfig.class),
                 conf(JsonConfig.class), conf(XmlConfig.class), conf(SSLConfig.class), conf(MatcherConfig.class),
-                conf(HeaderConfig.class), conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class));
+                conf(HeaderConfig.class), conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class), new FailureConfig());
     }
 
     /**
@@ -180,7 +183,7 @@ public class RestAssuredConfig implements Config {
         return new RestAssuredConfig(conf(RedirectConfig.class), conf(HttpClientConfig.class), conf(LogConfig.class), conf(EncoderConfig.class),
                 conf(DecoderConfig.class), sessionConfig, conf(ObjectMapperConfig.class), conf(ConnectionConfig.class),
                 conf(JsonConfig.class), conf(XmlConfig.class), conf(SSLConfig.class), conf(MatcherConfig.class),
-                conf(HeaderConfig.class), conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class));
+                conf(HeaderConfig.class), conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class), new FailureConfig());
     }
 
     /**
@@ -194,7 +197,7 @@ public class RestAssuredConfig implements Config {
         return new RestAssuredConfig(conf(RedirectConfig.class), conf(HttpClientConfig.class), conf(LogConfig.class), conf(EncoderConfig.class),
                 conf(DecoderConfig.class), conf(SessionConfig.class), objectMapperConfig, conf(ConnectionConfig.class),
                 conf(JsonConfig.class), conf(XmlConfig.class), conf(SSLConfig.class), conf(MatcherConfig.class),
-                conf(HeaderConfig.class), conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class));
+                conf(HeaderConfig.class), conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class), new FailureConfig());
     }
 
     /**
@@ -208,7 +211,7 @@ public class RestAssuredConfig implements Config {
         return new RestAssuredConfig(conf(RedirectConfig.class), conf(HttpClientConfig.class), conf(LogConfig.class), conf(EncoderConfig.class),
                 conf(DecoderConfig.class), conf(SessionConfig.class), conf(ObjectMapperConfig.class), connectionConfig,
                 conf(JsonConfig.class), conf(XmlConfig.class), conf(SSLConfig.class), conf(MatcherConfig.class),
-                conf(HeaderConfig.class), conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class));
+                conf(HeaderConfig.class), conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class), new FailureConfig());
     }
 
     /**
@@ -222,7 +225,7 @@ public class RestAssuredConfig implements Config {
         return new RestAssuredConfig(conf(RedirectConfig.class), conf(HttpClientConfig.class), conf(LogConfig.class), conf(EncoderConfig.class),
                 conf(DecoderConfig.class), conf(SessionConfig.class), conf(ObjectMapperConfig.class), conf(ConnectionConfig.class),
                 jsonConfig, conf(XmlConfig.class), conf(SSLConfig.class), conf(MatcherConfig.class),
-                conf(HeaderConfig.class), conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class));
+                conf(HeaderConfig.class), conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class), new FailureConfig());
     }
 
     /**
@@ -235,7 +238,8 @@ public class RestAssuredConfig implements Config {
         notNull(xmlConfig, "XmlConfig");
         return new RestAssuredConfig(conf(RedirectConfig.class), conf(HttpClientConfig.class), conf(LogConfig.class), conf(EncoderConfig.class),
                 conf(DecoderConfig.class), conf(SessionConfig.class), conf(ObjectMapperConfig.class), conf(ConnectionConfig.class),
-                conf(JsonConfig.class), xmlConfig, conf(SSLConfig.class), conf(MatcherConfig.class), conf(HeaderConfig.class), conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class));
+                conf(JsonConfig.class), xmlConfig, conf(SSLConfig.class), conf(MatcherConfig.class), conf(HeaderConfig.class),
+                conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class), new FailureConfig());
     }
 
     /**
@@ -248,7 +252,8 @@ public class RestAssuredConfig implements Config {
         notNull(sslConfig, "SSLConfig");
         return new RestAssuredConfig(conf(RedirectConfig.class), conf(HttpClientConfig.class), conf(LogConfig.class), conf(EncoderConfig.class),
                 conf(DecoderConfig.class), conf(SessionConfig.class), conf(ObjectMapperConfig.class), conf(ConnectionConfig.class),
-                conf(JsonConfig.class), conf(XmlConfig.class), sslConfig, conf(MatcherConfig.class), conf(HeaderConfig.class), conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class));
+                conf(JsonConfig.class), conf(XmlConfig.class), sslConfig, conf(MatcherConfig.class), conf(HeaderConfig.class),
+                conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class), new FailureConfig());
     }
 
     /**
@@ -261,7 +266,8 @@ public class RestAssuredConfig implements Config {
         notNull(matcherConfig, "MatcherConfig");
         return new RestAssuredConfig(conf(RedirectConfig.class), conf(HttpClientConfig.class), conf(LogConfig.class), conf(EncoderConfig.class),
                 conf(DecoderConfig.class), conf(SessionConfig.class), conf(ObjectMapperConfig.class), conf(ConnectionConfig.class),
-                conf(JsonConfig.class), conf(XmlConfig.class), conf(SSLConfig.class), matcherConfig, conf(HeaderConfig.class), conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class));
+                conf(JsonConfig.class), conf(XmlConfig.class), conf(SSLConfig.class), matcherConfig, conf(HeaderConfig.class),
+                conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class), new FailureConfig());
     }
 
     /**
@@ -274,7 +280,8 @@ public class RestAssuredConfig implements Config {
         notNull(headerConfig, "HeaderConfig");
         return new RestAssuredConfig(conf(RedirectConfig.class), conf(HttpClientConfig.class), conf(LogConfig.class), conf(EncoderConfig.class),
                 conf(DecoderConfig.class), conf(SessionConfig.class), conf(ObjectMapperConfig.class), conf(ConnectionConfig.class),
-                conf(JsonConfig.class), conf(XmlConfig.class), conf(SSLConfig.class), conf(MatcherConfig.class), headerConfig, conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class));
+                conf(JsonConfig.class), conf(XmlConfig.class), conf(SSLConfig.class), conf(MatcherConfig.class), headerConfig,
+                conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class), new FailureConfig());
     }
 
     /**
@@ -288,7 +295,7 @@ public class RestAssuredConfig implements Config {
         return new RestAssuredConfig(conf(RedirectConfig.class), conf(HttpClientConfig.class), conf(LogConfig.class), conf(EncoderConfig.class),
                 conf(DecoderConfig.class), conf(SessionConfig.class), conf(ObjectMapperConfig.class), conf(ConnectionConfig.class),
                 conf(JsonConfig.class), conf(XmlConfig.class), conf(SSLConfig.class), conf(MatcherConfig.class), conf(HeaderConfig.class),
-                multiPartConfig, conf(ParamConfig.class), conf(OAuthConfig.class));
+                multiPartConfig, conf(ParamConfig.class), conf(OAuthConfig.class), new FailureConfig());
     }
 
     /**
@@ -302,7 +309,7 @@ public class RestAssuredConfig implements Config {
         return new RestAssuredConfig(conf(RedirectConfig.class), conf(HttpClientConfig.class), conf(LogConfig.class), conf(EncoderConfig.class),
                 conf(DecoderConfig.class), conf(SessionConfig.class), conf(ObjectMapperConfig.class), conf(ConnectionConfig.class),
                 conf(JsonConfig.class), conf(XmlConfig.class), conf(SSLConfig.class), conf(MatcherConfig.class), conf(HeaderConfig.class),
-                conf(MultiPartConfig.class), paramConfig, conf(OAuthConfig.class));
+                conf(MultiPartConfig.class), paramConfig, conf(OAuthConfig.class), new FailureConfig());
     }
 
     /**
@@ -316,9 +323,22 @@ public class RestAssuredConfig implements Config {
         return new RestAssuredConfig(conf(RedirectConfig.class), conf(HttpClientConfig.class), conf(LogConfig.class), conf(EncoderConfig.class),
                 conf(DecoderConfig.class), conf(SessionConfig.class), conf(ObjectMapperConfig.class), conf(ConnectionConfig.class),
                 conf(JsonConfig.class), conf(XmlConfig.class), conf(SSLConfig.class), conf(MatcherConfig.class), conf(HeaderConfig.class),
-                conf(MultiPartConfig.class), conf(ParamConfig.class), oauthConfig);
+                conf(MultiPartConfig.class), conf(ParamConfig.class), oauthConfig, new FailureConfig());
     }
 
+    /**
+     * Set the failure config.
+     *
+     * @param failureConfig The {@link FailureConfig} to set
+     * @return An updated RestAssuredConfiguration
+     */
+    public RestAssuredConfig failureConfig(FailureConfig failureConfig) {
+        notNull(failureConfig, FailureConfig.class);
+        return new RestAssuredConfig(conf(RedirectConfig.class), conf(HttpClientConfig.class), conf(LogConfig.class), conf(EncoderConfig.class),
+                conf(DecoderConfig.class), conf(SessionConfig.class), conf(ObjectMapperConfig.class), conf(ConnectionConfig.class),
+                conf(JsonConfig.class), conf(XmlConfig.class), conf(SSLConfig.class), conf(MatcherConfig.class), conf(HeaderConfig.class),
+                conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class), failureConfig);
+    }
     /**
      * Syntactic sugar.
      *
@@ -456,6 +476,13 @@ public class RestAssuredConfig implements Config {
      */
     public OAuthConfig getOAuthConfig() {
         return conf(OAuthConfig.class);
+    }
+
+    /**
+     * @return The Failure Config
+     */
+    public FailureConfig getFailureConfig() {
+        return conf(FailureConfig.class);
     }
 
     /**

--- a/rest-assured/src/main/java/io/restassured/specification/ResponseSpecification.java
+++ b/rest-assured/src/main/java/io/restassured/specification/ResponseSpecification.java
@@ -19,6 +19,7 @@ package io.restassured.specification;
 import io.restassured.function.RestAssuredFunction;
 import io.restassured.http.ContentType;
 import io.restassured.http.Cookie;
+import io.restassured.internal.ResponseValidationFailureListener;
 import io.restassured.matcher.DetailedCookieMatcher;
 import io.restassured.parsing.Parser;
 import io.restassured.response.Response;

--- a/rest-assured/src/test/groovy/io/restassured/internal/ResponseSpecificationImplTest.groovy
+++ b/rest-assured/src/test/groovy/io/restassured/internal/ResponseSpecificationImplTest.groovy
@@ -1,0 +1,104 @@
+package io.restassured.internal
+
+import io.restassured.config.FailureConfig
+import io.restassured.config.LogConfig
+import io.restassured.config.RestAssuredConfig
+import io.restassured.internal.log.LogRepository
+import io.restassured.response.Response
+import io.restassured.specification.RequestSpecification
+import org.junit.Test
+
+import java.nio.charset.Charset
+
+import static org.hamcrest.CoreMatchers.equalTo
+import static org.mockito.Matchers.any
+import static org.mockito.Matchers.same
+import static org.mockito.Mockito.mock
+import static org.mockito.Mockito.never
+import static org.mockito.Mockito.times
+import static org.mockito.Mockito.verify
+import static org.mockito.Mockito.when
+
+/**
+ * Initial state for all checks here is response spec with response body loaded into its logRepository. This
+ * structure means that ResponseLoggingFilter saved response for later to be printed only if validation fails.
+ */
+class ResponseSpecificationImplTest {
+
+    private static final String EXPECTED_BODY = "goodTestBody"
+    private static final String UNEXPECTED_BODY = "badTestBody"
+
+    @Test
+    void "Should call default failure listener to print response if log repository has response and validation failed"() {
+        //given
+        PrintStream printStreamMock = mock(PrintStream)
+        ResponseSpecificationImpl respSpecImpl = createRespSpec(UNEXPECTED_BODY, printStreamMock)
+        Response unexpectedResponse = when(mock(Response).asString()).thenReturn(UNEXPECTED_BODY).getMock()
+
+        //when
+        try {
+            respSpecImpl.validate(unexpectedResponse)
+        } catch (AssertionError ignored) {}
+
+        //then
+        verify(printStreamMock, times(1)).print(UNEXPECTED_BODY)
+    }
+
+    @Test
+    void "Should NOT call default failure listener to print response if validation passed"() {
+        //given
+        PrintStream printStreamMock = mock(PrintStream)
+        ResponseSpecificationImpl respSpecImpl = createRespSpec(EXPECTED_BODY, printStreamMock)
+        Response expectedResponse = when(mock(Response).asString()).thenReturn(EXPECTED_BODY).getMock()
+
+        //when
+        respSpecImpl.validate(expectedResponse)
+        //then
+        verify(printStreamMock, never()).print(EXPECTED_BODY)
+    }
+
+    @Test
+    void "Should call custom failure listener when validation fails"() {
+        //given
+        ResponseValidationFailureListener customListener = mock(ResponseValidationFailureListener)
+        ResponseSpecificationImpl respSpecImpl = createRespSpec(UNEXPECTED_BODY, System.out, customListener)
+        Response matchingResponse = when(mock(Response).asString()).thenReturn(UNEXPECTED_BODY).getMock()
+        //when
+        try {
+            respSpecImpl.validate(matchingResponse)
+        } catch (AssertionError ignored) {}
+        //then
+        verify(customListener, times(1)).onFailure(any(RequestSpecification.class), same(respSpecImpl), same(matchingResponse))
+    }
+
+    @Test
+    void "Should NOT call custom failure listener when validation passes"() {
+        //given
+        ResponseValidationFailureListener customListener = mock(ResponseValidationFailureListener)
+        ResponseSpecificationImpl respSpecImpl = createRespSpec(EXPECTED_BODY, System.out, customListener)
+        Response nonmatchingResponse = when(mock(Response).asString()).thenReturn(EXPECTED_BODY).getMock()
+
+        //when
+        respSpecImpl.validate(nonmatchingResponse)
+        //then
+        verify(customListener, never()).onFailure(any(RequestSpecification.class), same(respSpecImpl), same(nonmatchingResponse))
+    }
+
+    private static ResponseSpecificationImpl createRespSpec(String responseContentInLogRepository, PrintStream logOutputStream = System.out, ResponseValidationFailureListener failureListener = null) {
+        def customFailureListeners = failureListener == null ? [] : [failureListener]
+        ByteArrayOutputStream baos = new ByteArrayOutputStream()
+        baos.write(responseContentInLogRepository.getBytes(Charset.defaultCharset()))
+        def logRepository = new LogRepository()
+        logRepository.registerResponseLog(baos)
+
+        def respSpecImpl = new ResponseSpecificationImpl('/', null, null,
+                new RestAssuredConfig()
+                        .logConfig(new LogConfig(logOutputStream, true))
+                        .failureConfig(new FailureConfig(customFailureListeners)),
+                logRepository)
+
+        respSpecImpl.content(equalTo(EXPECTED_BODY))
+
+        respSpecImpl
+    }
+}


### PR DESCRIPTION
Failure listeners will allow API users:
- run custom code in response to validation failure
- access response objects after failure
- write more advanced filter with customized post-failure actions

I also refactored existing handling of 'logging on validation failure" to be one of these listeners, the only one to be configured by default.
I think the introduced listener could be used to further improve the code by removing workarounds related to logging e.g. in ValidatableResponseOptionsImpl.specification()

Detailed description for my use case in #1093 