### PR TITLE
#1197: do not set default port for non-localhost

### DIFF
--- a/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/RequestSpecificationITest.java
+++ b/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/RequestSpecificationITest.java
@@ -49,4 +49,23 @@ public class RequestSpecificationITest {
             RestAssured.reset();
         }
     }
+
+    @Test
+    public void default_port_keeps_undefined_for_non_localhost() {
+        given().spec(new RequestSpecBuilder().build())
+            .baseUri("http://nonlocal.com/api")
+            .filter((requestSpec, responseSpec, ctx) -> {
+                assertThat(requestSpec.getPort(), is(RestAssured.UNDEFINED_PORT));
+                return new ResponseBuilder().setStatusCode(200).build();
+            }).when().get();
+    }
+
+    @Test
+    public void default_port_for_localhost() {
+        given().spec(new RequestSpecBuilder().build())
+            .filter((requestSpec, responseSpec, ctx) -> {
+                assertThat(requestSpec.getPort(), is(RestAssured.DEFAULT_PORT));
+                return new ResponseBuilder().setStatusCode(200).build();
+            }).when().get();
+    }
 }

--- a/rest-assured/src/main/groovy/io/restassured/internal/RequestSpecificationImpl.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/RequestSpecificationImpl.groovy
@@ -1553,22 +1553,21 @@ class RequestSpecificationImpl implements FilterableRequestSpecification, Groovy
   }
 
   private String getTargetUriFromUrl(URL url) {
-    def builder = new StringBuilder();
     def protocol = url.getProtocol()
     boolean useDefaultHttps = false
-    if (port == DEFAULT_HTTP_TEST_PORT && protocol.equalsIgnoreCase("https")) {
+    if (this.@port == RestAssured.UNDEFINED_PORT && protocol.equalsIgnoreCase("https")) {
       useDefaultHttps = true
     }
 
-    builder.append(protocol)
-    builder.append("://")
-    builder.append(url.getAuthority())
+    def builder = new StringBuilder(protocol)
+      .append("://")
+      .append(url.getAuthority())
 
-    def hasSpecifiedPortExplicitly = port != RestAssured.UNDEFINED_PORT
+    def hasSpecifiedPortExplicitly = this.@port != RestAssured.UNDEFINED_PORT
     if (!hasPortDefined(url) && !useDefaultHttps) {
       if (hasSpecifiedPortExplicitly) {
         builder.append(":")
-        builder.append(port)
+        builder.append(this.@port)
       } else if (!isFullyQualified(url.toString()) || hasAuthorityEqualToLocalhost(url)) {
         builder.append(":")
         builder.append(DEFAULT_HTTP_TEST_PORT)

--- a/rest-assured/src/main/groovy/io/restassured/internal/SpecificationMerger.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/SpecificationMerger.groovy
@@ -91,7 +91,7 @@ class SpecificationMerger {
     notNull thisOne, "Specification to merge"
     notNull with, "Specification to merge with"
 
-    thisOne.port = with.port
+    thisOne.@port = with.@port
     thisOne.baseUri = with.baseUri
     thisOne.basePath = with.basePath
     thisOne.requestParameters.putAll(with.requestParameters)


### PR DESCRIPTION
Fixes #1197 

replace port property reference with this.@port
this should skip the getter method which does some additional work.