### PR TITLE
Add unit tests for io.restassured.http.Header

### DIFF
--- a/rest-assured/src/test/java/io/restassured/http/HeaderTest.java
+++ b/rest-assured/src/test/java/io/restassured/http/HeaderTest.java
@@ -1,0 +1,24 @@
+package io.restassured.http;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HeaderTest {
+
+  @Test
+  public void header_has_same_name_as_expected() {
+    final Header header1 = new Header("foo", "bar");
+    final Header header2 = new Header("Foo", "baz");
+
+    assertThat(header2.hasSameNameAs(header1)).isTrue();
+  }
+
+  @Test
+  public void header_does_not_have_same_name_as_expected() {
+    final Header header1 = new Header("foo", "bar");
+    final Header header2 = new Header("bar", "baz");
+
+    assertThat(header2.hasSameNameAs(header1)).isFalse();
+  }
+}


### PR DESCRIPTION
I've written some tests for the methods in `io.restassured.http.Header` with the help of [Diffblue Cover](https://www.diffblue.com/opensource).

Hopefully, these tests will help detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other classes in a subsequent PR.