### PR TITLE
Make tests stable by changing test assertions

### DIFF
--- a/modules/spring-mock-mvc/pom.xml
+++ b/modules/spring-mock-mvc/pom.xml
@@ -116,5 +116,11 @@
             <version>1.0.0.RELEASE</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <version>1.5.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/ResponseLoggingTest.java
+++ b/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/ResponseLoggingTest.java
@@ -16,6 +16,7 @@
 
 package io.restassured.module.mockmvc;
 
+import org.json.JSONException;
 import io.restassured.RestAssured;
 import io.restassured.config.LogConfig;
 import io.restassured.module.mockmvc.config.RestAssuredMockMvcConfig;
@@ -24,12 +25,14 @@ import org.apache.commons.io.output.WriterOutputStream;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.io.PrintStream;
 import java.io.StringWriter;
 
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
@@ -49,6 +52,15 @@ public class ResponseLoggingTest {
         RestAssured.reset();
     }
 
+    public void
+    assertJsonEqualsNonStrict(String json1, String json2) {
+        try {
+            JSONAssert.assertEquals(json1, json2, false);
+        } catch (JSONException jse) {
+            throw new IllegalArgumentException(jse.getMessage());
+        }
+    }
+
     @Test public void
     logging_if_response_validation_fails_works() {
         try {
@@ -64,9 +76,12 @@ public class ResponseLoggingTest {
 
             fail("Should throw AssertionError");
         } catch (AssertionError e) {
-            assertThat(writer.toString(), equalTo(String.format("200%n" +
-                    "Content-Type: application/json;charset=UTF-8%n" +
-                    "%n{\n    \"id\": 1,\n    \"content\": \"Hello, Johan!\"\n}%n")));
+            String writerString = writer.toString();
+            String headerString = String.format("200%n" +
+                            "Content-Type: application/json;charset=UTF-8%n");
+            assertThat(writerString, startsWith(headerString));
+            assertJsonEqualsNonStrict(writerString.replace(headerString, "").trim(),
+                    "{\n    \"id\": 1,\n    \"content\": \"Hello, Johan!\"\n}");
         }
     }
 


### PR DESCRIPTION
Tests in `io/restassured/module/mockmvc/ResponseLoggingTest.java` uses `jackson` to serialize objects into json and assert the serialized results with several hard-coded strings. However, the order of serialized json is not guaranteed so tests may fail if the order is different. So tests may fail or pass without any changes made to the source code and cannot serve as good regression tests.

This PR proposes to use `JSONAssert` and change test assertions to check JSON results in a safer way.