### PR TITLE
Allow a user to specify their own AuthenticationScheme implementation

### DIFF
--- a/rest-assured/src/main/groovy/io/restassured/internal/AuthenticationSpecificationImpl.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/AuthenticationSpecificationImpl.groovy
@@ -35,6 +35,13 @@ class AuthenticationSpecificationImpl implements AuthenticationSpecification {
     this.requestSpecification = requestSpecification
   }
 
+  def RequestSpecification scheme(AuthenticationScheme scheme) {
+    notNull scheme, "scheme"
+
+    requestSpecification.authenticationScheme = scheme;
+    return requestSpecification
+  }
+
   /**
    * Use http basic authentication.
    *

--- a/rest-assured/src/main/java/io/restassured/specification/AuthenticationSpecification.java
+++ b/rest-assured/src/main/java/io/restassured/specification/AuthenticationSpecification.java
@@ -16,6 +16,7 @@
 
 package io.restassured.specification;
 
+import io.restassured.authentication.AuthenticationScheme;
 import io.restassured.authentication.CertificateAuthSettings;
 import io.restassured.authentication.FormAuthConfig;
 import io.restassured.authentication.OAuthSignature;
@@ -24,6 +25,15 @@ import io.restassured.authentication.OAuthSignature;
  * Specify an authentication scheme to use when sending a request.
  */
 public interface AuthenticationSpecification {
+    /**
+     * Allows the user to provide their own {@link AuthenticationScheme} implementation for custom authentication
+     * mechanisms.
+     *
+     * @param scheme The authentication scheme implementation to use.
+     * @return The request specification.
+     */
+    RequestSpecification scheme(AuthenticationScheme scheme);
+
     /**
      * Use http basic authentication.
      *

--- a/rest-assured/src/test/groovy/io/restassured/RequestSpecificationTest.groovy
+++ b/rest-assured/src/test/groovy/io/restassured/RequestSpecificationTest.groovy
@@ -18,10 +18,12 @@
 
 package io.restassured
 
+import io.restassured.authentication.AuthenticationScheme
 import io.restassured.filter.Filter
 import io.restassured.filter.FilterContext
 import io.restassured.http.Header
 import io.restassured.http.Headers
+import io.restassured.internal.http.HTTPBuilder
 import io.restassured.response.Response
 import io.restassured.specification.FilterableRequestSpecification
 import io.restassured.specification.FilterableResponseSpecification
@@ -88,6 +90,14 @@ class RequestSpecificationTest {
       assertEquals(CONTENT_TYPE_TEST_VALUE, requestSpec.requestHeaders.get(CONTENT_TYPE).getValue())
   }
 
+  @Test
+  public void canUseCustomAuthenticationSchemeImplementation() {
+    def scheme = new MyCustomAuthScheme();
+    def spec = given().auth().scheme(scheme);
+
+    assertEquals(scheme, spec.authenticationScheme)
+  }
+
   @Ignore
   private class ExampleFilter1 implements Filter {
     @Override
@@ -109,6 +119,14 @@ class RequestSpecificationTest {
     @Override
     Response filter(FilterableRequestSpecification requestSpec, FilterableResponseSpecification responseSpec, FilterContext ctx) {
       return null
+    }
+  }
+
+  @Ignore
+  private class MyCustomAuthScheme implements AuthenticationScheme {
+    @Override
+    void authenticate(HTTPBuilder httpBuilder) {
+      // Do nothing - only used for testing purposes.
     }
   }
 }


### PR DESCRIPTION
In our use-case, we have an API-key based authentication scheme for internal service-to-service communication. Currently the only way for us to use these scheme in tests is to do something like this:

```
RestAssured.authentication = new ApiKeyAuthScheme("...");
given()...
```

This PR introduces a new syntax:

```
given()
  .auth().scheme(new ApiKeyAuthScheme("..."))...
```