### PR TITLE
Keep version of httpmime in sync with httpclient

### DIFF
--- a/rest-assured/pom.xml
+++ b/rest-assured/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpmime</artifactId>
-            <version>4.5.1</version>
+            <version>${httpclient.version}</version>
         </dependency>
         <dependency>
             <groupId>com.github.scribejava</groupId>


### PR DESCRIPTION
`httpclient` is required in version 4.5.3, whereas `httpmime` is required in version 4.5.1. `httpmime` itself depends on `httpclient`, requiring the same version as its own version. This causes the maven enforcer plugin to complain about the dependency convergence when consuming rest-assured.

Use `${httpclient-version}` for all subcomponents of `org.apache.httpcomponents`.

See-also: #813