### PR TITLE
Blacklisting logged headers

### DIFF
--- a/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/SpecificationBuilderITest.java
+++ b/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/SpecificationBuilderITest.java
@@ -399,7 +399,8 @@ public class SpecificationBuilderITest extends WithJetty {
                 "Form params:\t<none>%n" +
                 "Path params:\tfirstName=John%n" +
                 "\t\t\t\tlastName=Doe%n" +
-                "Headers:Cookies:\t\t<none>%n" +
+                "Headers:\t\tAccept=[ REDACTED ]%n" +
+                "Cookies:\t\t<none>%n" +
                 "Multiparts:\t\t<none>%n" +
                 "Body:\t\t\t<none>%n")));
     }

--- a/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/SpecificationBuilderITest.java
+++ b/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/SpecificationBuilderITest.java
@@ -19,6 +19,7 @@ package io.restassured.itest.java;
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.builder.ResponseSpecBuilder;
+import io.restassured.filter.log.LogBlacklists;
 import io.restassured.http.Cookies;
 import io.restassured.itest.java.support.WithJetty;
 import io.restassured.specification.RequestSpecification;
@@ -364,6 +365,41 @@ public class SpecificationBuilderITest extends WithJetty {
                 "\t\t\t\tlastName=Doe%n" +
                 "Headers:\t\tAccept=*/*%n" +
                 "Cookies:\t\t<none>%n" +
+                "Multiparts:\t\t<none>%n" +
+                "Body:\t\t\t<none>%n")));
+    }
+
+    @Test
+    public void supportsSettingLoggingWithBlacklistsWhenUsingRequestSpecBuilder() {
+        final StringWriter writer = new StringWriter();
+        final PrintStream captor = new PrintStream(new WriterOutputStream(writer), true);
+        final RequestSpecification spec = new RequestSpecBuilder()
+                .setConfig(newConfig()
+                        .logConfig(logConfig().defaultStream(captor)))
+                .and()
+                .log(ALL)
+                .logBlacklists(new LogBlacklists()
+                .blacklistHeader("Accept"))
+                .build();
+
+        given().
+                spec(spec).
+                pathParam("firstName", "John").
+                pathParam("lastName", "Doe").
+                when().
+                get("/{firstName}/{lastName}").
+                then().
+                body("fullName", equalTo("John Doe"));
+
+        assertThat(writer.toString(), equalTo(String.format("Request method:\tGET%n" +
+                "Request URI:\thttp://localhost:8080/John/Doe%n" +
+                "Proxy:\t\t\t<none>%n" +
+                "Request params:\t<none>%n" +
+                "Query params:\t<none>%n" +
+                "Form params:\t<none>%n" +
+                "Path params:\tfirstName=John%n" +
+                "\t\t\t\tlastName=Doe%n" +
+                "Headers:Cookies:\t\t<none>%n" +
                 "Multiparts:\t\t<none>%n" +
                 "Body:\t\t\t<none>%n")));
     }

--- a/rest-assured/src/main/java/io/restassured/builder/RequestSpecBuilder.java
+++ b/rest-assured/src/main/java/io/restassured/builder/RequestSpecBuilder.java
@@ -22,6 +22,7 @@ import io.restassured.config.LogConfig;
 import io.restassured.config.RestAssuredConfig;
 import io.restassured.config.SessionConfig;
 import io.restassured.filter.Filter;
+import io.restassured.filter.log.LogBlacklists;
 import io.restassured.filter.log.LogDetail;
 import io.restassured.filter.log.RequestLoggingFilter;
 import io.restassured.http.ContentType;
@@ -1037,6 +1038,22 @@ public class RequestSpecBuilder {
         boolean prettyPrintingEnabled = logConfig.isPrettyPrintingEnabled();
         boolean shouldUrlEncodeRequestUri = logConfig.shouldUrlEncodeRequestUri();
         spec.filter(new RequestLoggingFilter(logDetail, prettyPrintingEnabled, printStream, shouldUrlEncodeRequestUri));
+        return this;
+    }
+
+    /**
+     * Blacklists certain components of an HTTP request.
+     *
+     * @param logBlacklists The blacklists to be used during logging.
+     * @return RequestSpecBuilder
+     */
+    public RequestSpecBuilder logBlacklists(final LogBlacklists logBlacklists) {
+        for (Filter filter : spec.getDefinedFilters()) {
+            if (filter instanceof RequestLoggingFilter) {
+                RequestLoggingFilter requestLoggingFilter = (RequestLoggingFilter) filter;
+                requestLoggingFilter.setLogBlacklists(logBlacklists);
+            }
+        }
         return this;
     }
 

