### PR TITLE
versionrange added to osgi-dependency groovy

### DIFF
--- a/json-path/pom.xml
+++ b/json-path/pom.xml
@@ -45,7 +45,11 @@
                 <configuration>
                     <instructions>
                         <Export-Package>io.restassured.*</Export-Package>
-                        <Import-Package>*</Import-Package>
+                        <Import-Package>
+							groovy.*;version="${groovy.range}",
+                            org.codehaus.groovy.*;version="${groovy.range}",
+                            *
+						</Import-Package>
                         <Private-Package />
                     </instructions>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
         <scm.branch>master</scm.branch>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <groovy.version>2.4.15</groovy.version>
+		<groovy.range>[2.4,2.5)</groovy.range>
         <gmaven.version>1.5</gmaven.version>
         <hamcrest.version>1.3</hamcrest.version>
         <jackson1.version>1.9.11</jackson1.version>

--- a/rest-assured-common/pom.xml
+++ b/rest-assured-common/pom.xml
@@ -46,7 +46,11 @@
                 <configuration>
                     <instructions>
                         <Export-Package>io.restassured.*</Export-Package>
-                        <Import-Package>*</Import-Package>
+                        <Import-Package>
+							groovy.*;version="${groovy.range}",
+                            org.codehaus.groovy.*;version="${groovy.range}",
+                            *
+						</Import-Package>
                         <Private-Package />
                     </instructions>
                 </configuration>

--- a/rest-assured/pom.xml
+++ b/rest-assured/pom.xml
@@ -48,7 +48,11 @@
                 <configuration>
                     <instructions>
                         <Export-Package>io.restassured.*</Export-Package>
-                        <Import-Package>*</Import-Package>
+                        <Import-Package>
+							groovy.*;version="${groovy.range}",
+                            org.codehaus.groovy.*;version="${groovy.range}",
+                            *
+						</Import-Package>
                         <Private-Package />
                     </instructions>
                 </configuration>

--- a/xml-path/pom.xml
+++ b/xml-path/pom.xml
@@ -39,7 +39,11 @@
                 <configuration>
                     <instructions>
                         <Export-Package>io.restassured.*</Export-Package>
-                        <Import-Package>*</Import-Package>
+                        <Import-Package>
+							groovy.*;version="${groovy.range}",
+                            org.codehaus.groovy.*;version="${groovy.range}",
+                            *
+						</Import-Package>
                         <Private-Package />
                     </instructions>
                 </configuration>


### PR DESCRIPTION
Hello johanhaleby,

This is a fix for the osgi-dependency on groovy in rest-assured. The api of groovy has changed in release 2.5. I've added a versionrange so only groovy-versions between 2.4 and 2.5 are permitted, excluding 2.5 and onward.

Greetings,
Rikske54