### PR TITLE
Supports using HttpStatus for the response status check.

### DIFF
--- a/modules/spring-mock-mvc/src/main/java/io/restassured/module/mockmvc/internal/ValidatableMockMvcResponseImpl.java
+++ b/modules/spring-mock-mvc/src/main/java/io/restassured/module/mockmvc/internal/ValidatableMockMvcResponseImpl.java
@@ -25,6 +25,7 @@ import io.restassured.internal.util.SafeExceptionRethrower;
 import io.restassured.module.mockmvc.response.MockMvcResponse;
 import io.restassured.module.mockmvc.response.ValidatableMockMvcResponse;
 import io.restassured.response.ExtractableResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.ResultHandler;
 import org.springframework.test.web.servlet.ResultMatcher;
@@ -70,6 +71,11 @@ public class ValidatableMockMvcResponseImpl extends ValidatableResponseOptionsIm
                 SafeExceptionRethrower.safeRethrow(e);
             }
         }
+        return this;
+    }
+
+    public ValidatableMockMvcResponse status(HttpStatus expectedStatus) {
+        statusCode(expectedStatus.value());
         return this;
     }
 

--- a/modules/spring-mock-mvc/src/main/java/io/restassured/module/mockmvc/response/ValidatableMockMvcResponse.java
+++ b/modules/spring-mock-mvc/src/main/java/io/restassured/module/mockmvc/response/ValidatableMockMvcResponse.java
@@ -17,6 +17,7 @@
 package io.restassured.module.mockmvc.response;
 
 import io.restassured.response.ValidatableResponseOptions;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.web.servlet.ResultHandler;
 import org.springframework.test.web.servlet.ResultMatcher;
 
@@ -58,4 +59,16 @@ public interface ValidatableMockMvcResponse extends ValidatableResponseOptions<V
      * @return The {@link ValidatableMockMvcResponse} instance.
      */
     ValidatableMockMvcResponse apply(ResultHandler resultHandler, ResultHandler... resultHandlers);
+
+    /**
+     * Validate that the response status matches an Spring-Framework HttpStatus. E.g.
+     * <pre>
+     * get("/something").then().assertThat().status(HttpStatus.OK);
+     * </pre>
+     * <p/>
+     *
+     * @param expectedStatus The expected status.
+     * @return the response specification
+     */
+    ValidatableMockMvcResponse status(HttpStatus expectedStatus);
 }

--- a/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/MockMvcResponseStatusTest.java
+++ b/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/MockMvcResponseStatusTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.restassured.module.mockmvc;
+
+import io.restassured.module.mockmvc.http.ResponseAwareMatcherController;
+import org.junit.Test;
+import org.springframework.http.HttpStatus;
+
+import static org.hamcrest.Matchers.is;
+
+public class MockMvcResponseStatusTest {
+
+    @Test
+    public void
+    can_use_integer_value_for_status_code_matching() {
+        RestAssuredMockMvc.given().
+                standaloneSetup(new ResponseAwareMatcherController()).
+                when().
+                get("/responseAware").
+                then().
+                statusCode(200);
+    }
+
+    @Test
+    public void
+    can_use_hamcrest_matcher_for_status_code_matching() {
+        RestAssuredMockMvc.given().
+                standaloneSetup(new ResponseAwareMatcherController()).
+                when().
+                get("/responseAware").
+                then().
+                statusCode(is(200));
+    }
+
+    @Test
+    public void
+    can_use_spring_http_status_for_status_matching() {
+        RestAssuredMockMvc.given().
+                standaloneSetup(new ResponseAwareMatcherController()).
+                when().
+                get("/responseAware").
+                then().
+                status(HttpStatus.OK);
+    }
+}

--- a/modules/spring-web-test-client/src/main/java/io/restassured/module/webtestclient/internal/ValidatableWebTestClientResponseImpl.java
+++ b/modules/spring-web-test-client/src/main/java/io/restassured/module/webtestclient/internal/ValidatableWebTestClientResponseImpl.java
@@ -23,6 +23,7 @@ import io.restassured.internal.log.LogRepository;
 import io.restassured.module.webtestclient.response.ValidatableWebTestClientResponse;
 import io.restassured.module.webtestclient.response.WebTestClientResponse;
 import io.restassured.response.ExtractableResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 import static io.restassured.module.webtestclient.internal.ResponseConverter.toStandardResponse;
@@ -41,6 +42,12 @@ public class ValidatableWebTestClientResponseImpl extends ValidatableResponseOpt
         super(responseParserRegistrar, config, toStandardResponse(response), extractableResponse, logRepository);
 		AssertParameter.notNull(responseSpec, WebTestClient.ResponseSpec.class);
 		this.response = response;
+	}
+
+	@Override
+	public ValidatableWebTestClientResponse status(HttpStatus expectedStatus) {
+		statusCode(expectedStatus.value());
+		return this;
 	}
 
 	@Override

--- a/modules/spring-web-test-client/src/main/java/io/restassured/module/webtestclient/response/ValidatableWebTestClientResponse.java
+++ b/modules/spring-web-test-client/src/main/java/io/restassured/module/webtestclient/response/ValidatableWebTestClientResponse.java
@@ -17,6 +17,7 @@
 package io.restassured.module.webtestclient.response;
 
 import io.restassured.response.ValidatableResponseOptions;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 /**
@@ -25,4 +26,15 @@ import org.springframework.test.web.reactive.server.WebTestClient;
  * {@link WebTestClient.ResponseSpec} API.
  */
 public interface ValidatableWebTestClientResponse extends ValidatableResponseOptions<ValidatableWebTestClientResponse, WebTestClientResponse> {
+    /**
+     * Validate that the response status matches an Spring-Framework HttpStatus. E.g.
+     * <pre>
+     * get("/something").then().assertThat().status(HttpStatus.OK);
+     * </pre>
+     * <p/>
+     *
+     * @param expectedStatus The expected status.
+     * @return the response specification
+     */
+    ValidatableWebTestClientResponse status(HttpStatus expectedStatus);
 }

--- a/modules/spring-web-test-client/src/test/java/io/restassured/module/webtestclient/WebTestClientResponseStatusTest.java
+++ b/modules/spring-web-test-client/src/test/java/io/restassured/module/webtestclient/WebTestClientResponseStatusTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.restassured.module.webtestclient;
+
+import io.restassured.module.webtestclient.setup.ResponseAwareMatcherController;
+import org.junit.Test;
+import org.springframework.http.HttpStatus;
+
+import static org.hamcrest.Matchers.is;
+
+public class WebTestClientResponseStatusTest {
+
+    @Test
+    public void
+    can_use_integer_value_for_status_code_matching() {
+        RestAssuredWebTestClient.given()
+                .standaloneSetup(new ResponseAwareMatcherController())
+                .when()
+                .get("/responseAware")
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
+    public void
+    can_use_hamcrest_matcher_for_status_code_matching() {
+        RestAssuredWebTestClient.given()
+                .standaloneSetup(new ResponseAwareMatcherController())
+                .when()
+                .get("/responseAware")
+                .then()
+                .statusCode(is(200));
+    }
+
+    @Test
+    public void
+    can_use_spring_http_status_for_status_matching() {
+        RestAssuredWebTestClient.given()
+                .standaloneSetup(new ResponseAwareMatcherController())
+                .when()
+                .get("/responseAware")
+                .then()
+                .status(HttpStatus.OK);
+    }
+}


### PR DESCRIPTION
Hi :)

I improved the response status checking method using SpringFramework's HttpStatus, I wonder your opinion on this.
(It was changed same part of ValidatableWebTestClientResponse)

Thank you for your effort. :D