--- a/rest-assured/src/main/java/io/restassured/builder/RequestSpecBuilder.java
+++ b/rest-assured/src/main/java/io/restassured/builder/RequestSpecBuilder.java
@@ -1048,7 +1048,7 @@ public class RequestSpecBuilder {
      * @return RequestSpecBuilder
      */
     public RequestSpecBuilder logBlacklists(final LogBlacklists logBlacklists) {
-        for (Filter filter : spec.getDefinedFilters()) {
+        for (Object filter : spec.getDefinedFilters()) {
             if (filter instanceof RequestLoggingFilter) {
                 RequestLoggingFilter requestLoggingFilter = (RequestLoggingFilter) filter;
                 requestLoggingFilter.setLogBlacklists(logBlacklists);

--- a/rest-assured/src/main/java/io/restassured/filter/log/LogBlacklists.java
+++ b/rest-assured/src/main/java/io/restassured/filter/log/LogBlacklists.java
@@ -16,6 +16,7 @@
 
 package io.restassured.filter.log;
 
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -42,9 +43,9 @@ public class LogBlacklists {
 
     /**
      * Returns the set of blacklisted headers
-     * @return set of bkaclisted headers
+     * @return set of blacklisted headers
      */
     public Set<String> getHeadersBlacklist() {
-        return headersBlacklist;
+        return Collections.unmodifiableSet(headersBlacklist);
     }
 }

--- a/rest-assured/src/main/java/io/restassured/filter/log/LogBlacklists.java
+++ b/rest-assured/src/main/java/io/restassured/filter/log/LogBlacklists.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.restassured.filter.log;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * This class represents a container of blacklists, to be used during logging, of key-based components of an HTTP request.
+ */
+public class LogBlacklists {
+
+    private Set<String> headersBlacklist;
+
+    public LogBlacklists() {
+        headersBlacklist = new LinkedHashSet<>();
+    }
+
+    /**
+     * Blacklists a header given its name
+     * @param headerName of the header to be blacklisted
+     * @return LogBlacklists
+     */
+    public LogBlacklists blacklistHeader(final String headerName) {
+        headersBlacklist.add(headerName);
+        return this;
+    }
+
+    /**
+     * Returns the set of blacklisted headers
+     * @return set of bkaclisted headers
+     */
+    public Set<String> getHeadersBlacklist() {
+        return headersBlacklist;
+    }
+}

--- a/rest-assured/src/main/java/io/restassured/filter/log/RequestLoggingFilter.java
+++ b/rest-assured/src/main/java/io/restassured/filter/log/RequestLoggingFilter.java
@@ -44,6 +44,7 @@ public class RequestLoggingFilter implements Filter {
     private final PrintStream stream;
     private final boolean shouldPrettyPrint;
     private final boolean showUrlEncodedUri;
+    private LogBlacklists logBlacklists;
 
     /**
      * Logs to System.out
@@ -108,6 +109,7 @@ public class RequestLoggingFilter implements Filter {
         }
         this.stream = stream;
         this.logDetail = logDetail;
+        this.logBlacklists = new LogBlacklists();
         this.shouldPrettyPrint = shouldPrettyPrint;
         this.showUrlEncodedUri = showUrlEncodedUri;
     }
@@ -118,8 +120,12 @@ public class RequestLoggingFilter implements Filter {
             uri = UrlDecoder.urlDecode(uri, Charset.forName(requestSpec.getConfig().getEncoderConfig().defaultQueryParameterCharset()), true);
         }
 
-        RequestPrinter.print(requestSpec, requestSpec.getMethod(), uri, logDetail, stream, shouldPrettyPrint);
+        RequestPrinter.print(requestSpec, requestSpec.getMethod(), uri, logDetail, logBlacklists, stream, shouldPrettyPrint);
         return ctx.next(requestSpec, responseSpec);
+    }
+
+    public void setLogBlacklists(final LogBlacklists logBlacklists) {
+        this.logBlacklists = logBlacklists;
     }
 
     /**

--- a/rest-assured/src/main/java/io/restassured/internal/print/RequestPrinter.java
+++ b/rest-assured/src/main/java/io/restassured/internal/print/RequestPrinter.java
@@ -47,6 +47,7 @@ public class RequestPrinter {
     private static final String TAB = "\t";
     private static final String EQUALS = "=";
     private static final String NONE = "<none>";
+    private static final String REDACTED = "[ REDACTED ]";
 
     public static String print(FilterableRequestSpecification requestSpec, String requestMethod, String completeRequestUri,
                                LogDetail logDetail, LogBlacklists logBlacklists,
@@ -141,14 +142,16 @@ public class RequestPrinter {
         } else {
             int i = 0;
             for (Header header : headers) {
-                if (!headersBlacklist.contains(header.getName())) {
-                    if (i++ == 0) {
-                        appendTwoTabs(builder);
-                    } else {
-                        appendFourTabs(builder);
-                    }
-                    builder.append(header).append(SystemUtils.LINE_SEPARATOR);
+                if (i++ == 0) {
+                    appendTwoTabs(builder);
+                } else {
+                    appendFourTabs(builder);
                 }
+                Header processedHeader = header;
+                if (headersBlacklist.contains(header.getName())) {
+                    processedHeader = new Header(header.getName(), REDACTED);
+                }
+                builder.append(processedHeader).append(SystemUtils.LINE_SEPARATOR);
             }
         }
     }


### PR DESCRIPTION
These changes will allow rest-assured clients to blacklist certain headers from being logged, regardless of whether the LogDetail is `ALL` or `HEADERS`.

The rationale of this change is that while headers are useful to look when debugging, they could also potentially contain secret or confidential data that one may wish to redact.

### Usage example:

```
new RequestSpecBuilder()
                .addHeader("x-api-key", "rest_assured_test")
                .addHeader("Authorization", "My funny secret")
                .log(ALL)
                .logBlacklists(new LogBlacklists()
                        .blacklistHeader("Authorization"))
                .build();
```

### Output example

```
Request method:	GET
Request URI:    http://localhost:8080/foo/bar
Proxy:          <none>
Request params: <none>
Query params:   <none>
Form params:    <none>
Path params:    x-api-key=rest_assured_test
Headers:        Accept=[ REDACTED ]
Cookies:        <none>
Multiparts:     <none>
Body:           <none>
```

### Further notes

These changes blacklist headers only, but the changes could be extended to other components of an HTTP request if required.

Also, this would be my first contribution to the project, so I hope this PR is fine and would be happy to take suggestions.