### PR TITLE
Fixed issue with overwriting FailureConfig on settings other configs

### DIFF
--- a/rest-assured/src/main/java/io/restassured/config/RestAssuredConfig.java
+++ b/rest-assured/src/main/java/io/restassured/config/RestAssuredConfig.java
@@ -113,7 +113,7 @@ public class RestAssuredConfig implements Config {
         return new RestAssuredConfig(redirectConfig, conf(HttpClientConfig.class), conf(LogConfig.class), conf(EncoderConfig.class),
                 conf(DecoderConfig.class), conf(SessionConfig.class), conf(ObjectMapperConfig.class), conf(ConnectionConfig.class),
                 conf(JsonConfig.class), conf(XmlConfig.class), conf(SSLConfig.class), conf(MatcherConfig.class),
-                conf(HeaderConfig.class), conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class), new FailureConfig());
+                conf(HeaderConfig.class), conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class), conf(FailureConfig.class));
     }
 
     /**
@@ -127,7 +127,7 @@ public class RestAssuredConfig implements Config {
         return new RestAssuredConfig(conf(RedirectConfig.class), httpClientConfig, conf(LogConfig.class), conf(EncoderConfig.class),
                 conf(DecoderConfig.class), conf(SessionConfig.class), conf(ObjectMapperConfig.class), conf(ConnectionConfig.class),
                 conf(JsonConfig.class), conf(XmlConfig.class), conf(SSLConfig.class), conf(MatcherConfig.class),
-                conf(HeaderConfig.class), conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class), new FailureConfig());
+                conf(HeaderConfig.class), conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class), conf(FailureConfig.class));
     }
 
     /**
@@ -141,7 +141,7 @@ public class RestAssuredConfig implements Config {
         return new RestAssuredConfig(conf(RedirectConfig.class), conf(HttpClientConfig.class), logConfig, conf(EncoderConfig.class),
                 conf(DecoderConfig.class), conf(SessionConfig.class), conf(ObjectMapperConfig.class), conf(ConnectionConfig.class),
                 conf(JsonConfig.class), conf(XmlConfig.class), conf(SSLConfig.class), conf(MatcherConfig.class),
-                conf(HeaderConfig.class), conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class), new FailureConfig());
+                conf(HeaderConfig.class), conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class), conf(FailureConfig.class));
     }
 
     /**
@@ -155,7 +155,7 @@ public class RestAssuredConfig implements Config {
         return new RestAssuredConfig(conf(RedirectConfig.class), conf(HttpClientConfig.class), conf(LogConfig.class), encoderConfig,
                 conf(DecoderConfig.class), conf(SessionConfig.class), conf(ObjectMapperConfig.class), conf(ConnectionConfig.class),
                 conf(JsonConfig.class), conf(XmlConfig.class), conf(SSLConfig.class), conf(MatcherConfig.class),
-                conf(HeaderConfig.class), conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class), new FailureConfig());
+                conf(HeaderConfig.class), conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class), conf(FailureConfig.class));
     }
 
     /**
@@ -169,7 +169,7 @@ public class RestAssuredConfig implements Config {
         return new RestAssuredConfig(conf(RedirectConfig.class), conf(HttpClientConfig.class), conf(LogConfig.class), conf(EncoderConfig.class),
                 decoderConfig, conf(SessionConfig.class), conf(ObjectMapperConfig.class), conf(ConnectionConfig.class),
                 conf(JsonConfig.class), conf(XmlConfig.class), conf(SSLConfig.class), conf(MatcherConfig.class),
-                conf(HeaderConfig.class), conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class), new FailureConfig());
+                conf(HeaderConfig.class), conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class), conf(FailureConfig.class));
     }
 
     /**
@@ -183,7 +183,7 @@ public class RestAssuredConfig implements Config {
         return new RestAssuredConfig(conf(RedirectConfig.class), conf(HttpClientConfig.class), conf(LogConfig.class), conf(EncoderConfig.class),
                 conf(DecoderConfig.class), sessionConfig, conf(ObjectMapperConfig.class), conf(ConnectionConfig.class),
                 conf(JsonConfig.class), conf(XmlConfig.class), conf(SSLConfig.class), conf(MatcherConfig.class),
-                conf(HeaderConfig.class), conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class), new FailureConfig());
+                conf(HeaderConfig.class), conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class), conf(FailureConfig.class));
     }
 
     /**
@@ -197,7 +197,7 @@ public class RestAssuredConfig implements Config {
         return new RestAssuredConfig(conf(RedirectConfig.class), conf(HttpClientConfig.class), conf(LogConfig.class), conf(EncoderConfig.class),
                 conf(DecoderConfig.class), conf(SessionConfig.class), objectMapperConfig, conf(ConnectionConfig.class),
                 conf(JsonConfig.class), conf(XmlConfig.class), conf(SSLConfig.class), conf(MatcherConfig.class),
-                conf(HeaderConfig.class), conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class), new FailureConfig());
+                conf(HeaderConfig.class), conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class), conf(FailureConfig.class));
     }
 
     /**
@@ -211,7 +211,7 @@ public class RestAssuredConfig implements Config {
         return new RestAssuredConfig(conf(RedirectConfig.class), conf(HttpClientConfig.class), conf(LogConfig.class), conf(EncoderConfig.class),
                 conf(DecoderConfig.class), conf(SessionConfig.class), conf(ObjectMapperConfig.class), connectionConfig,
                 conf(JsonConfig.class), conf(XmlConfig.class), conf(SSLConfig.class), conf(MatcherConfig.class),
-                conf(HeaderConfig.class), conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class), new FailureConfig());
+                conf(HeaderConfig.class), conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class), conf(FailureConfig.class));
     }
 
     /**
@@ -225,7 +225,7 @@ public class RestAssuredConfig implements Config {
         return new RestAssuredConfig(conf(RedirectConfig.class), conf(HttpClientConfig.class), conf(LogConfig.class), conf(EncoderConfig.class),
                 conf(DecoderConfig.class), conf(SessionConfig.class), conf(ObjectMapperConfig.class), conf(ConnectionConfig.class),
                 jsonConfig, conf(XmlConfig.class), conf(SSLConfig.class), conf(MatcherConfig.class),
-                conf(HeaderConfig.class), conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class), new FailureConfig());
+                conf(HeaderConfig.class), conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class),conf(FailureConfig.class));
     }
 
     /**
@@ -239,7 +239,7 @@ public class RestAssuredConfig implements Config {
         return new RestAssuredConfig(conf(RedirectConfig.class), conf(HttpClientConfig.class), conf(LogConfig.class), conf(EncoderConfig.class),
                 conf(DecoderConfig.class), conf(SessionConfig.class), conf(ObjectMapperConfig.class), conf(ConnectionConfig.class),
                 conf(JsonConfig.class), xmlConfig, conf(SSLConfig.class), conf(MatcherConfig.class), conf(HeaderConfig.class),
-                conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class), new FailureConfig());
+                conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class), conf(FailureConfig.class));
     }
 
     /**
@@ -253,7 +253,7 @@ public class RestAssuredConfig implements Config {
         return new RestAssuredConfig(conf(RedirectConfig.class), conf(HttpClientConfig.class), conf(LogConfig.class), conf(EncoderConfig.class),
                 conf(DecoderConfig.class), conf(SessionConfig.class), conf(ObjectMapperConfig.class), conf(ConnectionConfig.class),
                 conf(JsonConfig.class), conf(XmlConfig.class), sslConfig, conf(MatcherConfig.class), conf(HeaderConfig.class),
-                conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class), new FailureConfig());
+                conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class), conf(FailureConfig.class));
     }
 
     /**
@@ -267,7 +267,7 @@ public class RestAssuredConfig implements Config {
         return new RestAssuredConfig(conf(RedirectConfig.class), conf(HttpClientConfig.class), conf(LogConfig.class), conf(EncoderConfig.class),
                 conf(DecoderConfig.class), conf(SessionConfig.class), conf(ObjectMapperConfig.class), conf(ConnectionConfig.class),
                 conf(JsonConfig.class), conf(XmlConfig.class), conf(SSLConfig.class), matcherConfig, conf(HeaderConfig.class),
-                conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class), new FailureConfig());
+                conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class), conf(FailureConfig.class));
     }
 
     /**
@@ -281,7 +281,7 @@ public class RestAssuredConfig implements Config {
         return new RestAssuredConfig(conf(RedirectConfig.class), conf(HttpClientConfig.class), conf(LogConfig.class), conf(EncoderConfig.class),
                 conf(DecoderConfig.class), conf(SessionConfig.class), conf(ObjectMapperConfig.class), conf(ConnectionConfig.class),
                 conf(JsonConfig.class), conf(XmlConfig.class), conf(SSLConfig.class), conf(MatcherConfig.class), headerConfig,
-                conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class), new FailureConfig());
+                conf(MultiPartConfig.class), conf(ParamConfig.class), conf(OAuthConfig.class), conf(FailureConfig.class));
     }
 
     /**
@@ -295,7 +295,7 @@ public class RestAssuredConfig implements Config {
         return new RestAssuredConfig(conf(RedirectConfig.class), conf(HttpClientConfig.class), conf(LogConfig.class), conf(EncoderConfig.class),
                 conf(DecoderConfig.class), conf(SessionConfig.class), conf(ObjectMapperConfig.class), conf(ConnectionConfig.class),
                 conf(JsonConfig.class), conf(XmlConfig.class), conf(SSLConfig.class), conf(MatcherConfig.class), conf(HeaderConfig.class),
-                multiPartConfig, conf(ParamConfig.class), conf(OAuthConfig.class), new FailureConfig());
+                multiPartConfig, conf(ParamConfig.class), conf(OAuthConfig.class), conf(FailureConfig.class));
     }
 
     /**
@@ -309,7 +309,7 @@ public class RestAssuredConfig implements Config {
         return new RestAssuredConfig(conf(RedirectConfig.class), conf(HttpClientConfig.class), conf(LogConfig.class), conf(EncoderConfig.class),
                 conf(DecoderConfig.class), conf(SessionConfig.class), conf(ObjectMapperConfig.class), conf(ConnectionConfig.class),
                 conf(JsonConfig.class), conf(XmlConfig.class), conf(SSLConfig.class), conf(MatcherConfig.class), conf(HeaderConfig.class),
-                conf(MultiPartConfig.class), paramConfig, conf(OAuthConfig.class), new FailureConfig());
+                conf(MultiPartConfig.class), paramConfig, conf(OAuthConfig.class), conf(FailureConfig.class));
     }
 
     /**
@@ -323,7 +323,7 @@ public class RestAssuredConfig implements Config {
         return new RestAssuredConfig(conf(RedirectConfig.class), conf(HttpClientConfig.class), conf(LogConfig.class), conf(EncoderConfig.class),
                 conf(DecoderConfig.class), conf(SessionConfig.class), conf(ObjectMapperConfig.class), conf(ConnectionConfig.class),
                 conf(JsonConfig.class), conf(XmlConfig.class), conf(SSLConfig.class), conf(MatcherConfig.class), conf(HeaderConfig.class),
-                conf(MultiPartConfig.class), conf(ParamConfig.class), oauthConfig, new FailureConfig());
+                conf(MultiPartConfig.class), conf(ParamConfig.class), oauthConfig, conf(FailureConfig.class));
     }
 
     /**

--- a/rest-assured/src/test/java/io/restassured/config/FailureConfigTest.java
+++ b/rest-assured/src/test/java/io/restassured/config/FailureConfigTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.restassured.config;
+
+import io.restassured.listener.ResponseValidationFailureListener;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+import io.restassured.specification.ResponseSpecification;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+public class FailureConfigTest {
+
+    @Test
+    public void
+    shouldNotOverwriteFailureConfig() {
+        // Given
+        FailureConfig failureConfig = new FailureConfig().failureListeners(new ResponseValidationFailureListener() {
+            @Override
+            public void onFailure(RequestSpecification requestSpecification, ResponseSpecification responseSpecification, Response response) {
+            }
+        });
+        // When
+        RestAssuredConfig config = RestAssuredConfig.config().failureConfig(failureConfig)
+                .httpClient(new HttpClientConfig())
+                .redirect(new RedirectConfig())
+                .logConfig(new LogConfig())
+                .encoderConfig(new EncoderConfig())
+                .decoderConfig(new DecoderConfig())
+                .sessionConfig(new SessionConfig())
+                .objectMapperConfig(new ObjectMapperConfig())
+                .connectionConfig(new ConnectionConfig())
+                .jsonConfig(new JsonConfig())
+                .xmlConfig(new XmlConfig())
+                .sslConfig(new SSLConfig())
+                .matcherConfig(new MatcherConfig())
+                .headerConfig(new HeaderConfig())
+                .multiPartConfig(new MultiPartConfig())
+                .paramConfig(new ParamConfig())
+                .oauthConfig(new OAuthConfig());
+        // Then
+        assertThat(config.getFailureConfig().getFailureListeners(), hasSize(2));
+    }
+}


### PR DESCRIPTION
Hi!
I set custom FailureConfig(https://github.com/rest-assured/rest-assured/pull/1094), but it was overwritten (created new one) on adding other configs.
See an example  below.
`...failureConfig(FailureConfig.failureConfig().failureListeners(new MyFailureListener()))).logConfig(getLogConfig())... `
There will be an empty FailureConfig config with default listener when we use similar chain of calles cause it was recreated.

