### PR TITLE
Add Apache Johnzon object mapper support

### DIFF
--- a/json-path/pom.xml
+++ b/json-path/pom.xml
@@ -95,6 +95,16 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>org.apache.johnzon</groupId>
+            <artifactId>johnzon-mapper</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>javax.json</groupId>
+            <artifactId>javax.json-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy</artifactId>
         </dependency>

--- a/json-path/src/main/groovy/io/restassured/internal/path/json/mapping/JsonObjectDeserializer.groovy
+++ b/json-path/src/main/groovy/io/restassured/internal/path/json/mapping/JsonObjectDeserializer.groovy
@@ -22,10 +22,11 @@ package io.restassured.internal.path.json.mapping
 import io.restassured.internal.common.mapper.ObjectDeserializationContextImpl
 import io.restassured.common.mapper.DataToDeserialize
 import io.restassured.common.mapper.ObjectDeserializationContext
+import io.restassured.common.mapper.resolver.ObjectMapperResolver
 import io.restassured.path.json.mapper.factory.GsonObjectMapperFactory
 import io.restassured.path.json.mapper.factory.Jackson1ObjectMapperFactory
 import io.restassured.path.json.mapper.factory.Jackson2ObjectMapperFactory
-import io.restassured.common.mapper.resolver.ObjectMapperResolver
+import io.restassured.path.json.mapper.factory.JohnzonObjectMapperFactory
 import io.restassured.path.json.config.JsonParserType
 import io.restassured.path.json.config.JsonPathConfig
 import org.apache.commons.lang3.Validate
@@ -69,6 +70,8 @@ class JsonObjectDeserializer {
             return deserializeWithJackson1(deserializationCtx, jsonPathConfig.jackson1ObjectMapperFactory()) as T
         } else if (ObjectMapperResolver.isGsonInClassPath()) {
             return deserializeWithGson(deserializationCtx, jsonPathConfig.gsonObjectMapperFactory()) as T
+        } else if (ObjectMapperResolver.isJohnzonInClassPath()) {
+            return deserializeWithJohnzon(deserializationCtx, jsonPathConfig.johnzonObjectMapperFactory()) as T
         }
         throw new IllegalStateException("Cannot deserialize object because no JSON deserializer found in classpath. Please put either Jackson (Databind) or Gson in the classpath.")
     }
@@ -80,6 +83,8 @@ class JsonObjectDeserializer {
             return deserializeWithJackson1(ctx, config.jackson1ObjectMapperFactory()) as T
         } else if (mapperType == JsonParserType.GSON && ObjectMapperResolver.isGsonInClassPath()) {
             return deserializeWithGson(ctx, config.gsonObjectMapperFactory()) as T
+        } else if (mapperType == JsonParserType.JOHNZON && ObjectMapperResolver.isJohnzonInClassPath()) {
+            return deserializeWithJohnzon(ctx, config.johnzonObjectMapperFactory()) as T
         } else {
             def lowerCase = mapperType.toString().toLowerCase()
             throw new IllegalArgumentException("Cannot deserialize object using $mapperType because $lowerCase doesn't exist in the classpath.")
@@ -98,4 +103,7 @@ class JsonObjectDeserializer {
         new JsonPathJackson2ObjectDeserializer(factory).deserialize(ctx)
     }
 
+	static def deserializeWithJohnzon(ObjectDeserializationContext ctx, JohnzonObjectMapperFactory factory) {
+		new JsonPathJohnzonObjectDeserializer(factory).deserialize(ctx)
+	}
 }

--- a/json-path/src/main/groovy/io/restassured/internal/path/json/mapping/JsonPathJohnzonObjectDeserializer.groovy
+++ b/json-path/src/main/groovy/io/restassured/internal/path/json/mapping/JsonPathJohnzonObjectDeserializer.groovy
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.restassured.internal.path.json.mapping
+
+import java.lang.reflect.Type
+
+import org.apache.johnzon.mapper.Mapper
+
+import io.restassured.common.mapper.ObjectDeserializationContext
+import io.restassured.path.json.mapper.factory.JohnzonObjectMapperFactory
+import io.restassured.path.json.mapping.JsonPathObjectDeserializer
+
+import static io.restassured.internal.common.assertion.AssertParameter.notNull
+
+class JsonPathJohnzonObjectDeserializer implements JsonPathObjectDeserializer {
+    private final JohnzonObjectMapperFactory factory
+
+    JsonPathJohnzonObjectDeserializer(JohnzonObjectMapperFactory factory) {
+        notNull(factory, "JohnzonObjectMapperFactory")
+        this.factory = factory;
+    }
+	
+	private Mapper createJohnzonObjectMapper(Type cls, String charset) {
+		return factory.create(cls, charset)
+	}
+
+	@Override
+	def <T> T deserialize(ObjectDeserializationContext context) {
+		def object = context.getDataToDeserialize().asString()
+		def cls = context.getType()
+		def mapper = createJohnzonObjectMapper(cls, context.getCharset())
+		
+		context.getDataToDeserialize().asInputStream().withReader { reader ->
+			mapper.readObject(reader, cls)
+		}
+	}
+}

