### PR TITLE
#1129: Supported for logging when thrown assertion errors from matcher internal

### DIFF
--- a/rest-assured/src/main/groovy/io/restassured/internal/ResponseSpecificationImpl.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/ResponseSpecificationImpl.groovy
@@ -480,7 +480,7 @@ class ResponseSpecificationImpl implements FilterableResponseSpecification {
             }
             validations.addAll(bodyMatchers.validate(response, contentParser, cfg))
           }
-        } catch (Exception e) {
+        } catch (Throwable e) {
           fireFailureListeners(response)
           throw e;
         }


### PR DESCRIPTION
Hi :)

Not logged when matcher throws AssertionError. #1129 
it had caught only `Exception` and i changed to catch `Throwable`

I added test code that case. if you could review this PR then I appreciate it.
Thank you for your effort. :D