### PR TITLE
Improved OSGi support

### DIFF
--- a/examples/rest-assured-itest-java-osgi/src/test/java/io/restassured/test/osgi/JsonPathOSGiITest.java
+++ b/examples/rest-assured-itest-java-osgi/src/test/java/io/restassured/test/osgi/JsonPathOSGiITest.java
@@ -52,9 +52,15 @@ public class JsonPathOSGiITest {
                         Some of these need to be wrapped because they are not available as OSGi bundles */
                         mavenBundle("org.apache.commons", "commons-lang3").versionAsInProject(),
                         wrappedBundle(mavenBundle().groupId("org.codehaus.groovy").artifactId("groovy-all").version("2.4.15")),
+                        wrappedBundle(mavenBundle("javax.xml.bind", "jaxb-api").versionAsInProject()),
+                        wrappedBundle(mavenBundle("org.apache.httpcomponents", "httpclient").versionAsInProject()),
+                        wrappedBundle(mavenBundle("org.apache.httpcomponents", "httpmime").versionAsInProject()),
+                        wrappedBundle(mavenBundle("org.apache.httpcomponents", "httpcore").versionAsInProject()),
+                        wrappedBundle(mavenBundle().groupId("org.ccil.cowan.tagsoup").artifactId("tagsoup").versionAsInProject()),
 
                         /* Rest Assured dependencies needed in the Pax Exam container to be able to execute the tests below */
                         mavenBundle("io.rest-assured", "json-path").versionAsInProject(),
+                        mavenBundle("io.rest-assured", "rest-assured").versionAsInProject(),
                         mavenBundle("io.rest-assured", "rest-assured-common").versionAsInProject()
                 };
     }

--- a/examples/rest-assured-itest-java-osgi/src/test/java/io/restassured/test/osgi/JsonPathOSGiITest.java
+++ b/examples/rest-assured-itest-java-osgi/src/test/java/io/restassured/test/osgi/JsonPathOSGiITest.java
@@ -60,6 +60,7 @@ public class JsonPathOSGiITest {
 
                         /* Rest Assured dependencies needed in the Pax Exam container to be able to execute the tests below */
                         mavenBundle("io.rest-assured", "json-path").versionAsInProject(),
+                        mavenBundle("io.rest-assured", "xml-path").versionAsInProject(),
                         mavenBundle("io.rest-assured", "rest-assured").versionAsInProject(),
                         mavenBundle("io.rest-assured", "rest-assured-common").versionAsInProject()
                 };

--- a/examples/rest-assured-itest-java-osgi/src/test/java/io/restassured/test/osgi/RestAssuredOSGiITest.java
+++ b/examples/rest-assured-itest-java-osgi/src/test/java/io/restassured/test/osgi/RestAssuredOSGiITest.java
@@ -57,7 +57,10 @@ public class RestAssuredOSGiITest {
                         wrappedBundle(mavenBundle().groupId("org.codehaus.groovy").artifactId("groovy-all").version("2.4.15")),
 
                         /* Rest Assured dependencie needed in the Pax Exam container to be able to execute the test below */
-                        mavenBundle("io.rest-assured", "rest-assured").versionAsInProject()
+                        mavenBundle("io.rest-assured", "json-path").versionAsInProject(),
+                        mavenBundle("io.rest-assured", "xml-path").versionAsInProject(),
+                        mavenBundle("io.rest-assured", "rest-assured").versionAsInProject(),
+                        mavenBundle("io.rest-assured", "rest-assured-common").versionAsInProject()
                 };
     }
 

--- a/examples/rest-assured-itest-java-osgi/src/test/java/io/restassured/test/osgi/XmlPathOSGiITest.java
+++ b/examples/rest-assured-itest-java-osgi/src/test/java/io/restassured/test/osgi/XmlPathOSGiITest.java
@@ -54,9 +54,13 @@ public class XmlPathOSGiITest {
                         wrappedBundle(mavenBundle("javax.xml.bind", "jaxb-api").versionAsInProject()),
                         wrappedBundle(mavenBundle("javax.activation", "activation").version("1.1.1")),
                         wrappedBundle(mavenBundle().groupId("org.codehaus.groovy").artifactId("groovy-all").version("2.4.15")),
+                        wrappedBundle(mavenBundle("org.apache.httpcomponents", "httpclient").versionAsInProject()),
+                        wrappedBundle(mavenBundle("org.apache.httpcomponents", "httpmime").versionAsInProject()),
+                        wrappedBundle(mavenBundle("org.apache.httpcomponents", "httpcore").versionAsInProject()),
 
                         /* Rest Assured dependencies needed in the Pax Exam container to be able to execute the tests below */
                         mavenBundle("io.rest-assured", "xml-path").versionAsInProject(),
+                        mavenBundle("io.rest-assured", "rest-assured").versionAsInProject(),
                         mavenBundle("io.rest-assured", "rest-assured-common").versionAsInProject()
                 };
     }