--- a/json-path/src/main/java/io/restassured/path/json/JsonPath.java
+++ b/json-path/src/main/java/io/restassured/path/json/JsonPath.java
@@ -1067,6 +1067,8 @@ public class JsonPath {
             cfg = cfg.defaultParserType(JsonParserType.GSON);
         } else if (cfg.hasCustomJackson20ObjectMapperFactory()) {
             cfg = cfg.defaultParserType(JsonParserType.JACKSON_2);
+        } else if (cfg.hasCustomJohnzonObjectMapperFactory()) {
+            cfg = cfg.defaultParserType(JsonParserType.JOHNZON);
         }
 
         return JsonObjectDeserializer.deserialize(object, objectType, cfg);

--- a/json-path/src/main/java/io/restassured/path/json/config/JsonParserType.java
+++ b/json-path/src/main/java/io/restassured/path/json/config/JsonParserType.java
@@ -20,5 +20,5 @@ package io.restassured.path.json.config;
  * Specifies different pre-defined JSON parser types
  */
 public enum JsonParserType {
-    JACKSON_2, JACKSON_1, GSON
+    JACKSON_2, JACKSON_1, GSON, JOHNZON
 }

--- a/json-path/src/main/java/io/restassured/path/json/config/JsonPathConfig.java
+++ b/json-path/src/main/java/io/restassured/path/json/config/JsonPathConfig.java
@@ -16,13 +16,14 @@
 
 package io.restassured.path.json.config;
 
-import io.restassured.common.mapper.factory.*;
 import io.restassured.path.json.mapper.factory.DefaultGsonObjectMapperFactory;
 import io.restassured.path.json.mapper.factory.DefaultJackson1ObjectMapperFactory;
 import io.restassured.path.json.mapper.factory.DefaultJackson2ObjectMapperFactory;
+import io.restassured.path.json.mapper.factory.DefaultJohnzonObjectMapperFactory;
 import io.restassured.path.json.mapper.factory.GsonObjectMapperFactory;
 import io.restassured.path.json.mapper.factory.Jackson1ObjectMapperFactory;
 import io.restassured.path.json.mapper.factory.Jackson2ObjectMapperFactory;
+import io.restassured.path.json.mapper.factory.JohnzonObjectMapperFactory;
 import io.restassured.path.json.mapping.JsonPathObjectDeserializer;
 import org.apache.commons.lang3.StringUtils;
 
@@ -45,6 +46,7 @@ public class JsonPathConfig {
     private final GsonObjectMapperFactory gsonObjectMapperFactory;
     private final Jackson1ObjectMapperFactory jackson1ObjectMapperFactory;
     private final Jackson2ObjectMapperFactory jackson2ObjectMapperFactory;
+    private final JohnzonObjectMapperFactory johnzonObjectMapperFactory;
     private final String charset;
 
 
@@ -55,7 +57,7 @@ public class JsonPathConfig {
      */
     public JsonPathConfig(JsonPathConfig config) {
         this(config.numberReturnType(), config.defaultParserType(), config.gsonObjectMapperFactory(), config.jackson1ObjectMapperFactory(),
-                config.jackson2ObjectMapperFactory(), config.defaultDeserializer(), config.charset());
+                config.jackson2ObjectMapperFactory(), config.johnzonObjectMapperFactory(), config.defaultDeserializer(), config.charset());
     }
 
     /**
@@ -63,7 +65,7 @@ public class JsonPathConfig {
      */
     public JsonPathConfig() {
         this(FLOAT_AND_DOUBLE, null, new DefaultGsonObjectMapperFactory(), new DefaultJackson1ObjectMapperFactory(),
-                new DefaultJackson2ObjectMapperFactory(), null, defaultCharset());
+                new DefaultJackson2ObjectMapperFactory(), new DefaultJohnzonObjectMapperFactory(), null, defaultCharset());
     }
 
 
@@ -72,7 +74,7 @@ public class JsonPathConfig {
      */
     public JsonPathConfig(NumberReturnType numberReturnType) {
         this(numberReturnType, null, new DefaultGsonObjectMapperFactory(), new DefaultJackson1ObjectMapperFactory(),
-                new DefaultJackson2ObjectMapperFactory(), null, defaultCharset());
+                new DefaultJackson2ObjectMapperFactory(), new DefaultJohnzonObjectMapperFactory(), null, defaultCharset());
 
     }
 
