### PR TITLE
Fix duplication of content type

### DIFF
--- a/modules/spring-mock-mvc/src/main/java/io/restassured/module/mockmvc/internal/MockMvcRequestSenderImpl.java
+++ b/modules/spring-mock-mvc/src/main/java/io/restassured/module/mockmvc/internal/MockMvcRequestSenderImpl.java
@@ -362,15 +362,14 @@ class MockMvcRequestSenderImpl implements MockMvcRequestSender, MockMvcRequestAs
             request.requestAttr(ATTRIBUTE_NAME_URL_TEMPLATE, PathSupport.getPath(uri));
         }
 
-
-        if (StringUtils.isNotBlank(requestContentType)) {
-            request.contentType(MediaType.parseMediaType(requestContentType));
-        }
-
         if (headers.exist()) {
             for (Header header : headers) {
                 request.header(header.getName(), header.getValue());
             }
+        }
+
+        if (StringUtils.isNotBlank(requestContentType)) {
+            request.contentType(MediaType.parseMediaType(requestContentType));
         }
 
         if (cookies.exist()) {


### PR DESCRIPTION
Hi :)
I found trivial bug for `contentType` and `headers` from MockHttpServletRequestBuilder.

This bug I think so trivial bug for rest-assured, but saw duplication of `content-type` in result docs when using with `spring-rest-dcos` and `asciidoctor`.

I added test code that case, if you could review this PR then I appreciate it.
AND.. I use rest-assured very usefully, Thank you for your effort. :D