--- a/examples/rest-assured-itest-java-osgi/src/test/java/io/restassured/test/osgi/XmlPathOSGiITest.java
+++ b/examples/rest-assured-itest-java-osgi/src/test/java/io/restassured/test/osgi/XmlPathOSGiITest.java
@@ -59,6 +59,7 @@ public class XmlPathOSGiITest {
                         wrappedBundle(mavenBundle("org.apache.httpcomponents", "httpcore").versionAsInProject()),
 
                         /* Rest Assured dependencies needed in the Pax Exam container to be able to execute the tests below */
+                        mavenBundle("io.rest-assured", "json-path").versionAsInProject(),
                         mavenBundle("io.rest-assured", "xml-path").versionAsInProject(),
                         mavenBundle("io.rest-assured", "rest-assured").versionAsInProject(),
                         mavenBundle("io.rest-assured", "rest-assured-common").versionAsInProject()

--- a/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/CustomObjectMappingITest.java
+++ b/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/CustomObjectMappingITest.java
@@ -26,7 +26,8 @@ import io.restassured.itest.java.support.WithJetty;
 import io.restassured.mapper.ObjectMapper;
 import io.restassured.mapper.ObjectMapperDeserializationContext;
 import io.restassured.mapper.ObjectMapperSerializationContext;
-import io.restassured.mapper.factory.GsonObjectMapperFactory;
+import io.restassured.path.json.mapper.factory.GsonObjectMapperFactory;
+
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.Test;

--- a/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/GivenWhenThenExtractITest.java
+++ b/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/GivenWhenThenExtractITest.java
@@ -16,8 +16,8 @@
 
 package io.restassured.itest.java;
 
+import io.restassured.common.mapper.TypeRef;
 import io.restassured.itest.java.support.WithJetty;
-import io.restassured.mapper.TypeRef;
 import io.restassured.response.Response;
 import org.junit.Test;
 

--- a/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/MultiPartUploadITest.java
+++ b/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/MultiPartUploadITest.java
@@ -28,7 +28,7 @@ import io.restassured.itest.java.objects.Message;
 import io.restassured.itest.java.support.MyEnum;
 import io.restassured.itest.java.support.WithJetty;
 import io.restassured.mapper.ObjectMapperType;
-import io.restassured.mapper.factory.DefaultJackson2ObjectMapperFactory;
+import io.restassured.path.json.mapper.factory.DefaultJackson2ObjectMapperFactory;
 import io.restassured.specification.RequestSpecification;
 import org.apache.commons.io.IOUtils;
 import org.junit.Rule;

--- a/json-path/pom.xml
+++ b/json-path/pom.xml
@@ -44,7 +44,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <Export-Package>io.restassured.mapper.*, io.restassured.path.json.*</Export-Package>
+                        <Export-Package>io.restassured.path.json.*</Export-Package>
                         <Import-Package>
 							groovy.*;version="${groovy.range}",
                             org.codehaus.groovy.*;version="${groovy.range}",

--- a/json-path/pom.xml
+++ b/json-path/pom.xml
@@ -44,13 +44,12 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <Export-Package>io.restassured.*</Export-Package>
+                        <Export-Package>io.restassured.mapper.*, io.restassured.path.json.*</Export-Package>
                         <Import-Package>
 							groovy.*;version="${groovy.range}",
                             org.codehaus.groovy.*;version="${groovy.range}",
                             *
 						</Import-Package>
-                        <Private-Package />
                     </instructions>
                 </configuration>
             </plugin>

--- a/json-path/src/main/groovy/io/restassured/internal/path/json/mapping/JsonObjectDeserializer.groovy
+++ b/json-path/src/main/groovy/io/restassured/internal/path/json/mapping/JsonObjectDeserializer.groovy
@@ -20,12 +20,12 @@
 package io.restassured.internal.path.json.mapping
 
 import io.restassured.internal.mapper.ObjectDeserializationContextImpl
-import io.restassured.mapper.DataToDeserialize
-import io.restassured.mapper.ObjectDeserializationContext
-import io.restassured.mapper.factory.GsonObjectMapperFactory
-import io.restassured.mapper.factory.Jackson1ObjectMapperFactory
-import io.restassured.mapper.factory.Jackson2ObjectMapperFactory
-import io.restassured.mapper.resolver.ObjectMapperResolver
+import io.restassured.common.mapper.DataToDeserialize
+import io.restassured.common.mapper.ObjectDeserializationContext
+import io.restassured.path.json.mapper.factory.GsonObjectMapperFactory
+import io.restassured.path.json.mapper.factory.Jackson1ObjectMapperFactory
+import io.restassured.path.json.mapper.factory.Jackson2ObjectMapperFactory
+import io.restassured.common.mapper.resolver.ObjectMapperResolver
 import io.restassured.path.json.config.JsonParserType
 import io.restassured.path.json.config.JsonPathConfig
 import org.apache.commons.lang3.Validate

--- a/json-path/src/main/groovy/io/restassured/internal/path/json/mapping/JsonPathGsonObjectDeserializer.groovy
+++ b/json-path/src/main/groovy/io/restassured/internal/path/json/mapping/JsonPathGsonObjectDeserializer.groovy
@@ -20,8 +20,8 @@
 
 package io.restassured.internal.path.json.mapping
 
-import io.restassured.mapper.ObjectDeserializationContext
-import io.restassured.mapper.factory.GsonObjectMapperFactory
+import io.restassured.common.mapper.ObjectDeserializationContext
+import io.restassured.path.json.mapper.factory.GsonObjectMapperFactory
 import io.restassured.path.json.mapping.JsonPathObjectDeserializer
 
 import static io.restassured.internal.assertion.AssertParameter.notNull

--- a/json-path/src/main/groovy/io/restassured/internal/path/json/mapping/JsonPathJackson1ObjectDeserializer.groovy
+++ b/json-path/src/main/groovy/io/restassured/internal/path/json/mapping/JsonPathJackson1ObjectDeserializer.groovy
@@ -18,8 +18,8 @@
 
 package io.restassured.internal.path.json.mapping
 
-import io.restassured.mapper.ObjectDeserializationContext
-import io.restassured.mapper.factory.Jackson1ObjectMapperFactory
+import io.restassured.common.mapper.ObjectDeserializationContext
+import io.restassured.path.json.mapper.factory.Jackson1ObjectMapperFactory
 import io.restassured.path.json.mapping.JsonPathObjectDeserializer
 import org.codehaus.jackson.type.JavaType
 

--- a/json-path/src/main/groovy/io/restassured/internal/path/json/mapping/JsonPathJackson2ObjectDeserializer.groovy
+++ b/json-path/src/main/groovy/io/restassured/internal/path/json/mapping/JsonPathJackson2ObjectDeserializer.groovy
@@ -20,8 +20,8 @@ package io.restassured.internal.path.json.mapping
 
 import com.fasterxml.jackson.databind.JavaType
 import com.fasterxml.jackson.databind.ObjectMapper
-import io.restassured.mapper.ObjectDeserializationContext
-import io.restassured.mapper.factory.Jackson2ObjectMapperFactory
+import io.restassured.common.mapper.ObjectDeserializationContext
+import io.restassured.path.json.mapper.factory.Jackson2ObjectMapperFactory
 import io.restassured.path.json.mapping.JsonPathObjectDeserializer
 
 import java.lang.reflect.Type

--- a/json-path/src/main/java/io/restassured/path/json/JsonPath.java
+++ b/json-path/src/main/java/io/restassured/path/json/JsonPath.java
@@ -18,19 +18,19 @@ package io.restassured.path.json;
 
 import groovy.json.JsonBuilder;
 import groovy.json.JsonOutput;
+import io.restassured.common.mapper.TypeRef;
 import io.restassured.internal.assertion.AssertParameter;
 import io.restassured.internal.path.ObjectConverter;
 import io.restassured.internal.path.json.ConfigurableJsonSlurper;
 import io.restassured.internal.path.json.JSONAssertion;
 import io.restassured.internal.path.json.JsonPrettifier;
 import io.restassured.internal.path.json.mapping.JsonObjectDeserializer;
-import io.restassured.mapper.TypeRef;
-import io.restassured.mapper.factory.GsonObjectMapperFactory;
-import io.restassured.mapper.factory.Jackson1ObjectMapperFactory;
-import io.restassured.mapper.factory.Jackson2ObjectMapperFactory;
 import io.restassured.path.json.config.JsonParserType;
 import io.restassured.path.json.config.JsonPathConfig;
 import io.restassured.path.json.exception.JsonPathException;
+import io.restassured.path.json.mapper.factory.GsonObjectMapperFactory;
+import io.restassured.path.json.mapper.factory.Jackson1ObjectMapperFactory;
+import io.restassured.path.json.mapper.factory.Jackson2ObjectMapperFactory;
 
 import java.io.*;
 import java.net.URL;

--- a/json-path/src/main/java/io/restassured/path/json/config/JsonPathConfig.java
+++ b/json-path/src/main/java/io/restassured/path/json/config/JsonPathConfig.java
@@ -16,7 +16,13 @@
 
 package io.restassured.path.json.config;
 
-import io.restassured.mapper.factory.*;
+import io.restassured.common.mapper.factory.*;
+import io.restassured.path.json.mapper.factory.DefaultGsonObjectMapperFactory;
+import io.restassured.path.json.mapper.factory.DefaultJackson1ObjectMapperFactory;
+import io.restassured.path.json.mapper.factory.DefaultJackson2ObjectMapperFactory;
+import io.restassured.path.json.mapper.factory.GsonObjectMapperFactory;
+import io.restassured.path.json.mapper.factory.Jackson1ObjectMapperFactory;
+import io.restassured.path.json.mapper.factory.Jackson2ObjectMapperFactory;
 import io.restassured.path.json.mapping.JsonPathObjectDeserializer;
 import org.apache.commons.lang3.StringUtils;
 

--- a/json-path/src/main/java/io/restassured/path/json/exception/JsonPathException.java
+++ b/json-path/src/main/java/io/restassured/path/json/exception/JsonPathException.java
@@ -16,7 +16,7 @@
 
 package io.restassured.path.json.exception;
 
-import io.restassured.exception.PathException;
+import io.restassured.common.exception.PathException;
 
 public class JsonPathException extends PathException {
 

--- a/json-path/src/main/java/io/restassured/path/json/mapper/factory/DefaultGsonObjectMapperFactory.java
+++ b/json-path/src/main/java/io/restassured/path/json/mapper/factory/DefaultGsonObjectMapperFactory.java
@@ -14,22 +14,17 @@
  * limitations under the License.
  */
 
-package io.restassured.mapper.factory;
+package io.restassured.path.json.mapper.factory;
+
+import com.google.gson.Gson;
 
 import java.lang.reflect.Type;
 
 /**
- * The base interface for object mapper factories.
- * @param <T> The type of the created object mapper.
+ * Simply creates a new Gson instance.
  */
-public interface ObjectMapperFactory<T> {
-
-    /**
-     * Create the object mapper instance.
-     *
-     * @param cls The type of the class to serialize or de-serialize
-     * @param charset The charset
-     * @return An object mapper instance
-     */
-    T create(Type cls, String charset);
+public class DefaultGsonObjectMapperFactory implements GsonObjectMapperFactory {
+    public Gson create(Type cls, String charset) {
+        return new Gson();
+    }
 }

--- a/json-path/src/main/java/io/restassured/path/json/mapper/factory/DefaultJackson1ObjectMapperFactory.java
+++ b/json-path/src/main/java/io/restassured/path/json/mapper/factory/DefaultJackson1ObjectMapperFactory.java
@@ -14,13 +14,17 @@
  * limitations under the License.
  */
 
-package io.restassured.mapper.factory;
+package io.restassured.path.json.mapper.factory;
 
 import org.codehaus.jackson.map.ObjectMapper;
 
+import java.lang.reflect.Type;
+
 /**
- * Interface for Jackson 1.0 based object mappers. Implement this class and register it to the ObjectMapperConfig if you
- * want to override default settings for the Jackson object mapper.
+ * Simply creates a new Jackson 1.0 ObjectMapper
  */
-public interface Jackson1ObjectMapperFactory extends ObjectMapperFactory<ObjectMapper> {
+public class DefaultJackson1ObjectMapperFactory implements Jackson1ObjectMapperFactory {
+    public ObjectMapper create(Type cls, String charset) {
+        return new ObjectMapper();
+    }
 }

--- a/json-path/src/main/java/io/restassured/path/json/mapper/factory/DefaultJackson2ObjectMapperFactory.java
+++ b/json-path/src/main/java/io/restassured/path/json/mapper/factory/DefaultJackson2ObjectMapperFactory.java
@@ -14,24 +14,18 @@
  * limitations under the License.
  */
 
-package io.restassured.mapper.factory;
+package io.restassured.path.json.mapper.factory;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.lang.reflect.Type;
 
 /**
- * Simply creates a new JAXBContext based on the supplied class.
+ * Simply creates a new Jackson 2.0 ObjectMapper
  */
-public class DefaultJAXBObjectMapperFactory implements JAXBObjectMapperFactory {
-    public JAXBContext create(Type cls, String charset) {
-        try {
-            if (cls instanceof Class) {
-                return JAXBContext.newInstance((Class<?>) cls);
-            }
-            throw new RuntimeException("JAXB does not support type" + cls);
-        } catch (JAXBException e) {
-            throw new RuntimeException(e);
-        }
+public class DefaultJackson2ObjectMapperFactory implements Jackson2ObjectMapperFactory {
+    public ObjectMapper create(Type cls, String charset) {
+        return new ObjectMapper().findAndRegisterModules();
     }
 }

--- a/json-path/src/main/java/io/restassured/path/json/mapper/factory/GsonObjectMapperFactory.java
+++ b/json-path/src/main/java/io/restassured/path/json/mapper/factory/GsonObjectMapperFactory.java
@@ -14,29 +14,15 @@
  * limitations under the License.
  */
 
-package io.restassured.mapper;
+package io.restassured.path.json.mapper.factory;
 
-import java.io.InputStream;
+import com.google.gson.Gson;
 
-public interface DataToDeserialize {
-    /**
-     * Get the data as a string.
-     *
-     * @return The data as a string.
-     */
-    String asString();
+import io.restassured.common.mapper.factory.ObjectMapperFactory;
 
-    /**
-     * Get the data as a byte array.
-     *
-     * @return The data as a array.
-     */
-    byte[] asByteArray();
-
-    /**
-     * Get the data as an input stream.
-     *
-     * @return The data as an input stream.
-     */
-    InputStream asInputStream();
+/**
+ * Interface for Gson object mappers. Implement this class and register it to the ObjectMapperConfig if you
+ * want to override default settings for the Gson object mapper.
+ */
+public interface GsonObjectMapperFactory extends ObjectMapperFactory<Gson> {
 }

--- a/json-path/src/main/java/io/restassured/path/json/mapper/factory/Jackson1ObjectMapperFactory.java
+++ b/json-path/src/main/java/io/restassured/path/json/mapper/factory/Jackson1ObjectMapperFactory.java
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 
-package io.restassured.mapper.factory;
+package io.restassured.path.json.mapper.factory;
 
-import javax.xml.bind.JAXBContext;
+import org.codehaus.jackson.map.ObjectMapper;
+
+import io.restassured.common.mapper.factory.ObjectMapperFactory;
 
 /**
- * Interface for JAXB object mappers. Implement this class and register it to the ObjectMapperConfig if you
- * want to override default settings for the JAXB object mapper.
+ * Interface for Jackson 1.0 based object mappers. Implement this class and register it to the ObjectMapperConfig if you
+ * want to override default settings for the Jackson object mapper.
  */
-public interface JAXBObjectMapperFactory extends ObjectMapperFactory<JAXBContext> {
+public interface Jackson1ObjectMapperFactory extends ObjectMapperFactory<ObjectMapper> {
 }

--- a/json-path/src/main/java/io/restassured/path/json/mapper/factory/Jackson2ObjectMapperFactory.java
+++ b/json-path/src/main/java/io/restassured/path/json/mapper/factory/Jackson2ObjectMapperFactory.java
@@ -14,11 +14,16 @@
  * limitations under the License.
  */
 
-package io.restassured.exception;
+package io.restassured.path.json.mapper.factory;
 
-public abstract class PathException extends RuntimeException {
 
-    public PathException(String message, Throwable cause) {
-        super(message, cause);
-    }
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.restassured.common.mapper.factory.ObjectMapperFactory;
+
+/**
+ * Interface for Jackson 2.0 based object mappers. Implement this class and register it to the ObjectMapperConfig if you
+ * want to override default settings for the Jackson 2.0 object mapper.
+ */
+public interface Jackson2ObjectMapperFactory extends ObjectMapperFactory<ObjectMapper> {
 }

--- a/json-path/src/main/java/io/restassured/path/json/mapping/JsonPathObjectDeserializer.java
+++ b/json-path/src/main/java/io/restassured/path/json/mapping/JsonPathObjectDeserializer.java
@@ -16,7 +16,7 @@
 
 package io.restassured.path.json.mapping;
 
-import io.restassured.mapper.ObjectDeserializationContext;
+import io.restassured.common.mapper.ObjectDeserializationContext;
 
 /**
  * Interface for all JsonPath object deserializers. It's possible to roll your own implementation if the pre-defined

--- a/json-path/src/test/java/io/restassured/path/json/JsonPathObjectDeserializationTest.java
+++ b/json-path/src/test/java/io/restassured/path/json/JsonPathObjectDeserializationTest.java
@@ -16,7 +16,7 @@
 
 package io.restassured.path.json;
 
-import io.restassured.mapper.ObjectDeserializationContext;
+import io.restassured.common.mapper.ObjectDeserializationContext;
 import io.restassured.path.json.config.JsonPathConfig;
 import io.restassured.path.json.mapping.JsonPathObjectDeserializer;
 import io.restassured.path.json.support.Greeting;

--- a/json-path/src/test/java/io/restassured/path/json/JsonPathTest.java
+++ b/json-path/src/test/java/io/restassured/path/json/JsonPathTest.java
@@ -16,7 +16,7 @@
 
 package io.restassured.path.json;
 
-import io.restassured.mapper.TypeRef;
+import io.restassured.common.mapper.TypeRef;
 import io.restassured.path.json.config.JsonPathConfig;
 import io.restassured.path.json.exception.JsonPathException;
 import io.restassured.path.json.support.Book;

--- a/rest-assured-common/pom.xml
+++ b/rest-assured-common/pom.xml
@@ -45,13 +45,12 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <Export-Package>io.restassured.*</Export-Package>
+                        <Export-Package>io.restassured.mapper.*, io.restassured.exception.*</Export-Package>
                         <Import-Package>
 							groovy.*;version="${groovy.range}",
                             org.codehaus.groovy.*;version="${groovy.range}",
                             *
 						</Import-Package>
-                        <Private-Package />
                     </instructions>
                 </configuration>
             </plugin>

--- a/rest-assured-common/pom.xml
+++ b/rest-assured-common/pom.xml
@@ -45,7 +45,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <Export-Package>io.restassured.mapper.*, io.restassured.exception.*</Export-Package>
+                        <Export-Package>io.restassured.common.*</Export-Package>
                         <Import-Package>
 							groovy.*;version="${groovy.range}",
                             org.codehaus.groovy.*;version="${groovy.range}",

--- a/rest-assured-common/src/main/groovy/io/restassured/internal/mapper/ObjectDeserializationContextImpl.groovy
+++ b/rest-assured-common/src/main/groovy/io/restassured/internal/mapper/ObjectDeserializationContextImpl.groovy
@@ -19,8 +19,8 @@
 
 package io.restassured.internal.mapper
 
-import io.restassured.mapper.DataToDeserialize
-import io.restassured.mapper.ObjectDeserializationContext
+import io.restassured.common.mapper.DataToDeserialize
+import io.restassured.common.mapper.ObjectDeserializationContext
 
 import java.lang.reflect.Type
 

--- a/rest-assured-common/src/main/java/io/restassured/common/exception/PathException.java
+++ b/rest-assured-common/src/main/java/io/restassured/common/exception/PathException.java
@@ -14,14 +14,11 @@
  * limitations under the License.
  */
 
-package io.restassured.mapper.factory;
+package io.restassured.common.exception;
 
+public abstract class PathException extends RuntimeException {
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-/**
- * Interface for Jackson 2.0 based object mappers. Implement this class and register it to the ObjectMapperConfig if you
- * want to override default settings for the Jackson 2.0 object mapper.
- */
-public interface Jackson2ObjectMapperFactory extends ObjectMapperFactory<ObjectMapper> {
+    public PathException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/rest-assured-common/src/main/java/io/restassured/common/mapper/DataToDeserialize.java
+++ b/rest-assured-common/src/main/java/io/restassured/common/mapper/DataToDeserialize.java
@@ -14,17 +14,29 @@
  * limitations under the License.
  */
 
-package io.restassured.mapper.factory;
+package io.restassured.common.mapper;
 
-import org.codehaus.jackson.map.ObjectMapper;
+import java.io.InputStream;
 
-import java.lang.reflect.Type;
+public interface DataToDeserialize {
+    /**
+     * Get the data as a string.
+     *
+     * @return The data as a string.
+     */
+    String asString();
 
-/**
- * Simply creates a new Jackson 1.0 ObjectMapper
- */
-public class DefaultJackson1ObjectMapperFactory implements Jackson1ObjectMapperFactory {
-    public ObjectMapper create(Type cls, String charset) {
-        return new ObjectMapper();
-    }
+    /**
+     * Get the data as a byte array.
+     *
+     * @return The data as a array.
+     */
+    byte[] asByteArray();
+
+    /**
+     * Get the data as an input stream.
+     *
+     * @return The data as an input stream.
+     */
+    InputStream asInputStream();
 }

--- a/rest-assured-common/src/main/java/io/restassured/common/mapper/ObjectDeserializationContext.java
+++ b/rest-assured-common/src/main/java/io/restassured/common/mapper/ObjectDeserializationContext.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.restassured.mapper;
+package io.restassured.common.mapper;
 
 import java.lang.reflect.Type;
 

--- a/rest-assured-common/src/main/java/io/restassured/common/mapper/TypeRef.java
+++ b/rest-assured-common/src/main/java/io/restassured/common/mapper/TypeRef.java
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.restassured.mapper;
+package io.restassured.common.mapper;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;

--- a/rest-assured-common/src/main/java/io/restassured/common/mapper/factory/ObjectMapperFactory.java
+++ b/rest-assured-common/src/main/java/io/restassured/common/mapper/factory/ObjectMapperFactory.java
@@ -14,18 +14,22 @@
  * limitations under the License.
  */
 
-package io.restassured.mapper.factory;
-
-
-import com.fasterxml.jackson.databind.ObjectMapper;
+package io.restassured.common.mapper.factory;
 
 import java.lang.reflect.Type;
 
 /**
- * Simply creates a new Jackson 2.0 ObjectMapper
+ * The base interface for object mapper factories.
+ * @param <T> The type of the created object mapper.
  */
-public class DefaultJackson2ObjectMapperFactory implements Jackson2ObjectMapperFactory {
-    public ObjectMapper create(Type cls, String charset) {
-        return new ObjectMapper().findAndRegisterModules();
-    }
+public interface ObjectMapperFactory<T> {
+
+    /**
+     * Create the object mapper instance.
+     *
+     * @param cls The type of the class to serialize or de-serialize
+     * @param charset The charset
+     * @return An object mapper instance
+     */
+    T create(Type cls, String charset);
 }

--- a/rest-assured-common/src/main/java/io/restassured/common/mapper/resolver/ObjectMapperResolver.java
+++ b/rest-assured-common/src/main/java/io/restassured/common/mapper/resolver/ObjectMapperResolver.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.restassured.mapper.resolver;
+package io.restassured.common.mapper.resolver;
 
 import static io.restassured.internal.classpath.ClassPathResolver.existInCP;
 

--- a/rest-assured/pom.xml
+++ b/rest-assured/pom.xml
@@ -47,13 +47,12 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <Export-Package>io.restassured.*</Export-Package>
+                        <Export-Package>io.restassured.*, !io.restassured.path.xml.*, !io.restassured.path.json.*</Export-Package>
                         <Import-Package>
 							groovy.*;version="${groovy.range}",
                             org.codehaus.groovy.*;version="${groovy.range}",
                             *
 						</Import-Package>
-                        <Private-Package />
                     </instructions>
                 </configuration>
             </plugin>

--- a/rest-assured/pom.xml
+++ b/rest-assured/pom.xml
@@ -47,7 +47,12 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <Export-Package>io.restassured.*, !io.restassured.path.xml.*, !io.restassured.path.json.*</Export-Package>
+                        <Export-Package>
+                        	!io.restassured.path.xml.*,
+                        	!io.restassured.path.json.*,
+                        	!io.restassured.common.*,
+                        	io.restassured.*
+                        </Export-Package>
                         <Import-Package>
 							groovy.*;version="${groovy.range}",
                             org.codehaus.groovy.*;version="${groovy.range}",

--- a/rest-assured/src/main/groovy/io/restassured/internal/RestAssuredResponseOptionsGroovyImpl.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/RestAssuredResponseOptionsGroovyImpl.groovy
@@ -33,6 +33,7 @@ import io.restassured.internal.mapping.ObjectMapping
 import io.restassured.internal.print.ResponsePrinter
 import io.restassured.internal.support.CloseHTTPClientConnectionInputStreamWrapper
 import io.restassured.internal.support.Prettifier
+import io.restassured.common.mapper.*
 import io.restassured.mapper.*
 import io.restassured.path.json.JsonPath
 import io.restassured.path.json.config.JsonPathConfig

--- a/rest-assured/src/main/groovy/io/restassured/internal/mapping/GsonMapper.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/mapping/GsonMapper.groovy
@@ -20,7 +20,7 @@ package io.restassured.internal.mapping
 import io.restassured.mapper.ObjectMapper
 import io.restassured.mapper.ObjectMapperDeserializationContext
 import io.restassured.mapper.ObjectMapperSerializationContext
-import io.restassured.mapper.factory.GsonObjectMapperFactory
+import io.restassured.path.json.mapper.factory.GsonObjectMapperFactory
 import io.restassured.path.json.mapping.JsonPathObjectDeserializer
 import io.restassured.internal.path.json.mapping.JsonPathGsonObjectDeserializer
 

--- a/rest-assured/src/main/groovy/io/restassured/internal/mapping/Jackson1Mapper.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/mapping/Jackson1Mapper.groovy
@@ -20,7 +20,7 @@ package io.restassured.internal.mapping
 import io.restassured.internal.path.json.mapping.JsonPathJackson1ObjectDeserializer
 import io.restassured.mapper.ObjectMapper
 import io.restassured.mapper.ObjectMapperSerializationContext
-import io.restassured.mapper.factory.Jackson1ObjectMapperFactory
+import io.restassured.path.json.mapper.factory.Jackson1ObjectMapperFactory
 import io.restassured.path.json.mapping.JsonPathObjectDeserializer
 import io.restassured.mapper.ObjectMapperDeserializationContext
 import org.codehaus.jackson.JsonEncoding

--- a/rest-assured/src/main/groovy/io/restassured/internal/mapping/Jackson2Mapper.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/mapping/Jackson2Mapper.groovy
@@ -23,7 +23,7 @@ import io.restassured.mapper.ObjectMapper
 import io.restassured.mapper.ObjectMapperSerializationContext
 import io.restassured.internal.path.json.mapping.JsonPathJackson2ObjectDeserializer
 import io.restassured.mapper.ObjectMapperDeserializationContext
-import io.restassured.mapper.factory.Jackson2ObjectMapperFactory
+import io.restassured.path.json.mapper.factory.Jackson2ObjectMapperFactory
 import io.restassured.path.json.mapping.JsonPathObjectDeserializer
 
 /**

--- a/rest-assured/src/main/groovy/io/restassured/internal/mapping/JaxbMapper.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/mapping/JaxbMapper.groovy
@@ -19,7 +19,7 @@ import io.restassured.mapper.ObjectMapperSerializationContext
 import io.restassured.internal.path.xml.mapping.XmlPathJaxbObjectDeserializer
 import io.restassured.mapper.ObjectMapper
 import io.restassured.mapper.ObjectMapperDeserializationContext
-import io.restassured.mapper.factory.JAXBObjectMapperFactory
+import io.restassured.path.xml.mapper.factory.JAXBObjectMapperFactory
 import io.restassured.path.xml.mapping.XmlPathObjectDeserializer
 
 import javax.xml.bind.JAXBContext

--- a/rest-assured/src/main/groovy/io/restassured/internal/mapping/ObjectMapping.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/mapping/ObjectMapping.groovy
@@ -21,14 +21,14 @@ import io.restassured.config.EncoderConfig
 import io.restassured.config.ObjectMapperConfig
 import io.restassured.http.ContentType
 import io.restassured.internal.http.ContentTypeExtractor
-import io.restassured.mapper.DataToDeserialize
+import io.restassured.common.mapper.DataToDeserialize
 import io.restassured.mapper.ObjectMapperDeserializationContext
 import io.restassured.mapper.ObjectMapperSerializationContext
 import io.restassured.mapper.ObjectMapperType
-import io.restassured.mapper.factory.GsonObjectMapperFactory
-import io.restassured.mapper.factory.JAXBObjectMapperFactory
-import io.restassured.mapper.factory.Jackson1ObjectMapperFactory
-import io.restassured.mapper.factory.Jackson2ObjectMapperFactory
+import io.restassured.path.json.mapper.factory.GsonObjectMapperFactory
+import io.restassured.path.xml.mapper.factory.JAXBObjectMapperFactory
+import io.restassured.path.json.mapper.factory.Jackson1ObjectMapperFactory
+import io.restassured.path.json.mapper.factory.Jackson2ObjectMapperFactory
 import io.restassured.response.ResponseBodyData
 import org.apache.commons.lang3.Validate
 
@@ -36,7 +36,7 @@ import java.lang.reflect.Type
 
 import static io.restassured.http.ContentType.ANY
 import static io.restassured.internal.assertion.AssertParameter.notNull
-import static io.restassured.mapper.resolver.ObjectMapperResolver.*
+import static io.restassured.common.mapper.resolver.ObjectMapperResolver.*
 import static org.apache.commons.lang3.StringUtils.containsIgnoreCase
 
 class ObjectMapping {

--- a/rest-assured/src/main/java/io/restassured/config/ObjectMapperConfig.java
+++ b/rest-assured/src/main/java/io/restassured/config/ObjectMapperConfig.java
@@ -18,7 +18,14 @@ package io.restassured.config;
 
 import io.restassured.mapper.ObjectMapper;
 import io.restassured.mapper.ObjectMapperType;
-import io.restassured.mapper.factory.*;
+import io.restassured.path.json.mapper.factory.DefaultGsonObjectMapperFactory;
+import io.restassured.path.json.mapper.factory.DefaultJackson1ObjectMapperFactory;
+import io.restassured.path.json.mapper.factory.DefaultJackson2ObjectMapperFactory;
+import io.restassured.path.json.mapper.factory.GsonObjectMapperFactory;
+import io.restassured.path.json.mapper.factory.Jackson1ObjectMapperFactory;
+import io.restassured.path.json.mapper.factory.Jackson2ObjectMapperFactory;
+import io.restassured.path.xml.mapper.factory.*;
+
 import org.apache.commons.lang3.Validate;
 
 /**

--- a/rest-assured/src/main/java/io/restassured/internal/RestAssuredResponseOptionsImpl.java
+++ b/rest-assured/src/main/java/io/restassured/internal/RestAssuredResponseOptionsImpl.java
@@ -16,6 +16,7 @@
 
 package io.restassured.internal;
 
+import io.restassured.common.mapper.TypeRef;
 import io.restassured.config.DecoderConfig;
 import io.restassured.config.RestAssuredConfig;
 import io.restassured.http.Cookie;
@@ -24,7 +25,6 @@ import io.restassured.http.Headers;
 import io.restassured.internal.log.LogRepository;
 import io.restassured.mapper.ObjectMapper;
 import io.restassured.mapper.ObjectMapperType;
-import io.restassured.mapper.TypeRef;
 import io.restassured.path.json.JsonPath;
 import io.restassured.path.json.config.JsonPathConfig;
 import io.restassured.path.xml.XmlPath;

--- a/rest-assured/src/main/java/io/restassured/mapper/ObjectMapperDeserializationContext.java
+++ b/rest-assured/src/main/java/io/restassured/mapper/ObjectMapperDeserializationContext.java
@@ -16,6 +16,8 @@
 
 package io.restassured.mapper;
 
+import io.restassured.common.mapper.ObjectDeserializationContext;
+
 /**
  * Class containing details needed for REST Assured deserializers to convert a response to a Java class.
  */

--- a/rest-assured/src/main/java/io/restassured/response/ResponseBodyExtractionOptions.java
+++ b/rest-assured/src/main/java/io/restassured/response/ResponseBodyExtractionOptions.java
@@ -16,9 +16,9 @@
 
 package io.restassured.response;
 
+import io.restassured.common.mapper.TypeRef;
 import io.restassured.mapper.ObjectMapper;
 import io.restassured.mapper.ObjectMapperType;
-import io.restassured.mapper.TypeRef;
 import io.restassured.path.json.JsonPath;
 import io.restassured.path.json.config.JsonPathConfig;
 import io.restassured.path.xml.XmlPath;

--- a/xml-path/pom.xml
+++ b/xml-path/pom.xml
@@ -38,13 +38,12 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <Export-Package>io.restassured.*</Export-Package>
+                        <Export-Package>io.restassured.mapper.*, io.restassured.path.xml.*</Export-Package>
                         <Import-Package>
 							groovy.*;version="${groovy.range}",
                             org.codehaus.groovy.*;version="${groovy.range}",
                             *
 						</Import-Package>
-                        <Private-Package />
                     </instructions>
                 </configuration>
             </plugin>

--- a/xml-path/pom.xml
+++ b/xml-path/pom.xml
@@ -38,7 +38,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <Export-Package>io.restassured.mapper.*, io.restassured.path.xml.*</Export-Package>
+                        <Export-Package>io.restassured.path.xml.*</Export-Package>
                         <Import-Package>
 							groovy.*;version="${groovy.range}",
                             org.codehaus.groovy.*;version="${groovy.range}",

--- a/xml-path/src/main/groovy/io/restassured/internal/path/xml/mapping/XmlObjectDeserializer.groovy
+++ b/xml-path/src/main/groovy/io/restassured/internal/path/xml/mapping/XmlObjectDeserializer.groovy
@@ -20,14 +20,14 @@
 package io.restassured.internal.path.xml.mapping
 
 import io.restassured.internal.mapper.ObjectDeserializationContextImpl
-import io.restassured.mapper.DataToDeserialize
-import io.restassured.mapper.ObjectDeserializationContext
-import io.restassured.mapper.factory.JAXBObjectMapperFactory
+import io.restassured.common.mapper.DataToDeserialize
+import io.restassured.common.mapper.ObjectDeserializationContext
+import io.restassured.path.xml.mapper.factory.JAXBObjectMapperFactory
 import io.restassured.path.xml.config.XmlParserType
 import io.restassured.path.xml.config.XmlPathConfig
 import org.apache.commons.lang3.Validate
 
-import static io.restassured.mapper.resolver.ObjectMapperResolver.isJAXBInClassPath
+import static io.restassured.common.mapper.resolver.ObjectMapperResolver.isJAXBInClassPath
 
 class XmlObjectDeserializer {
 

--- a/xml-path/src/main/groovy/io/restassured/internal/path/xml/mapping/XmlPathJaxbObjectDeserializer.groovy
+++ b/xml-path/src/main/groovy/io/restassured/internal/path/xml/mapping/XmlPathJaxbObjectDeserializer.groovy
@@ -17,8 +17,8 @@
 
 package io.restassured.internal.path.xml.mapping
 
-import io.restassured.mapper.ObjectDeserializationContext
-import io.restassured.mapper.factory.JAXBObjectMapperFactory
+import io.restassured.common.mapper.ObjectDeserializationContext
+import io.restassured.path.xml.mapper.factory.JAXBObjectMapperFactory
 import io.restassured.path.xml.mapping.XmlPathObjectDeserializer
 
 import javax.xml.bind.JAXBContext

--- a/xml-path/src/main/java/io/restassured/path/xml/XmlPath.java
+++ b/xml-path/src/main/java/io/restassured/path/xml/XmlPath.java
@@ -24,12 +24,13 @@ import io.restassured.internal.assertion.AssertParameter;
 import io.restassured.internal.path.ObjectConverter;
 import io.restassured.internal.path.xml.*;
 import io.restassured.internal.path.xml.mapping.XmlObjectDeserializer;
-import io.restassured.mapper.factory.JAXBObjectMapperFactory;
 import io.restassured.path.xml.config.XmlParserType;
 import io.restassured.path.xml.config.XmlPathConfig;
 import io.restassured.path.xml.element.Node;
 import io.restassured.path.xml.element.NodeChildren;
 import io.restassured.path.xml.exception.XmlPathException;
+import io.restassured.path.xml.mapper.factory.JAXBObjectMapperFactory;
+
 import org.apache.commons.lang3.Validate;
 import org.xml.sax.InputSource;
 import org.xml.sax.XMLReader;

--- a/xml-path/src/main/java/io/restassured/path/xml/config/XmlPathConfig.java
+++ b/xml-path/src/main/java/io/restassured/path/xml/config/XmlPathConfig.java
@@ -16,9 +16,9 @@
 
 package io.restassured.path.xml.config;
 
-import io.restassured.mapper.factory.DefaultJAXBObjectMapperFactory;
-import io.restassured.mapper.factory.JAXBObjectMapperFactory;
 import io.restassured.path.xml.XmlPath;
+import io.restassured.path.xml.mapper.factory.DefaultJAXBObjectMapperFactory;
+import io.restassured.path.xml.mapper.factory.JAXBObjectMapperFactory;
 import io.restassured.path.xml.mapping.XmlPathObjectDeserializer;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;

--- a/xml-path/src/main/java/io/restassured/path/xml/exception/XmlPathException.java
+++ b/xml-path/src/main/java/io/restassured/path/xml/exception/XmlPathException.java
@@ -16,7 +16,7 @@
 
 package io.restassured.path.xml.exception;
 
-import io.restassured.exception.PathException;
+import io.restassured.common.exception.PathException;
 
 public class XmlPathException extends PathException {
 

--- a/xml-path/src/main/java/io/restassured/path/xml/mapper/factory/DefaultJAXBObjectMapperFactory.java
+++ b/xml-path/src/main/java/io/restassured/path/xml/mapper/factory/DefaultJAXBObjectMapperFactory.java
@@ -14,17 +14,24 @@
  * limitations under the License.
  */
 
-package io.restassured.mapper.factory;
+package io.restassured.path.xml.mapper.factory;
 
-import com.google.gson.Gson;
-
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
 import java.lang.reflect.Type;
 
 /**
- * Simply creates a new Gson instance.
+ * Simply creates a new JAXBContext based on the supplied class.
  */
-public class DefaultGsonObjectMapperFactory implements GsonObjectMapperFactory {
-    public Gson create(Type cls, String charset) {
-        return new Gson();
+public class DefaultJAXBObjectMapperFactory implements JAXBObjectMapperFactory {
+    public JAXBContext create(Type cls, String charset) {
+        try {
+            if (cls instanceof Class) {
+                return JAXBContext.newInstance((Class<?>) cls);
+            }
+            throw new RuntimeException("JAXB does not support type" + cls);
+        } catch (JAXBException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/xml-path/src/main/java/io/restassured/path/xml/mapper/factory/JAXBObjectMapperFactory.java
+++ b/xml-path/src/main/java/io/restassured/path/xml/mapper/factory/JAXBObjectMapperFactory.java
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 
-package io.restassured.mapper.factory;
+package io.restassured.path.xml.mapper.factory;
 
-import com.google.gson.Gson;
+import javax.xml.bind.JAXBContext;
+
+import io.restassured.common.mapper.factory.ObjectMapperFactory;
 
 /**
- * Interface for Gson object mappers. Implement this class and register it to the ObjectMapperConfig if you
- * want to override default settings for the Gson object mapper.
+ * Interface for JAXB object mappers. Implement this class and register it to the ObjectMapperConfig if you
+ * want to override default settings for the JAXB object mapper.
  */
-public interface GsonObjectMapperFactory extends ObjectMapperFactory<Gson> {
+public interface JAXBObjectMapperFactory extends ObjectMapperFactory<JAXBContext> {
 }

--- a/xml-path/src/main/java/io/restassured/path/xml/mapping/XmlPathObjectDeserializer.java
+++ b/xml-path/src/main/java/io/restassured/path/xml/mapping/XmlPathObjectDeserializer.java
@@ -16,7 +16,7 @@
 
 package io.restassured.path.xml.mapping;
 
-import io.restassured.mapper.ObjectDeserializationContext;
+import io.restassured.common.mapper.ObjectDeserializationContext;
 
 /**
  * Interface for all XmlPath object deserializers. It's possible to roll your own implementation if the pre-defined

--- a/xml-path/src/test/java/io/restassured/path/xml/XmlPathObjectDeserializationTest.java
+++ b/xml-path/src/test/java/io/restassured/path/xml/XmlPathObjectDeserializationTest.java
@@ -16,11 +16,11 @@
 
 package io.restassured.path.xml;
 
-import io.restassured.mapper.ObjectDeserializationContext;
 import io.restassured.path.xml.mapping.XmlPathObjectDeserializer;
 import io.restassured.path.xml.support.CoolGreeting;
 import io.restassured.path.xml.support.Greeting;
 import io.restassured.path.xml.support.Greetings;
+import io.restassured.common.mapper.ObjectDeserializationContext;
 import io.restassured.path.xml.config.XmlPathConfig;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Rule;


### PR DESCRIPTION
This should fix #1117 
Please note, this does not make the project truly modular solution. It merely ensures modules export only their own packages and thus no files are copied to other modules. Unfortunately due to the lack of cohesion and proper isolation, now all four bundles (`rest-assured`, `rest-assured-common`, `xml-path` and `json-path`) must be installed in the OSGi runtime in order to be resolved. Essentially, this is no different than the current situation where a single bundle resolves in OSGi environment only because all of them contain copies of all packages they need.