### PR TITLE
Supports using MediaType for Accept header in WebTestClient

### DIFF
--- a/modules/spring-web-test-client/src/main/java/io/restassured/module/webtestclient/internal/WebTestClientRequestSpecificationImpl.java
+++ b/modules/spring-web-test-client/src/main/java/io/restassured/module/webtestclient/internal/WebTestClientRequestSpecificationImpl.java
@@ -44,6 +44,7 @@ import io.restassured.module.webtestclient.specification.WebTestClientRequestSen
 import io.restassured.module.webtestclient.specification.WebTestClientRequestSpecification;
 import io.restassured.specification.ResponseSpecification;
 import org.springframework.context.ApplicationContext;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.reactive.server.EntityExchangeResult;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.test.web.reactive.server.WebTestClientConfigurer;
@@ -127,6 +128,12 @@ public class WebTestClientRequestSpecificationImpl implements WebTestClientReque
 	public WebTestClientRequestSpecification accept(ContentType contentType) {
 		notNull(contentType, "contentType");
 		return header(ACCEPT, contentType.getAcceptHeader());
+	}
+
+	@Override
+	public WebTestClientRequestSpecification accept(MediaType... mediaTypes) {
+		notNull(mediaTypes, "mediaTypes");
+		return header(ACCEPT, MediaType.toString(Arrays.asList(mediaTypes)));
 	}
 
 	@Override

--- a/modules/spring-web-test-client/src/main/java/io/restassured/module/webtestclient/specification/WebTestClientRequestSpecification.java
+++ b/modules/spring-web-test-client/src/main/java/io/restassured/module/webtestclient/specification/WebTestClientRequestSpecification.java
@@ -23,6 +23,7 @@ import io.restassured.mapper.ObjectMapperType;
 import io.restassured.module.spring.commons.config.SpecificationConfig;
 import io.restassured.module.webtestclient.config.RestAssuredWebTestClientConfig;
 import org.springframework.context.ApplicationContext;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.test.web.reactive.server.WebTestClientConfigurer;
 import org.springframework.web.context.WebApplicationContext;
@@ -68,6 +69,20 @@ public interface WebTestClientRequestSpecification extends WebTestClientRequestS
 	 * @see #header(String, Object, Object...)
 	 */
 	WebTestClientRequestSpecification accept(ContentType contentType);
+
+	/**
+	 * Specify the accept header of the request. This just a shortcut for:
+	 * <pre>
+	 * header("Accept", contentType);
+	 * </pre>
+	 *
+	 * @param mediaTypes The media type(s) that will be used as Accept header in the request.
+	 * @return The request specification
+	 *
+	 * @see ContentType
+	 * @see #header(String, Object, Object...)
+	 */
+	WebTestClientRequestSpecification accept(MediaType... mediaTypes);
 
 	/**
 	 * Specify the accept header of the request. This just a shortcut for:

--- a/modules/spring-web-test-client/src/test/java/io/restassured/module/webtestclient/AcceptTest.java
+++ b/modules/spring-web-test-client/src/test/java/io/restassured/module/webtestclient/AcceptTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.restassured.module.webtestclient;
+
+import io.restassured.http.ContentType;
+import io.restassured.module.webtestclient.setup.HeaderController;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import static io.restassured.module.webtestclient.RestAssuredWebTestClient.given;
+import static org.hamcrest.Matchers.equalTo;
+
+public class AcceptTest {
+    @Before
+    public void
+    given_rest_assured_is_initialized_with_controller() {
+        RestAssuredWebTestClient.standaloneSetup(new HeaderController());
+    }
+
+    @After
+    public void
+    rest_assured_is_reset_after_each_test() {
+        RestAssuredWebTestClient.reset();
+    }
+
+    @Test
+    public void
+    adds_accept_by_content_type() {
+        given()
+                .accept(ContentType.JSON)
+                .when()
+                .get("/headers")
+                .then()
+                .status(HttpStatus.OK)
+                .body("Accept", equalTo("application/json, application/javascript, text/javascript, text/json"));
+    }
+
+    @Test
+    public void
+    adds_accept_by_string_value() {
+        given()
+                .accept("application/json, application/javascript")
+                .when()
+                .get("/headers")
+                .then()
+                .status(HttpStatus.OK)
+                .body("Accept", equalTo("application/json, application/javascript"));
+    }
+
+    @Test
+    public void
+    adds_accept_by_media_type() {
+        given()
+                .accept(MediaType.APPLICATION_JSON, MediaType.APPLICATION_FORM_URLENCODED)
+                .when()
+                .get("/headers")
+                .then()
+                .status(HttpStatus.OK)
+                .body("Accept", equalTo("application/json, application/x-www-form-urlencoded"));
+    }
+}

--- a/modules/spring-web-test-client/src/test/java/io/restassured/module/webtestclient/setup/HeaderController.java
+++ b/modules/spring-web-test-client/src/test/java/io/restassured/module/webtestclient/setup/HeaderController.java
@@ -16,6 +16,8 @@
 
 package io.restassured.module.webtestclient.setup;
 
+import java.util.Map;
+import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
@@ -30,5 +32,10 @@ public class HeaderController {
     public Mono<String> header(@RequestHeader("headerName") String headerValue,
                                @RequestHeader(value = "User-Agent", required = false) String userAgent) {
         return Mono.just("{\"headerName\" : \"" + headerValue + "\", \"user-agent\" : \"" + userAgent + "\"}");
+    }
+
+    @GetMapping(value = "/headers", produces = APPLICATION_JSON_VALUE)
+    public Mono<Map<String, String>> headers(ServerHttpRequest request) {
+        return Mono.just(request.getHeaders().toSingleValueMap());
     }
 }


### PR DESCRIPTION
Hi :)
I added some code and tests for the WebTestClient supported accept value using a MediaType.
This Pull Request is similar #1152, but i've missed adding a code for the WebTestClient.

Thank you for your effort. :D