@@ -81,13 +83,13 @@ public class JsonPathConfig {
      */
     public JsonPathConfig(String defaultCharset) {
         this(FLOAT_AND_DOUBLE, null, new DefaultGsonObjectMapperFactory(), new DefaultJackson1ObjectMapperFactory(),
-                new DefaultJackson2ObjectMapperFactory(), null, defaultCharset);
+                new DefaultJackson2ObjectMapperFactory(), new DefaultJohnzonObjectMapperFactory(), null, defaultCharset);
 
     }
 
     private JsonPathConfig(NumberReturnType numberReturnType, JsonParserType parserType, GsonObjectMapperFactory gsonObjectMapperFactory,
                            Jackson1ObjectMapperFactory jackson1ObjectMapperFactory, Jackson2ObjectMapperFactory jackson2ObjectMapperFactory,
-                           JsonPathObjectDeserializer defaultDeserializer, String charset) {
+                           JohnzonObjectMapperFactory johnzonObjectMapperFactory, JsonPathObjectDeserializer defaultDeserializer, String charset) {
         if (numberReturnType == null) throw new IllegalArgumentException("numberReturnType cannot be null");
         charset = StringUtils.trimToNull(charset);
         if (charset == null) throw new IllegalArgumentException("Charset cannot be empty");
@@ -98,6 +100,7 @@ public class JsonPathConfig {
         this.gsonObjectMapperFactory = gsonObjectMapperFactory;
         this.jackson1ObjectMapperFactory = jackson1ObjectMapperFactory;
         this.jackson2ObjectMapperFactory = jackson2ObjectMapperFactory;
+        this.johnzonObjectMapperFactory = johnzonObjectMapperFactory;
     }
 
     private static String defaultCharset() {
@@ -116,7 +119,8 @@ public class JsonPathConfig {
      */
     public JsonPathConfig charset(String charset) {
         return new JsonPathConfig(numberReturnType, defaultParserType, gsonObjectMapperFactory,
-                jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, defaultDeserializer, charset);
+                jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, 
+                    johnzonObjectMapperFactory, defaultDeserializer, charset);
     }
 
 
@@ -132,7 +136,8 @@ public class JsonPathConfig {
      */
     public JsonPathConfig numberReturnType(NumberReturnType numberReturnType) {
         return new JsonPathConfig(numberReturnType, defaultParserType, gsonObjectMapperFactory,
-                jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, defaultDeserializer, charset);
+                jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, 
+                    johnzonObjectMapperFactory, defaultDeserializer, charset);
     }
 
     public boolean shouldRepresentJsonNumbersAsBigDecimal() {
@@ -159,6 +164,10 @@ public class JsonPathConfig {
         return jackson2ObjectMapperFactory() != null && jackson2ObjectMapperFactory().getClass() != DefaultJackson2ObjectMapperFactory.class;
     }
 
+    public boolean hasCustomJohnzonObjectMapperFactory() {
+        return johnzonObjectMapperFactory() != null && johnzonObjectMapperFactory().getClass() != DefaultJohnzonObjectMapperFactory.class;
+    }
+
     /**
      * Creates an json path configuration that uses the specified parser type as default.
      *
@@ -166,7 +175,8 @@ public class JsonPathConfig {
      */
     public JsonPathConfig defaultParserType(JsonParserType defaultParserType) {
         return new JsonPathConfig(numberReturnType, defaultParserType, gsonObjectMapperFactory,
-                jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, defaultDeserializer, charset);
+                jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, 
+                    johnzonObjectMapperFactory, defaultDeserializer, charset);
     }
 
     public JsonPathObjectDeserializer defaultDeserializer() {
@@ -184,7 +194,7 @@ public class JsonPathConfig {
      */
     public JsonPathConfig defaultObjectDeserializer(JsonPathObjectDeserializer defaultObjectDeserializer) {
         return new JsonPathConfig(numberReturnType, null, gsonObjectMapperFactory, jackson1ObjectMapperFactory,
-                jackson2ObjectMapperFactory, defaultObjectDeserializer, charset);
+                jackson2ObjectMapperFactory, johnzonObjectMapperFactory, defaultObjectDeserializer, charset);
     }
 
     public GsonObjectMapperFactory gsonObjectMapperFactory() {
@@ -198,7 +208,8 @@ public class JsonPathConfig {
      */
     public JsonPathConfig gsonObjectMapperFactory(GsonObjectMapperFactory gsonObjectMapperFactory) {
         return new JsonPathConfig(numberReturnType, defaultParserType, gsonObjectMapperFactory,
-                jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, defaultDeserializer, charset);
+                jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, 
+                    johnzonObjectMapperFactory, defaultDeserializer, charset);
     }
 
     public Jackson1ObjectMapperFactory jackson1ObjectMapperFactory() {
@@ -212,11 +223,16 @@ public class JsonPathConfig {
      */
     public JsonPathConfig jackson1ObjectMapperFactory(Jackson1ObjectMapperFactory jackson1ObjectMapperFactory) {
         return new JsonPathConfig(numberReturnType, defaultParserType, gsonObjectMapperFactory,
-                jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, defaultDeserializer, charset);
+                jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, 
+                    johnzonObjectMapperFactory, defaultDeserializer, charset);
     }
 
     public Jackson2ObjectMapperFactory jackson2ObjectMapperFactory() {
         return jackson2ObjectMapperFactory;
+    }
+    
+    public JohnzonObjectMapperFactory johnzonObjectMapperFactory() {
+        return johnzonObjectMapperFactory;
     }
 
     /**
@@ -226,7 +242,8 @@ public class JsonPathConfig {
      */
     public JsonPathConfig jackson2ObjectMapperFactory(Jackson2ObjectMapperFactory jackson2ObjectMapperFactory) {
         return new JsonPathConfig(numberReturnType, defaultParserType, gsonObjectMapperFactory,
-                jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, defaultDeserializer, charset);
+                jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, 
+                    johnzonObjectMapperFactory, defaultDeserializer, charset);
     }
 
     /**

--- a/json-path/src/main/java/io/restassured/path/json/mapper/factory/DefaultJohnzonObjectMapperFactory.java
+++ b/json-path/src/main/java/io/restassured/path/json/mapper/factory/DefaultJohnzonObjectMapperFactory.java
@@ -1,0 +1,19 @@
+package io.restassured.path.json.mapper.factory;
+
+import java.lang.reflect.Type;
+
+import org.apache.johnzon.mapper.Mapper;
+import org.apache.johnzon.mapper.MapperBuilder;
+
+/**
+ * Simply creates a new Mapper instance.
+ */
+public class DefaultJohnzonObjectMapperFactory implements JohnzonObjectMapperFactory {
+	@Override
+	public Mapper create(Type cls, String charset) {
+	    return new MapperBuilder()
+            .setAccessModeName("field")
+            .setSupportHiddenAccess(true)
+            .build();
+	}
+}

--- a/json-path/src/main/java/io/restassured/path/json/mapper/factory/JohnzonObjectMapperFactory.java
+++ b/json-path/src/main/java/io/restassured/path/json/mapper/factory/JohnzonObjectMapperFactory.java
@@ -1,0 +1,12 @@
+package io.restassured.path.json.mapper.factory;
+
+import org.apache.johnzon.mapper.Mapper;
+
+import io.restassured.common.mapper.factory.ObjectMapperFactory;
+
+/**
+ * Interface for Johnzon object mappers. Implement this class and register it to the ObjectMapperConfig if you
+ * want to override default settings for the Gson object mapper.
+ */
+public interface JohnzonObjectMapperFactory extends ObjectMapperFactory<Mapper> {
+}

--- a/json-path/src/test/java/io/restassured/path/json/JsonPathBuiltinObjectDeserializationTest.java
+++ b/json-path/src/test/java/io/restassured/path/json/JsonPathBuiltinObjectDeserializationTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.restassured.path.json;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import io.restassured.path.json.config.JsonParserType;
+import io.restassured.path.json.config.JsonPathConfig;
+import io.restassured.path.json.support.Greeting;
+
+@RunWith(Parameterized.class)
+public class JsonPathBuiltinObjectDeserializationTest {
+    private static final String GREETING = "{ \"greeting\" : { \n" +
+            "                \"firstName\" : \"John\", \n" +
+            "                \"lastName\" : \"Doe\" \n" +
+            "               }\n" +
+            "}";
+
+    private static final String GREETINGS = "{ \"greeting\" : [{ \n" +
+            "                \"firstName\" : \"John\", \n" +
+            "                \"lastName\" : \"Doe\" \n" +
+            "                }, { \n" +
+            "                \"firstName\" : \"Tom\", \n" +
+            "                \"lastName\" : \"Smith\" \n" +
+            "               }]\n" +
+            "}";
+
+    private final JsonParserType parserType;
+    
+    public JsonPathBuiltinObjectDeserializationTest(JsonParserType parserType) {
+    	this.parserType = parserType;
+    }
+
+    @Parameters
+    public static JsonParserType[] data() {
+        return JsonParserType.values();
+    }
+
+    @Test public void
+    json_path_supports_buitin_deserializers() {
+        final JsonPath jsonPath = new JsonPath(GREETING)
+        	.using(new JsonPathConfig().defaultParserType(parserType));
+
+        // When
+        final Greeting greeting = jsonPath.getObject("greeting", Greeting.class);
+
+        // Then
+        assertThat(greeting.getFirstName(), equalTo("John"));
+        assertThat(greeting.getLastName(), equalTo("Doe"));
+    }
+    
+    @Test public void
+    json_path_supports_buitin_deserializers_with_arrays() {
+        final JsonPath jsonPath = new JsonPath(GREETINGS)
+        	.using(new JsonPathConfig().defaultParserType(parserType));
+
+        // When
+        final Greeting[] greeting = jsonPath.getObject("greeting", Greeting[].class);
+
+        // Then
+        assertThat(greeting.length, equalTo(2));
+        assertThat(greeting[0].getFirstName(), equalTo("John"));
+        assertThat(greeting[0].getLastName(), equalTo("Doe"));
+        assertThat(greeting[1].getFirstName(), equalTo("Tom"));
+        assertThat(greeting[1].getLastName(), equalTo("Smith"));
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,8 @@
         <hamcrest.version>1.3</hamcrest.version>
         <jackson1.version>1.9.11</jackson1.version>
         <jackson2.version>2.9.8</jackson2.version>
+        <johnzon.version>1.1.11</johnzon.version>
+        <javax.json.version>1.1.4</javax.json.version>
         <maven-javadoc.version>2.9.1</maven-javadoc.version>
         <surefire.version>2.22.0</surefire.version>
     </properties>
@@ -369,6 +371,16 @@
                 <groupId>org.codehaus.jackson</groupId>
                 <artifactId>jackson-mapper-asl</artifactId>
                 <version>${jackson1.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.johnzon</groupId>
+                <artifactId>johnzon-mapper</artifactId>
+                <version>${johnzon.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.json</groupId>
+                <artifactId>javax.json-api</artifactId>
+                <version>${javax.json.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.code.gson</groupId>

--- a/rest-assured-common/src/main/java/io/restassured/common/mapper/resolver/ObjectMapperResolver.java
+++ b/rest-assured-common/src/main/java/io/restassured/common/mapper/resolver/ObjectMapperResolver.java
@@ -23,6 +23,7 @@ public class ObjectMapperResolver {
     private static final boolean isJackson2Present = existInCP("com.fasterxml.jackson.databind.ObjectMapper") && existInCP("com.fasterxml.jackson.core.JsonGenerator");
     private static final boolean isJaxbPresent = existInCP("javax.xml.bind.Binder");
     private static final boolean isGsonPresent = existInCP("com.google.gson.Gson");
+    private static final boolean isJohnzonPresent = existInCP("org.apache.johnzon.mapper.Mapper");
 
     public static boolean isJackson1InClassPath() {
         return isJackson1Present;
@@ -38,5 +39,9 @@ public class ObjectMapperResolver {
 
     public static boolean isGsonInClassPath() {
         return isGsonPresent;
+    }
+    
+    public static boolean isJohnzonInClassPath() {
+        return isJohnzonPresent;
     }
 }

--- a/rest-assured/pom.xml
+++ b/rest-assured/pom.xml
@@ -145,6 +145,16 @@
             <artifactId>json-simple</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.apache.johnzon</groupId>
+            <artifactId>johnzon-mapper</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>javax.json</groupId>
+            <artifactId>javax.json-api</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>junit</groupId>

--- a/rest-assured/src/main/groovy/io/restassured/internal/mapping/JohnzonMapper.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/mapping/JohnzonMapper.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.restassured.internal.mapping
+
+import io.restassured.internal.path.json.mapping.JsonPathJohnzonObjectDeserializer
+import io.restassured.mapper.ObjectMapper
+import io.restassured.mapper.ObjectMapperDeserializationContext
+import io.restassured.mapper.ObjectMapperSerializationContext
+import io.restassured.path.json.mapper.factory.JohnzonObjectMapperFactory
+import io.restassured.path.json.mapping.JsonPathObjectDeserializer
+
+class JohnzonMapper implements ObjectMapper {
+	private JohnzonObjectMapperFactory factory;
+	
+	private JsonPathObjectDeserializer deserializer
+
+	public JohnzonMapper(JohnzonObjectMapperFactory factory) {
+		this.factory = factory
+		deserializer = new JsonPathJohnzonObjectDeserializer(factory)
+	}
+
+	def Object deserialize(ObjectMapperDeserializationContext context) {
+		return deserializer.deserialize(context);
+	}
+
+	def Object serialize(ObjectMapperSerializationContext context) {
+		def object = context.getObjectToSerialize();
+		def mapper = factory.create(object.getClass(), context.getCharset())
+		
+		new StringWriter().withWriter { out ->
+			mapper.writeObject(context.getObjectToSerialize(), out)
+			out.toString();
+		}
+	}
+
+}

--- a/rest-assured/src/main/groovy/io/restassured/internal/mapping/ObjectMapping.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/mapping/ObjectMapping.groovy
@@ -29,6 +29,7 @@ import io.restassured.path.json.mapper.factory.GsonObjectMapperFactory
 import io.restassured.path.xml.mapper.factory.JAXBObjectMapperFactory
 import io.restassured.path.json.mapper.factory.Jackson1ObjectMapperFactory
 import io.restassured.path.json.mapper.factory.Jackson2ObjectMapperFactory
+import io.restassured.path.json.mapper.factory.JohnzonObjectMapperFactory
 import io.restassured.response.ResponseBodyData
 import org.apache.commons.lang3.Validate
 
@@ -59,6 +60,8 @@ class ObjectMapping {
         return parseWithJackson1(deserializationCtx, objectMapperConfig.jackson1ObjectMapperFactory()) as T
       } else if (isGsonInClassPath()) {
         return parseWithGson(deserializationCtx, objectMapperConfig.gsonObjectMapperFactory()) as T
+      } else if (isJohnzonInClassPath()) {
+        return parseWithJohnzon(deserializationCtx, objectMapperConfig.johnzonObjectMapperFactory()) as T
       }
       throw new IllegalStateException("Cannot parse object because no JSON deserializer found in classpath. Please put either Jackson (Databind) or Gson in the classpath.")
     } else if (containsIgnoreCase(contentType, "xml")) {
@@ -74,7 +77,9 @@ class ObjectMapping {
           return parseWithJackson1(deserializationCtx, objectMapperConfig.jackson1ObjectMapperFactory()) as T
         } else if (isGsonInClassPath()) {
           return parseWithGson(deserializationCtx, objectMapperConfig.gsonObjectMapperFactory()) as T
-        }
+		} else if (isJohnzonInClassPath()) {
+			return parseWithJohnzon(deserializationCtx, objectMapperConfig.johnzonObjectMapperFactory()) as T
+		}
       } else if (containsIgnoreCase(defaultContentType, "xml")) {
         if (isJAXBInClassPath()) {
           return parseWithJaxb(deserializationCtx, objectMapperConfig.jaxbObjectMapperFactory()) as T
@@ -94,6 +99,8 @@ class ObjectMapping {
       return parseWithGson(ctx, config.gsonObjectMapperFactory()) as T
     } else if (mapperType == ObjectMapperType.JAXB && isJAXBInClassPath()) {
       return parseWithJaxb(ctx, config.jaxbObjectMapperFactory()) as T
+    } else if (mapperType == ObjectMapperType.JOHNZON && isJohnzonInClassPath()) {
+      return parseWithJohnzon(ctx, config.johnzonObjectMapperFactory()) as T
     } else {
       def lowerCase = mapperType.toString().toLowerCase()
       throw new IllegalArgumentException("Cannot map response body with mapper $mapperType because $lowerCase doesn't exist in the classpath.")
@@ -123,6 +130,8 @@ class ObjectMapping {
         return serializeWithGson(serializationCtx, config.gsonObjectMapperFactory())
       } else if (isJAXBInClassPath()) {
         return serializeWithJaxb(serializationCtx, config.jaxbObjectMapperFactory())
+      } else if (isJohnzonInClassPath()) {
+        return serializeWithJohnzon(serializationCtx, config.johnzonObjectMapperFactory())
       }
       throw new IllegalArgumentException("Cannot serialize because no JSON or XML serializer found in classpath.")
     } else {
@@ -134,6 +143,8 @@ class ObjectMapping {
           return serializeWithJackson1(serializationCtx, config.jackson1ObjectMapperFactory())
         } else if (isGsonInClassPath()) {
           return serializeWithGson(serializationCtx, config.gsonObjectMapperFactory())
+        } else if (isJohnzonInClassPath()) {
+          return serializeWithJohnzon(serializationCtx, config.johnzonObjectMapperFactory())
         }
         throw new IllegalStateException("Cannot serialize object because no JSON serializer found in classpath. Please put either Jackson (Databind) or Gson in the classpath.")
       } else if (containsIgnoreCase(ct, "xml") || encoderConfig.contentEncoders().get(ContentTypeExtractor.getContentTypeWithoutCharset(ct)) == ContentType.XML) {
@@ -165,6 +176,8 @@ class ObjectMapping {
       return serializeWithGson(ctx, config.gsonObjectMapperFactory())
     } else if (mapperType == ObjectMapperType.JAXB && isJAXBInClassPath()) {
       return serializeWithJaxb(ctx, config.jaxbObjectMapperFactory())
+    } else if (mapperType == ObjectMapperType.JOHNZON && isJohnzonInClassPath()) {
+      return serializeWithJohnzon(ctx, config.johnzonObjectMapperFactory())
     } else {
       def lowerCase = mapperType.toString().toLowerCase()
       throw new IllegalArgumentException("Cannot serialize object with mapper $mapperType because $lowerCase doesn't exist in the classpath.")
@@ -188,6 +201,10 @@ class ObjectMapping {
     new JaxbMapper(factory).serialize(ctx)
   }
 
+  private static String serializeWithJohnzon(ObjectMapperSerializationContext ctx, JohnzonObjectMapperFactory factory) {
+    new JohnzonMapper(factory).serialize(ctx)
+  }
+	
   private static def parseWithJaxb(ObjectMapperDeserializationContext ctx, JAXBObjectMapperFactory factory) {
     new JaxbMapper(factory).deserialize(ctx)
   }
@@ -204,6 +221,10 @@ class ObjectMapping {
     new Jackson2Mapper(factory).deserialize(ctx)
   }
 
+  static def parseWithJohnzon(ObjectMapperDeserializationContext ctx, JohnzonObjectMapperFactory factory) {
+    new JohnzonMapper(factory).deserialize(ctx)
+  }
+	
   private static ObjectMapperDeserializationContext deserializationContext(ResponseBodyData responseData, Type cls, contentType, charset) {
     def ctx = new ObjectMapperDeserializationContextImpl()
     ctx.type = cls

--- a/rest-assured/src/main/java/io/restassured/config/ObjectMapperConfig.java
+++ b/rest-assured/src/main/java/io/restassured/config/ObjectMapperConfig.java
@@ -21,9 +21,11 @@ import io.restassured.mapper.ObjectMapperType;
 import io.restassured.path.json.mapper.factory.DefaultGsonObjectMapperFactory;
 import io.restassured.path.json.mapper.factory.DefaultJackson1ObjectMapperFactory;
 import io.restassured.path.json.mapper.factory.DefaultJackson2ObjectMapperFactory;
+import io.restassured.path.json.mapper.factory.DefaultJohnzonObjectMapperFactory;
 import io.restassured.path.json.mapper.factory.GsonObjectMapperFactory;
 import io.restassured.path.json.mapper.factory.Jackson1ObjectMapperFactory;
 import io.restassured.path.json.mapper.factory.Jackson2ObjectMapperFactory;
+import io.restassured.path.json.mapper.factory.JohnzonObjectMapperFactory;
 import io.restassured.path.xml.mapper.factory.*;
 
 import org.apache.commons.lang3.Validate;
@@ -39,6 +41,7 @@ public class ObjectMapperConfig implements Config {
     private final Jackson1ObjectMapperFactory jackson1ObjectMapperFactory;
     private final Jackson2ObjectMapperFactory jackson2ObjectMapperFactory;
     private final JAXBObjectMapperFactory jaxbObjectMapperFactory;
+    private final JohnzonObjectMapperFactory johnzonObjectMapperFactory;
     private final boolean isUserConfigured;
 
     /**
@@ -54,6 +57,7 @@ public class ObjectMapperConfig implements Config {
         jackson1ObjectMapperFactory = new DefaultJackson1ObjectMapperFactory();
         jackson2ObjectMapperFactory = new DefaultJackson2ObjectMapperFactory();
         jaxbObjectMapperFactory = new DefaultJAXBObjectMapperFactory();
+        johnzonObjectMapperFactory = new DefaultJohnzonObjectMapperFactory();
         isUserConfigured = false;
     }
 
@@ -64,7 +68,8 @@ public class ObjectMapperConfig implements Config {
      */
     public ObjectMapperConfig(ObjectMapperType defaultObjectMapperType) {
         this(null, defaultObjectMapperType, new DefaultGsonObjectMapperFactory(), new DefaultJackson1ObjectMapperFactory(),
-                new DefaultJackson2ObjectMapperFactory(), new DefaultJAXBObjectMapperFactory(), true);
+                new DefaultJackson2ObjectMapperFactory(), new DefaultJAXBObjectMapperFactory(), 
+                    new DefaultJohnzonObjectMapperFactory(), true);
     }
 
     /**
@@ -74,13 +79,14 @@ public class ObjectMapperConfig implements Config {
      */
     public ObjectMapperConfig(ObjectMapper defaultObjectMapper) {
         this(defaultObjectMapper, null, new DefaultGsonObjectMapperFactory(), new DefaultJackson1ObjectMapperFactory(),
-                new DefaultJackson2ObjectMapperFactory(), new DefaultJAXBObjectMapperFactory(), true);
+                new DefaultJackson2ObjectMapperFactory(), new DefaultJAXBObjectMapperFactory(), 
+                    new DefaultJohnzonObjectMapperFactory(), true);
     }
 
     private ObjectMapperConfig(ObjectMapper defaultObjectMapper, ObjectMapperType defaultObjectMapperType,
                                GsonObjectMapperFactory gsonObjectMapperFactory, Jackson1ObjectMapperFactory jackson1ObjectMapperFactory,
                                Jackson2ObjectMapperFactory jackson2ObjectMapperFactory, JAXBObjectMapperFactory jaxbObjectMapperFactory,
-                               boolean isUserConfigured) {
+                               JohnzonObjectMapperFactory johnzonObjectMapperFactory, boolean isUserConfigured) {
         Validate.notNull(gsonObjectMapperFactory, GsonObjectMapperFactory.class.getSimpleName() + " cannot be null");
         Validate.notNull(jackson1ObjectMapperFactory, Jackson1ObjectMapperFactory.class.getSimpleName() + " cannot be null");
         Validate.notNull(jackson2ObjectMapperFactory, Jackson2ObjectMapperFactory.class.getSimpleName() + " cannot be null");
@@ -91,6 +97,7 @@ public class ObjectMapperConfig implements Config {
         this.jackson1ObjectMapperFactory = jackson1ObjectMapperFactory;
         this.jackson2ObjectMapperFactory = jackson2ObjectMapperFactory;
         this.jaxbObjectMapperFactory = jaxbObjectMapperFactory;
+        this.johnzonObjectMapperFactory = johnzonObjectMapperFactory;
         this.isUserConfigured = isUserConfigured;
     }
 
@@ -109,7 +116,8 @@ public class ObjectMapperConfig implements Config {
      */
     public ObjectMapperConfig defaultObjectMapperType(ObjectMapperType defaultObjectMapperType) {
         return new ObjectMapperConfig(defaultObjectMapper, defaultObjectMapperType, gsonObjectMapperFactory,
-                jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, jaxbObjectMapperFactory, true);
+                jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, jaxbObjectMapperFactory, 
+                    johnzonObjectMapperFactory, true);
     }
 
     public ObjectMapper defaultObjectMapper() {
@@ -140,7 +148,8 @@ public class ObjectMapperConfig implements Config {
      */
     public ObjectMapperConfig gsonObjectMapperFactory(GsonObjectMapperFactory gsonObjectMapperFactory) {
         return new ObjectMapperConfig(defaultObjectMapper, defaultObjectMapperType, gsonObjectMapperFactory,
-                jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, jaxbObjectMapperFactory, true);
+                jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, jaxbObjectMapperFactory, 
+                    johnzonObjectMapperFactory, true);
     }
 
     public Jackson1ObjectMapperFactory jackson1ObjectMapperFactory() {
@@ -154,7 +163,8 @@ public class ObjectMapperConfig implements Config {
      */
     public ObjectMapperConfig jackson1ObjectMapperFactory(Jackson1ObjectMapperFactory jackson1ObjectMapperFactory) {
         return new ObjectMapperConfig(defaultObjectMapper, defaultObjectMapperType, gsonObjectMapperFactory,
-                jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, jaxbObjectMapperFactory, true);
+                jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, jaxbObjectMapperFactory, 
+                    johnzonObjectMapperFactory, true);
     }
 
     public Jackson2ObjectMapperFactory jackson2ObjectMapperFactory() {
@@ -168,11 +178,16 @@ public class ObjectMapperConfig implements Config {
      */
     public ObjectMapperConfig jackson2ObjectMapperFactory(Jackson2ObjectMapperFactory jackson2ObjectMapperFactory) {
         return new ObjectMapperConfig(defaultObjectMapper, defaultObjectMapperType, gsonObjectMapperFactory,
-                jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, jaxbObjectMapperFactory, true);
+                jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, jaxbObjectMapperFactory, 
+                   johnzonObjectMapperFactory, true);
     }
 
     public JAXBObjectMapperFactory jaxbObjectMapperFactory() {
         return jaxbObjectMapperFactory;
+    }
+    
+    public JohnzonObjectMapperFactory johnzonObjectMapperFactory() {
+        return johnzonObjectMapperFactory;
     }
 
     /**
@@ -182,7 +197,8 @@ public class ObjectMapperConfig implements Config {
      */
     public ObjectMapperConfig jaxbObjectMapperFactory(JAXBObjectMapperFactory jaxbObjectMapperFactory) {
         return new ObjectMapperConfig(defaultObjectMapper, defaultObjectMapperType, gsonObjectMapperFactory,
-                jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, jaxbObjectMapperFactory, true);
+                jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, jaxbObjectMapperFactory, 
+                    johnzonObjectMapperFactory, true);
     }
 
     /**

--- a/rest-assured/src/main/java/io/restassured/mapper/ObjectMapperType.java
+++ b/rest-assured/src/main/java/io/restassured/mapper/ObjectMapperType.java
@@ -20,5 +20,5 @@ package io.restassured.mapper;
  * The predefined object mappers that can be used with REST Assured
  */
 public enum ObjectMapperType {
-    JACKSON_2, JACKSON_1, GSON, JAXB
+    JACKSON_2, JACKSON_1, GSON, JAXB, JOHNZON
 }


### PR DESCRIPTION
Hey guys!

I would like to resume https://github.com/rest-assured/rest-assured/issues/526 and provide built in support  for `Apache Johnzon` (https://johnzon.apache.org/). 

> Apache Johnzon is a project providing an implementation of JsonProcessing (aka JSR-353) and a set of     useful extension for this specification like an Object mapper, some JAX-RS providers and a WebSocket module provides a basic integration with Java WebSocket API (JSR-356).

This PR adds integration with `Apache Johnzon 1.1.11`.
Thank you! 