### PR TITLE
Jakarta EE API: switch from javax.xml.bind:jaxb-api to jakarta.xml.bi…

### DIFF
--- a/examples/rest-assured-itest-java-osgi/src/test/java/io/restassured/test/osgi/JsonPathOSGiITest.java
+++ b/examples/rest-assured-itest-java-osgi/src/test/java/io/restassured/test/osgi/JsonPathOSGiITest.java
@@ -55,7 +55,7 @@ public class JsonPathOSGiITest {
                         mavenBundle().groupId("org.codehaus.groovy").artifactId("groovy-xml").versionAsInProject().noStart(),
                         mavenBundle().groupId("org.codehaus.groovy").artifactId("groovy").versionAsInProject(),
 
-                        wrappedBundle(mavenBundle().groupId("javax.xml.bind").artifactId("jaxb-api").versionAsInProject()),
+                        wrappedBundle(mavenBundle("jakarta.xml.bind", "jakarta.xml.bind-api").versionAsInProject()),
                         wrappedBundle(mavenBundle().groupId("org.apache.httpcomponents").artifactId("httpclient").versionAsInProject()),
                         wrappedBundle(mavenBundle().groupId("org.apache.httpcomponents").artifactId("httpmime").versionAsInProject()),
                         wrappedBundle(mavenBundle().groupId("org.apache.httpcomponents").artifactId("httpcore").versionAsInProject()),

--- a/examples/rest-assured-itest-java-osgi/src/test/java/io/restassured/test/osgi/RestAssuredOSGiITest.java
+++ b/examples/rest-assured-itest-java-osgi/src/test/java/io/restassured/test/osgi/RestAssuredOSGiITest.java
@@ -59,7 +59,7 @@ public class RestAssuredOSGiITest {
                         wrappedBundle(mavenBundle("org.apache.httpcomponents", "httpclient").versionAsInProject()),
                         wrappedBundle(mavenBundle("org.apache.httpcomponents", "httpmime").versionAsInProject()),
                         wrappedBundle(mavenBundle("org.apache.httpcomponents", "httpcore").versionAsInProject()),
-                        wrappedBundle(mavenBundle("javax.xml.bind", "jaxb-api").versionAsInProject()),
+                        wrappedBundle(mavenBundle("jakarta.xml.bind", "jakarta.xml.bind-api").versionAsInProject()),
                         wrappedBundle(mavenBundle("javax.activation", "activation").version("1.1.1")),
 
                         /* Rest Assured dependencie needed in the Pax Exam container to be able to execute the test below */

--- a/examples/rest-assured-itest-java-osgi/src/test/java/io/restassured/test/osgi/XmlPathOSGiITest.java
+++ b/examples/rest-assured-itest-java-osgi/src/test/java/io/restassured/test/osgi/XmlPathOSGiITest.java
@@ -60,7 +60,7 @@ public class XmlPathOSGiITest {
                         mavenBundle().groupId("org.codehaus.groovy").artifactId("groovy").versionAsInProject(),
 
                         wrappedBundle(mavenBundle().groupId("org.ccil.cowan.tagsoup").artifactId("tagsoup").versionAsInProject()),
-                        wrappedBundle(mavenBundle("javax.xml.bind", "jaxb-api").versionAsInProject()),
+                        wrappedBundle(mavenBundle("jakarta.xml.bind", "jakarta.xml.bind-api").versionAsInProject()),
                         wrappedBundle(mavenBundle("javax.activation", "activation").version("1.1.1")),
                         wrappedBundle(mavenBundle("org.apache.httpcomponents", "httpclient").versionAsInProject()),
                         wrappedBundle(mavenBundle("org.apache.httpcomponents", "httpmime").versionAsInProject()),

--- a/pom.xml
+++ b/pom.xml
@@ -314,9 +314,9 @@
                 <version>1.2.1</version>
             </dependency>
             <dependency>
-                <groupId>javax.xml.bind</groupId>
-                <artifactId>jaxb-api</artifactId>
-                <version>2.3.1</version>
+                <groupId>jakarta.xml.bind</groupId>
+                <artifactId>jakarta.xml.bind-api</artifactId>
+                <version>2.3.2</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.xml.bind</groupId>

--- a/xml-path/pom.xml
+++ b/xml-path/pom.xml
@@ -81,8 +81,8 @@
             <artifactId>tagsoup</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>


### PR DESCRIPTION
…nd:jakarta.xml.bind-api

Fixes #1226 

N.B. The test `RestAssuredOSGiITest` is failing for me, but I had this problem before this patch as well so it seems unrelated. I don't really understand how that test is supposed to work so I hope it's ok I ignore that.