### PR TITLE
changing HashMap to LinkedHashMap for deterministic iterations

### DIFF
--- a/json-path/src/main/groovy/io/restassured/internal/path/json/ConfigurableJsonSlurper.groovy
+++ b/json-path/src/main/groovy/io/restassured/internal/path/json/ConfigurableJsonSlurper.groovy
@@ -193,7 +193,7 @@ class ConfigurableJsonSlurper {
      * @return a Map representing a JSON object
      */
     private Map parseObject(JsonLexer lexer) {
-        Map content = new HashMap();
+        Map content = new LinkedHashMap();
 
         JsonToken previousToken = null;
         JsonToken currentToken = null;

--- a/json-path/src/test/java/io/restassured/path/json/JsonPathTest.java
+++ b/json-path/src/test/java/io/restassured/path/json/JsonPathTest.java
@@ -407,14 +407,15 @@ public class JsonPathTest {
     public void jsonPathSupportsPrettifiyingJson() {
         final String prettyJson = JsonPath.with(JSON2).prettify();
 
-        assertThat(prettyJson, equalTo("[\n    {\n        \"phone\": \"3456789\",\n        \"alias\": \"name one\",\n        \"email\": \"name1@mail.com\"\n    },\n    {\n        \"phone\": \"1234567\",\n        \"alias\": \"name two\",\n        \"email\": \"name2@mail.com\"\n    },\n    {\n        \"phone\": \"2345678\",\n        \"alias\": \"name three\",\n        \"email\": \"name3@mail.com\"\n    }\n]"));
+        assertThat(prettyJson, equalTo("[\n    {\n        \"email\": \"name1@mail.com\",\n        \"alias\": \"name one\",\n        \"phone\": \"3456789\"\n    },\n    {\n        \"email\": \"name2@mail.com\",\n        \"alias\": \"name two\",\n        \"phone\": \"1234567\"\n    },\n    {\n        \"email\": \"name3@mail.com\",\n        \"alias\": \"name three\",\n        \"phone\": \"2345678\"\n    }\n]"));
+
     }
 
     @Test
     public void jsonPathSupportsPrettyPrintingJson() {
         final String prettyJson = JsonPath.with(JSON2).prettyPrint();
 
-        assertThat(prettyJson, equalTo("[\n    {\n        \"phone\": \"3456789\",\n        \"alias\": \"name one\",\n        \"email\": \"name1@mail.com\"\n    },\n    {\n        \"phone\": \"1234567\",\n        \"alias\": \"name two\",\n        \"email\": \"name2@mail.com\"\n    },\n    {\n        \"phone\": \"2345678\",\n        \"alias\": \"name three\",\n        \"email\": \"name3@mail.com\"\n    }\n]"));
+        assertThat(prettyJson, equalTo("[\n    {\n        \"email\": \"name1@mail.com\",\n        \"alias\": \"name one\",\n        \"phone\": \"3456789\"\n    },\n    {\n        \"email\": \"name2@mail.com\",\n        \"alias\": \"name two\",\n        \"phone\": \"1234567\"\n    },\n    {\n        \"email\": \"name3@mail.com\",\n        \"alias\": \"name three\",\n        \"phone\": \"2345678\"\n    }\n]"));
     }
 
     @Test


### PR DESCRIPTION
When the ConfigurableJsonSlurper parses a json string, it uses a HashMap where iteration order is not guaranteed. When the resulting json object is prettified into a string again, the string can have elements in different order and thus, the test `io.restassured.path.json.JsonPathTest#jsonPathSupportsPrettyPrintingJson` may fail. This PR changes the HashMap to a LinkedHashMap, where iteration order is guaranteed. This PR also updates test assertions to match the deterministic order. 

Please let me know if you want to discuss the changes more.