### PR TITLE
Fixed typo in Javadoc of ValidatableResponseOptions.java

### DIFF
--- a/rest-assured/src/main/java/io/restassured/response/ValidatableResponseOptions.java
+++ b/rest-assured/src/main/java/io/restassured/response/ValidatableResponseOptions.java
@@ -288,7 +288,7 @@ public interface ValidatableResponseOptions<T extends ValidatableResponseOptions
      * To verify that the Location header ends with "/x/{id}" you can do like this:
      * <p>
      * <pre>
-     * given().param("id", 1).body(..).post("/x").then().assertThat().header("Location", response -> response.endsWith("/x/") + response.path("id"));
+     * given().param("id", 1).body(..).post("/x").then().assertThat().header("Location", response -> endsWith("/x/" + response.path("id")));
      * </pre>
      * </p>
      * <p/>


### PR DESCRIPTION
The Javadoc of T header(String headerName, ResponseAwareMatcher<R> expectedValueMatcher) shows an example that does not compile:

```
assertThat().header("Location", response -> response.endsWith("/x/") + response.path("id"));
```

in fact, `endsWith` is not a method of response, it's an Hamcrest matcher. This small patch fixes the example in the Javadoc. I propose the fix according to one of the tests of REST Assured itself, https://github.com/rest-assured/rest-assured/blob/master/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/HeaderITest.java#L220