### PR TITLE
rest-assured#579 Add logging functionality to the ResponseSpecBuilder

### DIFF
--- a/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/SpecificationBuilderITest.java
+++ b/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/SpecificationBuilderITest.java
@@ -36,13 +36,14 @@ import static io.restassured.config.RedirectConfig.redirectConfig;
 import static io.restassured.config.RestAssuredConfig.newConfig;
 import static io.restassured.filter.log.LogDetail.ALL;
 import static java.util.Arrays.asList;
+import static org.apache.http.HttpStatus.SC_OK;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
 public class SpecificationBuilderITest extends WithJetty {
 
     @Test
-    public void expectingSpecificationMergesTheCurrentSpecificationWithTheSuppliedOne() throws Exception {
+    public void expectingSpecificationMergesTheCurrentSpecificationWithTheSuppliedOne() {
         final ResponseSpecBuilder builder = new ResponseSpecBuilder();
         builder.expectBody("store.book.size()", is(4)).expectStatusCode(200);
         final ResponseSpecification responseSpecification = builder.build();
@@ -55,7 +56,7 @@ public class SpecificationBuilderITest extends WithJetty {
     }
 
     @Test
-    public void supportsSpecifyingDefaultResponseSpec() throws Exception {
+    public void supportsSpecifyingDefaultResponseSpec() {
         RestAssured.responseSpecification = new ResponseSpecBuilder().expectBody("store.book.size()", is(4)).expectStatusCode(200).build();
 
         try {
@@ -69,7 +70,7 @@ public class SpecificationBuilderITest extends WithJetty {
     }
 
     @Test
-    public void expectingSpecMergesTheCurrentSpecificationWithTheSuppliedOne() throws Exception {
+    public void expectingSpecMergesTheCurrentSpecificationWithTheSuppliedOne() {
         final ResponseSpecBuilder builder = new ResponseSpecBuilder();
         builder.expectBody("store.book.size()", is(4)).expectStatusCode(200);
         final ResponseSpecification responseSpecification = builder.build();
@@ -82,7 +83,7 @@ public class SpecificationBuilderITest extends WithJetty {
     }
 
     @Test
-    public void bodyExpectationsAreNotOverwritten() throws Exception {
+    public void bodyExpectationsAreNotOverwritten() {
         final ResponseSpecBuilder builder = new ResponseSpecBuilder();
         builder.expectBody("store.book.size()", is(4)).expectStatusCode(200);
         final ResponseSpecification responseSpecification = builder.build();
@@ -96,7 +97,7 @@ public class SpecificationBuilderITest extends WithJetty {
     }
 
     @Test
-    public void responseSpecificationSupportsMergingWithAnotherResponseSpecification() throws Exception {
+    public void responseSpecificationSupportsMergingWithAnotherResponseSpecification() {
         final ResponseSpecification specification = expect().body("store.book.size()", equalTo(4));
         final ResponseSpecification built = new ResponseSpecBuilder().expectStatusCode(200).addResponseSpecification(specification).build();
 
@@ -109,7 +110,7 @@ public class SpecificationBuilderITest extends WithJetty {
     }
 
     @Test
-    public void responseSpecificationCanExpectBodyWithArgs () throws Exception {
+    public void responseSpecificationCanExpectBodyWithArgs () {
         final ResponseSpecification spec = new ResponseSpecBuilder().rootPath("store.book[%d]").expectBody("author", withArgs(0), equalTo("Nigel Rees")).build();
 
         expect().
@@ -120,7 +121,7 @@ public class SpecificationBuilderITest extends WithJetty {
     }
 
     @Test
-    public void responseSpecificationCanExpectContentWithArgs () throws Exception {
+    public void responseSpecificationCanExpectContentWithArgs() {
         final ResponseSpecification spec = new ResponseSpecBuilder().rootPath("store.book[%d]").expectContent("author", withArgs(0), equalTo("Nigel Rees")).build();
 
         expect().
@@ -131,7 +132,7 @@ public class SpecificationBuilderITest extends WithJetty {
     }
 
     @Test
-    public void supportsSpecifyingParametersInRequestSpecBuilder() throws Exception {
+    public void supportsSpecifyingParametersInRequestSpecBuilder() {
         final RequestSpecification spec = new RequestSpecBuilder().addParameter("firstName", "John").addParam("lastName", "Doe").build();
 
         given().
@@ -144,7 +145,7 @@ public class SpecificationBuilderITest extends WithJetty {
     }
 
     @Test
-    public void supportsSpecifyingDefaultRequestSpec() throws Exception {
+    public void supportsSpecifyingDefaultRequestSpec() {
         RestAssured.requestSpecification = new RequestSpecBuilder().addParameter("firstName", "John").addParam("lastName", "Doe").build();
         try {
             expect().
@@ -158,7 +159,7 @@ public class SpecificationBuilderITest extends WithJetty {
     }
 
     @Test
-    public void supportsSpecifyingQueryParametersInRequestSpecBuilderWhenGet() throws Exception {
+    public void supportsSpecifyingQueryParametersInRequestSpecBuilderWhenGet() {
         final RequestSpecification spec = new RequestSpecBuilder().addQueryParameter("firstName", "John").addQueryParam("lastName", "Doe").build();
 
         given().
@@ -171,7 +172,7 @@ public class SpecificationBuilderITest extends WithJetty {
     }
 
     @Test
-    public void supportsSpecifyingQueryParametersInRequestSpecBuilderWhenPost() throws Exception {
+    public void supportsSpecifyingQueryParametersInRequestSpecBuilderWhenPost() {
         final RequestSpecification spec = new RequestSpecBuilder().addQueryParameter("firstName", "John").addQueryParam("lastName", "Doe").build();
 
         given().
@@ -184,7 +185,7 @@ public class SpecificationBuilderITest extends WithJetty {
     }
 
     @Test
-    public void supportsMergesParametersWhenUsingRequestSpecBuilder() throws Exception {
+    public void supportsMergesParametersWhenUsingRequestSpecBuilder() {
         final RequestSpecification spec = new RequestSpecBuilder().addParameter("firstName", "John").build();
 
         given().
@@ -198,7 +199,7 @@ public class SpecificationBuilderITest extends WithJetty {
     }
 
     @Test
-    public void supportsMergingCookiesWhenUsingRequestSpecBuilder() throws Exception {
+    public void supportsMergingCookiesWhenUsingRequestSpecBuilder() {
         final RequestSpecification spec1 = new RequestSpecBuilder().addCookie("cookie3", "value3").build();
         final RequestSpecification spec2 = new RequestSpecBuilder().addCookie("cookie1", "value1").addRequestSpecification(spec1).build();
 
@@ -212,7 +213,7 @@ public class SpecificationBuilderITest extends WithJetty {
     }
 
     @Test
-    public void supportsMergingHeadersWhenUsingRequestSpecBuilder() throws Exception {
+    public void supportsMergingHeadersWhenUsingRequestSpecBuilder() {
         final RequestSpecification spec = new RequestSpecBuilder().addHeader("header1", "value1").build();
 
         given().
@@ -226,7 +227,7 @@ public class SpecificationBuilderITest extends WithJetty {
     }
 
     @Test
-    public void supportsMergingRequestSpecHeadersUsingTheBuilder() throws Exception {
+    public void supportsMergingRequestSpecHeadersUsingTheBuilder() {
         final RequestSpecification spec = given().header("header2", "value2");
         final RequestSpecification spec2 = new RequestSpecBuilder().addHeader("header1", "value1").addRequestSpecification(spec).build();
 
@@ -242,7 +243,7 @@ public class SpecificationBuilderITest extends WithJetty {
     }
 
     @Test
-    public void requestSpecBuilderSupportsSettingAuthentication() throws Exception {
+    public void requestSpecBuilderSupportsSettingAuthentication() {
         final RequestSpecification spec = new RequestSpecBuilder().setAuth(basic("jetty", "jetty")).build();
 
         given().
@@ -254,7 +255,7 @@ public class SpecificationBuilderITest extends WithJetty {
     }
 
     @Test
-    public void supportsMergingMultiValueParametersWhenUsingRequestSpecBuilder() throws Exception {
+    public void supportsMergingMultiValueParametersWhenUsingRequestSpecBuilder() {
         final RequestSpecification spec = new RequestSpecBuilder().addParam("list", "1", "2", "3").build();
 
         given().
@@ -266,7 +267,7 @@ public class SpecificationBuilderITest extends WithJetty {
     }
 
     @Test
-    public void supportsMergingMultiValueQueryParametersWhenUsingRequestSpecBuilder() throws Exception {
+    public void supportsMergingMultiValueQueryParametersWhenUsingRequestSpecBuilder() {
         final RequestSpecification spec = new RequestSpecBuilder().addQueryParam("list", "1", "2", "3").build();
 
         given().
@@ -278,7 +279,7 @@ public class SpecificationBuilderITest extends WithJetty {
     }
 
     @Test
-    public void supportsMergingMultiValueFormParametersWhenUsingRequestSpecBuilder() throws Exception {
+    public void supportsMergingMultiValueFormParametersWhenUsingRequestSpecBuilder() {
         final RequestSpecification spec = new RequestSpecBuilder().addFormParam("list", "1", "2", "3").build();
 
         given().
@@ -290,7 +291,7 @@ public class SpecificationBuilderITest extends WithJetty {
     }
 
     @Test
-    public void supportsMergingMultiValueParametersUsingListWhenUsingRequestSpecBuilder() throws Exception {
+    public void supportsMergingMultiValueParametersUsingListWhenUsingRequestSpecBuilder() {
         final RequestSpecification spec = new RequestSpecBuilder().addParam("list", asList("1", "2", "3")).build();
 
         given().
@@ -302,7 +303,7 @@ public class SpecificationBuilderITest extends WithJetty {
     }
 
     @Test
-    public void supportsMergingMultiValueQueryParametersUsingListWhenUsingRequestSpecBuilder() throws Exception {
+    public void supportsMergingMultiValueQueryParametersUsingListWhenUsingRequestSpecBuilder() {
         final RequestSpecification spec = new RequestSpecBuilder().addQueryParam("list", asList("1", "2", "3")).build();
 
         given().
@@ -314,7 +315,7 @@ public class SpecificationBuilderITest extends WithJetty {
     }
 
     @Test
-    public void supportsMergingMultiValueFormParametersUsingListWhenUsingRequestSpecBuilder() throws Exception {
+    public void supportsMergingMultiValueFormParametersUsingListWhenUsingRequestSpecBuilder() {
         final RequestSpecification spec = new RequestSpecBuilder().addFormParam("list", asList("1", "2", "3")).build();
 
         given().
@@ -326,7 +327,7 @@ public class SpecificationBuilderITest extends WithJetty {
     }
 
     @Test
-    public void supportsMergingFormParametersWhenUsingRequestSpecBuilder() throws Exception {
+    public void supportsMergingFormParametersWhenUsingRequestSpecBuilder() {
         final RequestSpecification spec = new RequestSpecBuilder().addFormParam("lastName", "Doe").build();
 
         given().
@@ -339,7 +340,7 @@ public class SpecificationBuilderITest extends WithJetty {
     }
 
     @Test
-    public void supportsMergingPathParametersWhenUsingRequestSpecBuilder() throws Exception {
+    public void supportsMergingPathParametersWhenUsingRequestSpecBuilder() {
         final RequestSpecification spec = new RequestSpecBuilder().addPathParam("lastName", "Doe").build();
 
         given().
@@ -352,7 +353,7 @@ public class SpecificationBuilderITest extends WithJetty {
     }
 
     @Test
-    public void supportsSettingLoggingWhenUsingRequestSpecBuilder() throws Exception {
+    public void supportsSettingLoggingWhenUsingRequestSpecBuilder() {
         final StringWriter writer = new StringWriter();
         final PrintStream captor = new PrintStream(new WriterOutputStream(writer), true);
         final RequestSpecification spec = new RequestSpecBuilder().setConfig(newConfig().logConfig(logConfig().defaultStream(captor))).and().log(ALL).build();
@@ -381,7 +382,59 @@ public class SpecificationBuilderITest extends WithJetty {
     }
 
     @Test
-    public void supportsSettingConfigWhenUsingRequestSpecBuilder() throws Exception {
+    public void supportsSettingLoggingWhenUsingRequestAndResponseSpecBuilder() {
+        final StringWriter writer = new StringWriter();
+        final PrintStream captor = new PrintStream(new WriterOutputStream(writer), true);
+        final RequestSpecification requestSpec = new RequestSpecBuilder().
+             setConfig(newConfig().logConfig(logConfig().defaultStream(captor))).
+             addPathParam("firstName", "John").
+             addPathParam("lastName", "Doe").build();
+        final ResponseSpecification responseSpec = new ResponseSpecBuilder().expectStatusCode(SC_OK).log(ALL).build();
+
+        given(requestSpec, responseSpec).
+                                         get("/{firstName}/{lastName}");
+
+        assertThat(writer.toString(), equalTo(String.format("HTTP/1.1 200 OK%n" +
+                "Content-Type: application/json;charset=utf-8%n" +
+                "Content-Length: 59%n" +
+                "Server: Jetty(9.3.2.v20150730)%n" +
+                "%n" +
+                "{%n" +
+                "    \"firstName\": \"John\",%n" +
+                "    \"lastName\": \"Doe\",%n" +
+                "    \"fullName\": \"John Doe\"%n" +
+                "}%n")));
+    }
+
+    @Test
+    public void supportsSettingLoggingWhenUsingOnlyResponseSpecBuilder() {
+        final StringWriter writer = new StringWriter();
+        final PrintStream captor = new PrintStream(new WriterOutputStream(writer), true);
+        final ResponseSpecification responseSpec = new ResponseSpecBuilder().expectStatusCode(SC_OK).log(ALL).build();
+
+        given().
+                config(newConfig().logConfig(logConfig().defaultStream(captor))).
+                pathParameter("firstName", "John").
+                pathParameter("lastName", "Doe").
+                get("/{firstName}/{lastName}").
+        then().
+               spec(responseSpec).
+               body("fullName", equalTo("John Doe"));
+
+        assertThat(writer.toString(), equalTo(String.format("HTTP/1.1 200 OK%n" +
+                "Content-Type: application/json;charset=utf-8%n" +
+                "Content-Length: 59%n" +
+                "Server: Jetty(9.3.2.v20150730)%n" +
+                "%n" +
+                "{%n" +
+                "    \"firstName\": \"John\",%n" +
+                "    \"lastName\": \"Doe\",%n" +
+                "    \"fullName\": \"John Doe\"%n" +
+                "}%n")));
+    }
+
+    @Test
+    public void supportsSettingConfigWhenUsingRequestSpecBuilder() {
         final RequestSpecification spec = new RequestSpecBuilder().setConfig(newConfig().redirect(redirectConfig().followRedirects(false))).build();
 
         given().
@@ -395,7 +448,7 @@ public class SpecificationBuilderITest extends WithJetty {
     }
 
     @Test
-    public void mergesStaticallyDefinedResponseSpecificationsCorrectly() throws Exception {
+    public void mergesStaticallyDefinedResponseSpecificationsCorrectly() {
         RestAssured.responseSpecification = new ResponseSpecBuilder().expectCookie("Cookie1", "Value1").build();
         ResponseSpecification reqSpec1 = new ResponseSpecBuilder().expectCookie("Cookie2", "Value2").build();
         ResponseSpecification reqSpec2 = new ResponseSpecBuilder().expectCookie("Cookie3", "Value3").build();
@@ -438,7 +491,7 @@ public class SpecificationBuilderITest extends WithJetty {
     }
 
     @Test
-    public void mergesStaticallyDefinedRequestSpecificationsCorrectly() throws Exception {
+    public void mergesStaticallyDefinedRequestSpecificationsCorrectly() {
         RestAssured.requestSpecification = new RequestSpecBuilder().addCookie("Cookie1", "Value1").build();
         RequestSpecification reqSpec1 = new RequestSpecBuilder().addCookie("Cookie2", "Value2").build();
         RequestSpecification reqSpec2 = new RequestSpecBuilder().addCookie("Cookie3", "Value3").build();

--- a/rest-assured/src/main/groovy/io/restassured/internal/RequestSpecificationImpl.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/RequestSpecificationImpl.groovy
@@ -1730,6 +1730,11 @@ class RequestSpecificationImpl implements FilterableRequestSpecification, Groovy
     }
     restAssuredConfig = config ?: new RestAssuredConfig()
 
+    if (!filters.any { ResponseLoggingFilter.class.isAssignableFrom(it.getClass()) } && responseSpecification?.getLogDetail()) {
+      filters.add(new ResponseLoggingFilter(responseSpecification.getLogDetail(),
+      logConfig.isPrettyPrintingEnabled(), logConfig.defaultStream()))
+    }
+
     // Sort filters by order
     filters = filters.toSorted { f1, f2 -> getFilterOrder(f1) <=> getFilterOrder(f2) }
 

--- a/rest-assured/src/main/groovy/io/restassured/internal/ResponseSpecificationImpl.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/ResponseSpecificationImpl.groovy
@@ -19,6 +19,7 @@ package io.restassured.internal
 
 import io.restassured.assertion.*
 import io.restassured.config.RestAssuredConfig
+import io.restassured.filter.log.LogDetail
 import io.restassured.function.RestAssuredFunction
 import io.restassured.http.ContentType
 import io.restassured.internal.MapCreator.CollisionStrategy
@@ -59,6 +60,7 @@ class ResponseSpecificationImpl implements FilterableResponseSpecification {
   def RestAssuredConfig config
   private Response response
   private Tuple2<Matcher<Long>, TimeUnit> expectedResponseTime;
+  private LogDetail responseLogDetail
 
   private contentParser
   def LogRepository logRepository
@@ -296,6 +298,15 @@ class ResponseSpecificationImpl implements FilterableResponseSpecification {
 
   def ResponseLogSpecification log() {
     return new ResponseLogSpecificationImpl(responseSpecification: this, logRepository: logRepository)
+  }
+
+  ResponseSpecificationImpl logDetail(LogDetail logDetail) {
+    this.responseLogDetail = logDetail
+    this
+  }
+
+  LogDetail getLogDetail() {
+    responseLogDetail
   }
 
   def RequestSender when() {

--- a/rest-assured/src/main/java/io/restassured/builder/ResponseSpecBuilder.java
+++ b/rest-assured/src/main/java/io/restassured/builder/ResponseSpecBuilder.java
@@ -17,7 +17,9 @@
 package io.restassured.builder;
 
 import io.restassured.RestAssured;
+import io.restassured.config.LogConfig;
 import io.restassured.config.RestAssuredConfig;
+import io.restassured.filter.log.LogDetail;
 import io.restassured.http.ContentType;
 import io.restassured.internal.ResponseParserRegistrar;
 import io.restassured.internal.ResponseSpecificationImpl;
@@ -35,6 +37,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static io.restassured.RestAssured.rootPath;
+import static io.restassured.internal.assertion.AssertParameter.notNull;
 
 /**
  * You can use the builder to construct a response specification. The specification can be used as e.g.
@@ -671,6 +674,18 @@ public class ResponseSpecBuilder {
 
         ResponseSpecificationImpl rs = (ResponseSpecificationImpl) specification;
         SpecificationMerger.merge((ResponseSpecificationImpl) spec, rs);
+        return this;
+    }
+
+    /**
+     * Enabled logging with the specified log detail. Set a {@link LogConfig} to configure the print stream and pretty printing options.
+     *
+     * @param logDetail The log detail.
+     * @return ResponseSpecBuilder
+     */
+    public ResponseSpecBuilder log(LogDetail logDetail) {
+        notNull(logDetail, LogDetail.class);
+        spec.logDetail(logDetail);
         return this;
     }
 

--- a/rest-assured/src/main/java/io/restassured/internal/ValidatableResponseOptionsImpl.java
+++ b/rest-assured/src/main/java/io/restassured/internal/ValidatableResponseOptionsImpl.java
@@ -311,6 +311,10 @@ public abstract class ValidatableResponseOptionsImpl<T extends ValidatableRespon
                 impl.setConfig(impl.getConfig().logConfig(globalLogConfig));
                 impl.setLogRepository(responseSpec.getLogRepository());
             }
+            if (impl.getLogDetail() != null) {
+                logResponse(impl.getLogDetail(), globalLogConfig.isPrettyPrintingEnabled(),
+                globalLogConfig.defaultStream());
+            }
         }
 
         // Finally validate the response

--- a/rest-assured/src/main/java/io/restassured/specification/FilterableResponseSpecification.java
+++ b/rest-assured/src/main/java/io/restassured/specification/FilterableResponseSpecification.java
@@ -16,6 +16,7 @@
 
 package io.restassured.specification;
 
+import io.restassured.filter.log.LogDetail;
 import org.hamcrest.Matcher;
 
 /**
@@ -52,4 +53,9 @@ public interface FilterableResponseSpecification extends ResponseSpecification {
      * @return The body root path when expecting XML or JSON
      */
     String getRootPath();
+
+    /**
+     * @return  The log detail for the response
+     */
+    LogDetail getLogDetail();
 }

--- a/rest-assured/src/main/java/io/restassured/specification/ResponseSpecification.java
+++ b/rest-assured/src/main/java/io/restassured/specification/ResponseSpecification.java
@@ -16,9 +16,9 @@
 
 package io.restassured.specification;
 
+import io.restassured.filter.log.LogDetail;
 import io.restassured.function.RestAssuredFunction;
 import io.restassured.http.ContentType;
-import io.restassured.http.Cookie;
 import io.restassured.matcher.DetailedCookieMatcher;
 import io.restassured.parsing.Parser;
 import io.restassured.response.Response;
@@ -1220,4 +1220,15 @@ public interface ResponseSpecification {
      * @param parser The parser to use when verifying the response if no other parser is found for the response content-type.
      */
     ResponseSpecification defaultParser(Parser parser);
+
+     /**
+     * Log different parts of the {@link ResponseSpecification} by using {@link LogDetail}.
+     * This is mainly useful for debug purposes when writing your tests. It's a shortcut for:
+     * <pre>
+     * given().filter(new ResponseLoggingFilter(logDetail))). ..
+     * </pre>
+     *
+     * @param logDetail The log detail
+     */
+    ResponseSpecification logDetail(LogDetail logDetail);
 }


### PR DESCRIPTION
Changes:
* Add logging functionality to the ResponseSpecBuilder
* Remove redundant `throws Exception`