### PR TITLE
#679: Add on fail message builder for response specification

### DIFF
--- a/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/ErrorMessageITest.java
+++ b/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/ErrorMessageITest.java
@@ -93,6 +93,32 @@ public class ErrorMessageITest extends WithJetty {
     }
 
     @Test public void
+    error_message_with_on_fail_message_look_ok_when_mixing_body_and_status_code_errors() {
+        exception.expect(AssertionError.class);
+        exception.expectMessage("3 expectations failed.\n" +
+                "Expected status code <201> but was <200>.\n" +
+                "\n" +
+                "JSON path lotto.lottoId doesn't match.\n" +
+                "Expected: a value less than <2>\n" +
+                "  Actual: 5\n" +
+                "\n" +
+                "JSON path lotto.winning-numbers doesn't match.\n" +
+                "Expected: a collection containing <21>\n" +
+                "  Actual: [2, 45, 34, 23, 7, 5, 3]\n" +
+                "\n" +
+                "On fail message: An additional information to find the cause of the error");
+
+        expect().
+                statusCode(201).
+                body("lotto.lottoId", greaterThan(4)).
+                body("lotto.lottoId", lessThan(2)).
+                body("lotto.winning-numbers", hasItem(21)).
+                onFailMessage("An additional information to find the cause of the error").
+                when().
+                get("/lotto");
+    }
+
+    @Test public void
     error_message_with_failed_xpath_expected_looks_ok() {
         exception.expect(AssertionError.class);
         exception.expectMessage(equalTo("1 expectation failed.\n"+

--- a/rest-assured/src/main/groovy/io/restassured/internal/ResponseSpecificationImpl.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/ResponseSpecificationImpl.groovy
@@ -60,6 +60,7 @@ class ResponseSpecificationImpl implements FilterableResponseSpecification {
   private Response response
   private Tuple2<Matcher<Long>, TimeUnit> expectedResponseTime;
   private LogDetail responseLogDetail
+  private String onFailMessage
 
   private contentParser
   def LogRepository logRepository
@@ -304,6 +305,11 @@ class ResponseSpecificationImpl implements FilterableResponseSpecification {
     this
   }
 
+  ResponseSpecification onFailMessage(String message) {
+    this.onFailMessage = message
+    this
+  }
+
   LogDetail getLogDetail() {
     responseLogDetail
   }
@@ -491,9 +497,13 @@ class ResponseSpecificationImpl implements FilterableResponseSpecification {
           fireFailureListeners(response)
           def errorMessage = errors.collect { it.errorMessage }.join("\n")
           def s = numberOfErrors > 1 ? "s" : ""
-          throw new AssertionError("$numberOfErrors expectation$s failed.\n$errorMessage")
+          throw new AssertionError("$numberOfErrors expectation$s failed.\n$errorMessage$formattedOnFailMessage")
         }
       }
+    }
+
+    private String getFormattedOnFailMessage() {
+      onFailMessage ? "\nOn fail message: $onFailMessage" : ""
     }
 
     private void fireFailureListeners(Response response) {

--- a/rest-assured/src/main/java/io/restassured/specification/ResponseSpecification.java
+++ b/rest-assured/src/main/java/io/restassured/specification/ResponseSpecification.java
@@ -1236,6 +1236,9 @@ public interface ResponseSpecification {
      * Add user message to final mismatch description.
      * <p/>
      * This is useful when you need to associate a mismatch description with additional user information. For example, in parallel execution.
+     * <p/>
+     * Note, if you want to add a description for certain matching, not for all, you should use something like
+     * Hamcrest wrapper matcher - {@link org.hamcrest.CoreMatchers#describedAs}.
      *
      * @param message The user message
      */

--- a/rest-assured/src/main/java/io/restassured/specification/ResponseSpecification.java
+++ b/rest-assured/src/main/java/io/restassured/specification/ResponseSpecification.java
@@ -1231,4 +1231,13 @@ public interface ResponseSpecification {
      * @param logDetail The log detail
      */
     ResponseSpecification logDetail(LogDetail logDetail);
+
+    /**
+     * Add user message to final mismatch description.
+     * <p/>
+     * This is useful when you need to associate a mismatch description with additional user information. For example, in parallel execution.
+     *
+     * @param message The user message
+     */
+    ResponseSpecification onFailMessage(String message);
 }


### PR DESCRIPTION
This is useful when you need to associate a mismatch description with additional user information. For example, in parallel execution.