### PR TITLE
Introduce JSON-B object mapper type

### DIFF
--- a/json-path/pom.xml
+++ b/json-path/pom.xml
@@ -100,8 +100,13 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse</groupId>
+            <artifactId>yasson</artifactId>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/json-path/src/main/groovy/io/restassured/internal/path/json/mapping/JsonObjectDeserializer.groovy
+++ b/json-path/src/main/groovy/io/restassured/internal/path/json/mapping/JsonObjectDeserializer.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019,2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,8 @@ import io.restassured.path.json.mapper.factory.GsonObjectMapperFactory
 import io.restassured.path.json.mapper.factory.Jackson1ObjectMapperFactory
 import io.restassured.path.json.mapper.factory.Jackson2ObjectMapperFactory
 import io.restassured.path.json.mapper.factory.JohnzonObjectMapperFactory
+import io.restassured.path.json.mapper.factory.JsonbObjectMapperFactory
+
 import org.apache.commons.lang3.Validate
 
 class JsonObjectDeserializer {
@@ -72,8 +74,10 @@ class JsonObjectDeserializer {
             return deserializeWithGson(deserializationCtx, jsonPathConfig.gsonObjectMapperFactory()) as T
         } else if (ObjectMapperResolver.isJohnzonInClassPath()) {
             return deserializeWithJohnzon(deserializationCtx, jsonPathConfig.johnzonObjectMapperFactory()) as T
+        } else if (ObjectMapperResolver.isYassonInClassPath()) {
+            return deserializeWithJsonb(deserializationCtx, jsonPathConfig.jsonbObjectMapperFactory()) as T
         }
-        throw new IllegalStateException("Cannot deserialize object because no JSON deserializer found in classpath. Please put either Jackson (Databind) or Gson in the classpath.")
+        throw new IllegalStateException("Cannot deserialize object because no JSON deserializer found in classpath. Please put Jackson (Databind), Gson, Jackson, or Yasson in the classpath.")
     }
 
     private static <T> T deserializeWithObjectMapper(ObjectDeserializationContext ctx, JsonParserType mapperType, JsonPathConfig config) {
@@ -85,6 +89,8 @@ class JsonObjectDeserializer {
             return deserializeWithGson(ctx, config.gsonObjectMapperFactory()) as T
         } else if (mapperType == JsonParserType.JOHNZON && ObjectMapperResolver.isJohnzonInClassPath()) {
             return deserializeWithJohnzon(ctx, config.johnzonObjectMapperFactory()) as T
+        } else if (mapperType == JsonParserType.JSONB && ObjectMapperResolver.isYassonInClassPath()) {
+            return deserializeWithJsonb(ctx, config.jsonbObjectMapperFactory()) as T
         } else {
             def lowerCase = mapperType.toString().toLowerCase()
             throw new IllegalArgumentException("Cannot deserialize object using $mapperType because $lowerCase doesn't exist in the classpath.")
@@ -106,4 +112,8 @@ class JsonObjectDeserializer {
 	static def deserializeWithJohnzon(ObjectDeserializationContext ctx, JohnzonObjectMapperFactory factory) {
 		new JsonPathJohnzonObjectDeserializer(factory).deserialize(ctx)
 	}
+	
+	static def deserializeWithJsonb(ObjectDeserializationContext ctx, JsonbObjectMapperFactory factory) {
+        new JsonPathJsonbObjectDeserializer(factory).deserialize(ctx)
+    }
 }

--- a/json-path/src/main/groovy/io/restassured/internal/path/json/mapping/JsonPathJsonbObjectDeserializer.groovy
+++ b/json-path/src/main/groovy/io/restassured/internal/path/json/mapping/JsonPathJsonbObjectDeserializer.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.restassured.internal.path.json.mapping
+
+import io.restassured.common.mapper.ObjectDeserializationContext
+import io.restassured.path.json.mapper.factory.JsonbObjectMapperFactory
+import io.restassured.path.json.mapping.JsonPathObjectDeserializer
+import javax.json.bind.Jsonb
+
+import java.lang.reflect.Type
+
+import static io.restassured.internal.common.assertion.AssertParameter.notNull
+
+class JsonPathJsonbObjectDeserializer implements JsonPathObjectDeserializer {
+  private final JsonbObjectMapperFactory factory
+
+  JsonPathJsonbObjectDeserializer(JsonbObjectMapperFactory factory) {
+    notNull(factory, "JsonbObjectMapperFactory")
+    this.factory = factory;
+  }
+
+  private Jsonb createJsonbObjectMapper(Type cls, String charset) {
+    return factory.create(cls, charset)
+  }
+
+  @Override
+  def deserialize(ObjectDeserializationContext context) {
+    def cls = context.getType()
+    def mapper = createJsonbObjectMapper(cls, context.getCharset())
+
+    context.getDataToDeserialize().asInputStream().withReader { reader ->
+      mapper.fromJson(reader, cls)
+    }
+  }
+}

--- a/json-path/src/main/java/io/restassured/path/json/JsonPath.java
+++ b/json-path/src/main/java/io/restassured/path/json/JsonPath.java
@@ -1085,6 +1085,8 @@ public class JsonPath {
             cfg = cfg.defaultParserType(JsonParserType.JACKSON_2);
         } else if (cfg.hasCustomJohnzonObjectMapperFactory()) {
             cfg = cfg.defaultParserType(JsonParserType.JOHNZON);
+        } else if (cfg.hasCustomJsonbObjectMapperFactory()) {
+            cfg = cfg.defaultParserType(JsonParserType.JSONB);
         }
 
         //noinspection unchecked

--- a/json-path/src/main/java/io/restassured/path/json/config/JsonParserType.java
+++ b/json-path/src/main/java/io/restassured/path/json/config/JsonParserType.java
@@ -20,5 +20,5 @@ package io.restassured.path.json.config;
  * Specifies different pre-defined JSON parser types
  */
 public enum JsonParserType {
-    JACKSON_2, JACKSON_1, GSON, JOHNZON
+    JACKSON_2, JACKSON_1, GSON, JOHNZON, JSONB
 }

--- a/json-path/src/main/java/io/restassured/path/json/config/JsonPathConfig.java
+++ b/json-path/src/main/java/io/restassured/path/json/config/JsonPathConfig.java
@@ -40,6 +40,7 @@ public class JsonPathConfig {
     private final Jackson1ObjectMapperFactory jackson1ObjectMapperFactory;
     private final Jackson2ObjectMapperFactory jackson2ObjectMapperFactory;
     private final JohnzonObjectMapperFactory johnzonObjectMapperFactory;
+    private final JsonbObjectMapperFactory jsonbObjectMapperFactory;
     private final String charset;
 
 
@@ -50,7 +51,8 @@ public class JsonPathConfig {
      */
     public JsonPathConfig(JsonPathConfig config) {
         this(config.numberReturnType(), config.defaultParserType(), config.gsonObjectMapperFactory(), config.jackson1ObjectMapperFactory(),
-                config.jackson2ObjectMapperFactory(), config.johnzonObjectMapperFactory(), config.defaultDeserializer(), config.charset());
+                config.jackson2ObjectMapperFactory(), config.johnzonObjectMapperFactory(), config.jsonbObjectMapperFactory(),
+                config.defaultDeserializer(), config.charset());
     }
 
     /**
@@ -58,7 +60,8 @@ public class JsonPathConfig {
      */
     public JsonPathConfig() {
         this(FLOAT_AND_DOUBLE, null, new DefaultGsonObjectMapperFactory(), new DefaultJackson1ObjectMapperFactory(),
-                new DefaultJackson2ObjectMapperFactory(), new DefaultJohnzonObjectMapperFactory(), null, defaultCharset());
+                new DefaultJackson2ObjectMapperFactory(), new DefaultJohnzonObjectMapperFactory(), 
+                new DefaultYassonObjectMapperFactory(), null, defaultCharset());
     }
 
 
@@ -67,7 +70,8 @@ public class JsonPathConfig {
      */
     public JsonPathConfig(NumberReturnType numberReturnType) {
         this(numberReturnType, null, new DefaultGsonObjectMapperFactory(), new DefaultJackson1ObjectMapperFactory(),
-                new DefaultJackson2ObjectMapperFactory(), new DefaultJohnzonObjectMapperFactory(), null, defaultCharset());
+                new DefaultJackson2ObjectMapperFactory(), new DefaultJohnzonObjectMapperFactory(), 
+                new DefaultYassonObjectMapperFactory(), null, defaultCharset());
 
     }
 
@@ -76,13 +80,15 @@ public class JsonPathConfig {
      */
     public JsonPathConfig(String defaultCharset) {
         this(FLOAT_AND_DOUBLE, null, new DefaultGsonObjectMapperFactory(), new DefaultJackson1ObjectMapperFactory(),
-                new DefaultJackson2ObjectMapperFactory(), new DefaultJohnzonObjectMapperFactory(), null, defaultCharset);
+                new DefaultJackson2ObjectMapperFactory(), new DefaultJohnzonObjectMapperFactory(), 
+                new DefaultYassonObjectMapperFactory(), null, defaultCharset);
 
     }
 
     private JsonPathConfig(NumberReturnType numberReturnType, JsonParserType parserType, GsonObjectMapperFactory gsonObjectMapperFactory,
                            Jackson1ObjectMapperFactory jackson1ObjectMapperFactory, Jackson2ObjectMapperFactory jackson2ObjectMapperFactory,
-                           JohnzonObjectMapperFactory johnzonObjectMapperFactory, JsonPathObjectDeserializer defaultDeserializer, String charset) {
+                           JohnzonObjectMapperFactory johnzonObjectMapperFactory,JsonbObjectMapperFactory jsonbObjectMapperFactory, 
+                           JsonPathObjectDeserializer defaultDeserializer, String charset) {
         if (numberReturnType == null) throw new IllegalArgumentException("numberReturnType cannot be null");
         charset = StringUtils.trimToNull(charset);
         if (charset == null) throw new IllegalArgumentException("Charset cannot be empty");
@@ -94,6 +100,7 @@ public class JsonPathConfig {
         this.jackson1ObjectMapperFactory = jackson1ObjectMapperFactory;
         this.jackson2ObjectMapperFactory = jackson2ObjectMapperFactory;
         this.johnzonObjectMapperFactory = johnzonObjectMapperFactory;
+        this.jsonbObjectMapperFactory = jsonbObjectMapperFactory;
     }
 
     private static String defaultCharset() {
@@ -113,7 +120,7 @@ public class JsonPathConfig {
     public JsonPathConfig charset(String charset) {
         return new JsonPathConfig(numberReturnType, defaultParserType, gsonObjectMapperFactory,
                 jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, 
-                    johnzonObjectMapperFactory, defaultDeserializer, charset);
+                    johnzonObjectMapperFactory, jsonbObjectMapperFactory, defaultDeserializer, charset);
     }
 
 
@@ -130,7 +137,7 @@ public class JsonPathConfig {
     public JsonPathConfig numberReturnType(NumberReturnType numberReturnType) {
         return new JsonPathConfig(numberReturnType, defaultParserType, gsonObjectMapperFactory,
                 jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, 
-                    johnzonObjectMapperFactory, defaultDeserializer, charset);
+                    johnzonObjectMapperFactory, jsonbObjectMapperFactory, defaultDeserializer, charset);
     }
 
     public boolean shouldRepresentJsonNumbersAsBigDecimal() {
@@ -160,6 +167,10 @@ public class JsonPathConfig {
     public boolean hasCustomJohnzonObjectMapperFactory() {
         return johnzonObjectMapperFactory() != null && johnzonObjectMapperFactory().getClass() != DefaultJohnzonObjectMapperFactory.class;
     }
+    
+    public boolean hasCustomJsonbObjectMapperFactory() {
+        return jsonbObjectMapperFactory() != null && jsonbObjectMapperFactory().getClass() != DefaultYassonObjectMapperFactory.class;
+    }
 
     /**
      * Creates an json path configuration that uses the specified parser type as default.
@@ -169,7 +180,7 @@ public class JsonPathConfig {
     public JsonPathConfig defaultParserType(JsonParserType defaultParserType) {
         return new JsonPathConfig(numberReturnType, defaultParserType, gsonObjectMapperFactory,
                 jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, 
-                    johnzonObjectMapperFactory, defaultDeserializer, charset);
+                    johnzonObjectMapperFactory, jsonbObjectMapperFactory, defaultDeserializer, charset);
     }
 
     public JsonPathObjectDeserializer defaultDeserializer() {
@@ -187,7 +198,7 @@ public class JsonPathConfig {
      */
     public JsonPathConfig defaultObjectDeserializer(JsonPathObjectDeserializer defaultObjectDeserializer) {
         return new JsonPathConfig(numberReturnType, null, gsonObjectMapperFactory, jackson1ObjectMapperFactory,
-                jackson2ObjectMapperFactory, johnzonObjectMapperFactory, defaultObjectDeserializer, charset);
+                jackson2ObjectMapperFactory, johnzonObjectMapperFactory, jsonbObjectMapperFactory, defaultObjectDeserializer, charset);
     }
 
     public GsonObjectMapperFactory gsonObjectMapperFactory() {
@@ -202,7 +213,7 @@ public class JsonPathConfig {
     public JsonPathConfig gsonObjectMapperFactory(GsonObjectMapperFactory gsonObjectMapperFactory) {
         return new JsonPathConfig(numberReturnType, defaultParserType, gsonObjectMapperFactory,
                 jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, 
-                    johnzonObjectMapperFactory, defaultDeserializer, charset);
+                    johnzonObjectMapperFactory, jsonbObjectMapperFactory, defaultDeserializer, charset);
     }
 
     public Jackson1ObjectMapperFactory jackson1ObjectMapperFactory() {
@@ -217,7 +228,7 @@ public class JsonPathConfig {
     public JsonPathConfig jackson1ObjectMapperFactory(Jackson1ObjectMapperFactory jackson1ObjectMapperFactory) {
         return new JsonPathConfig(numberReturnType, defaultParserType, gsonObjectMapperFactory,
                 jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, 
-                    johnzonObjectMapperFactory, defaultDeserializer, charset);
+                    johnzonObjectMapperFactory, jsonbObjectMapperFactory, defaultDeserializer, charset);
     }
 
     public Jackson2ObjectMapperFactory jackson2ObjectMapperFactory() {
@@ -236,7 +247,22 @@ public class JsonPathConfig {
     public JsonPathConfig jackson2ObjectMapperFactory(Jackson2ObjectMapperFactory jackson2ObjectMapperFactory) {
         return new JsonPathConfig(numberReturnType, defaultParserType, gsonObjectMapperFactory,
                 jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, 
-                    johnzonObjectMapperFactory, defaultDeserializer, charset);
+                    johnzonObjectMapperFactory, jsonbObjectMapperFactory, defaultDeserializer, charset);
+    }
+    
+    public JsonbObjectMapperFactory jsonbObjectMapperFactory() {
+        return jsonbObjectMapperFactory;
+    }
+
+    /**
+     * Specify a custom JSON-B object mapper factory.
+     *
+     * @param jsonbObjectMapperFactory The object mapper factory
+     */
+    public JsonPathConfig jsonbObjectMapperFactory(JsonbObjectMapperFactory jsonbObjectMapperFactory) {
+        return new JsonPathConfig(numberReturnType, defaultParserType, gsonObjectMapperFactory,
+                jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, 
+                    johnzonObjectMapperFactory, jsonbObjectMapperFactory, defaultDeserializer, charset);
     }
 
     /**

--- a/json-path/src/main/java/io/restassured/path/json/mapper/factory/DefaultYassonObjectMapperFactory.java
+++ b/json-path/src/main/java/io/restassured/path/json/mapper/factory/DefaultYassonObjectMapperFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,12 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package io.restassured.path.json.mapper.factory;
 
-package io.restassured.mapper;
+import java.lang.reflect.Type;
 
-/**
- * The predefined object mappers that can be used with REST Assured
- */
-public enum ObjectMapperType {
-    JACKSON_2, JACKSON_1, GSON, JAXB, JOHNZON, JSONB
+import javax.json.bind.Jsonb;
+
+import org.eclipse.yasson.JsonBindingProvider;
+
+public class DefaultYassonObjectMapperFactory implements JsonbObjectMapperFactory {
+    
+    private static Object cachedJsonb = null;
+    
+	@Override
+	public Jsonb create(Type cls, String charset) {
+	    if (cachedJsonb == null) {
+	        cachedJsonb = new JsonBindingProvider().create().build();
+	    }
+	    return (Jsonb) cachedJsonb;
+	}
 }

--- a/json-path/src/main/java/io/restassured/path/json/mapper/factory/JsonbObjectMapperFactory.java
+++ b/json-path/src/main/java/io/restassured/path/json/mapper/factory/JsonbObjectMapperFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,15 @@
  * limitations under the License.
  */
 
-package io.restassured.mapper;
+package io.restassured.path.json.mapper.factory;
+
+import javax.json.bind.Jsonb;
+
+import io.restassured.common.mapper.factory.ObjectMapperFactory;
 
 /**
- * The predefined object mappers that can be used with REST Assured
+ * Interface for JSON-B object mappers. Implement this class and register it to the ObjectMapperConfig if you
+ * want to override default settings for the Jsonb object mapper.
  */
-public enum ObjectMapperType {
-    JACKSON_2, JACKSON_1, GSON, JAXB, JOHNZON, JSONB
+public interface JsonbObjectMapperFactory extends ObjectMapperFactory<Jsonb> {
 }

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,8 @@
         <jackson1.version>1.9.11</jackson1.version>
         <jackson2.version>2.10.2</jackson2.version>
         <johnzon.version>1.1.11</johnzon.version>
-        <javax.json.version>1.1.4</javax.json.version>
+        <yasson.version>1.0.6</yasson.version>
+        <jakarta.json.version>1.1.6</jakarta.json.version>
         <maven-javadoc.version>2.9.1</maven-javadoc.version>
         <surefire.version>2.22.0</surefire.version>
         <kotlin.version>1.3.50</kotlin.version>
@@ -375,9 +376,14 @@
                 <version>${johnzon.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.json</groupId>
-                <artifactId>javax.json-api</artifactId>
-                <version>${javax.json.version}</version>
+                <groupId>org.eclipse</groupId>
+                <artifactId>yasson</artifactId>
+                <version>${yasson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.json</groupId>
+                <artifactId>jakarta.json-api</artifactId>
+                <version>${jakarta.json.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.code.gson</groupId>

--- a/rest-assured-common/src/main/java/io/restassured/common/mapper/resolver/ObjectMapperResolver.java
+++ b/rest-assured-common/src/main/java/io/restassured/common/mapper/resolver/ObjectMapperResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019, 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ public class ObjectMapperResolver {
     private static final boolean isJaxbPresent = existInCP("javax.xml.bind.Binder");
     private static final boolean isGsonPresent = existInCP("com.google.gson.Gson");
     private static final boolean isJohnzonPresent = existInCP("org.apache.johnzon.mapper.Mapper");
+    private static final boolean isYassonPresent = existInCP("org.eclipse.yasson.JsonBindingProvider");
 
     public static boolean isJackson1InClassPath() {
         return isJackson1Present;
@@ -43,5 +44,9 @@ public class ObjectMapperResolver {
     
     public static boolean isJohnzonInClassPath() {
         return isJohnzonPresent;
+    }
+    
+    public static boolean isYassonInClassPath() {
+        return isYassonPresent;
     }
 }

--- a/rest-assured/pom.xml
+++ b/rest-assured/pom.xml
@@ -147,8 +147,13 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
+            <groupId>org.eclipse</groupId>
+            <artifactId>yasson</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
             <optional>true</optional>
         </dependency>
         <!-- Test dependencies -->

--- a/rest-assured/src/main/groovy/io/restassured/internal/mapping/JsonbMapper.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/mapping/JsonbMapper.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.restassured.internal.mapping
+
+import io.restassured.internal.path.json.mapping.JsonPathJsonbObjectDeserializer
+import io.restassured.mapper.ObjectMapper
+import io.restassured.mapper.ObjectMapperDeserializationContext
+import io.restassured.mapper.ObjectMapperSerializationContext
+import io.restassured.path.json.mapper.factory.JsonbObjectMapperFactory
+import io.restassured.path.json.mapping.JsonPathObjectDeserializer
+
+class JsonbMapper implements ObjectMapper {
+	private JsonbObjectMapperFactory factory;
+	
+	private JsonPathObjectDeserializer deserializer;
+
+	public JsonbMapper(JsonbObjectMapperFactory factory) {
+		this.factory = factory;
+		deserializer = new JsonPathJsonbObjectDeserializer(factory)
+	}
+
+	def Object deserialize(ObjectMapperDeserializationContext context) {
+		return deserializer.deserialize(context);
+	}
+
+	def Object serialize(ObjectMapperSerializationContext context) {
+		def object = context.getObjectToSerialize();
+		def mapper = factory.create(object.getClass(), context.getCharset())
+		
+		new StringWriter().withWriter { out ->
+			mapper.writeObject(context.getObjectToSerialize(), out)
+			out.toString();
+		}
+	}
+
+}

--- a/rest-assured/src/main/java/io/restassured/RestAssured.java
+++ b/rest-assured/src/main/java/io/restassured/RestAssured.java
@@ -27,6 +27,7 @@ import io.restassured.internal.*;
 import io.restassured.internal.common.assertion.AssertParameter;
 import io.restassured.internal.log.LogRepository;
 import io.restassured.mapper.ObjectMapper;
+import io.restassured.mapper.ObjectMapperType;
 import io.restassured.matcher.RestAssuredMatchers;
 import io.restassured.parsing.Parser;
 import io.restassured.path.json.JsonPath;
@@ -559,6 +560,17 @@ public class RestAssured {
     public static void objectMapper(ObjectMapper objectMapper) {
         Validate.notNull(objectMapper, "Default object mapper cannot be null");
         config = config().objectMapperConfig(ObjectMapperConfig.objectMapperConfig().defaultObjectMapper(objectMapper));
+    }
+    
+    /**
+     * Set a object mapper type that'll be used when serializing and deserializing Java objects to and from it's
+     * document representation (XML, JSON etc).
+     *
+     * @param objectMapperType The object mapper type to use.
+     */
+    public static void objectMapper(ObjectMapperType objectMapperType) {
+        Validate.notNull(objectMapperType, "Default object mapper type cannot be null");
+        config = config().objectMapperConfig(ObjectMapperConfig.objectMapperConfig().defaultObjectMapperType(objectMapperType));
     }
 
     /**

--- a/rest-assured/src/main/java/io/restassured/config/ObjectMapperConfig.java
+++ b/rest-assured/src/main/java/io/restassured/config/ObjectMapperConfig.java
@@ -35,6 +35,7 @@ public class ObjectMapperConfig implements Config {
     private final Jackson2ObjectMapperFactory jackson2ObjectMapperFactory;
     private final JAXBObjectMapperFactory jaxbObjectMapperFactory;
     private final JohnzonObjectMapperFactory johnzonObjectMapperFactory;
+    private final JsonbObjectMapperFactory jsonbObjectMapperFactory;
     private final boolean isUserConfigured;
 
     /**
@@ -51,6 +52,7 @@ public class ObjectMapperConfig implements Config {
         jackson2ObjectMapperFactory = new DefaultJackson2ObjectMapperFactory();
         jaxbObjectMapperFactory = new DefaultJAXBObjectMapperFactory();
         johnzonObjectMapperFactory = new DefaultJohnzonObjectMapperFactory();
+        jsonbObjectMapperFactory = new DefaultYassonObjectMapperFactory();
         isUserConfigured = false;
     }
 
@@ -62,7 +64,7 @@ public class ObjectMapperConfig implements Config {
     public ObjectMapperConfig(ObjectMapperType defaultObjectMapperType) {
         this(null, defaultObjectMapperType, new DefaultGsonObjectMapperFactory(), new DefaultJackson1ObjectMapperFactory(),
                 new DefaultJackson2ObjectMapperFactory(), new DefaultJAXBObjectMapperFactory(), 
-                    new DefaultJohnzonObjectMapperFactory(), true);
+                    new DefaultJohnzonObjectMapperFactory(), new DefaultYassonObjectMapperFactory(), true);
     }
 
     /**
@@ -73,13 +75,14 @@ public class ObjectMapperConfig implements Config {
     public ObjectMapperConfig(ObjectMapper defaultObjectMapper) {
         this(defaultObjectMapper, null, new DefaultGsonObjectMapperFactory(), new DefaultJackson1ObjectMapperFactory(),
                 new DefaultJackson2ObjectMapperFactory(), new DefaultJAXBObjectMapperFactory(), 
-                    new DefaultJohnzonObjectMapperFactory(), true);
+                    new DefaultJohnzonObjectMapperFactory(), new DefaultYassonObjectMapperFactory(), true);
     }
 
     private ObjectMapperConfig(ObjectMapper defaultObjectMapper, ObjectMapperType defaultObjectMapperType,
                                GsonObjectMapperFactory gsonObjectMapperFactory, Jackson1ObjectMapperFactory jackson1ObjectMapperFactory,
                                Jackson2ObjectMapperFactory jackson2ObjectMapperFactory, JAXBObjectMapperFactory jaxbObjectMapperFactory,
-                               JohnzonObjectMapperFactory johnzonObjectMapperFactory, boolean isUserConfigured) {
+                               JohnzonObjectMapperFactory johnzonObjectMapperFactory, JsonbObjectMapperFactory jsonbObjectMapperFactory, 
+                               boolean isUserConfigured) {
         Validate.notNull(gsonObjectMapperFactory, GsonObjectMapperFactory.class.getSimpleName() + " cannot be null");
         Validate.notNull(jackson1ObjectMapperFactory, Jackson1ObjectMapperFactory.class.getSimpleName() + " cannot be null");
         Validate.notNull(jackson2ObjectMapperFactory, Jackson2ObjectMapperFactory.class.getSimpleName() + " cannot be null");
@@ -91,6 +94,7 @@ public class ObjectMapperConfig implements Config {
         this.jackson2ObjectMapperFactory = jackson2ObjectMapperFactory;
         this.jaxbObjectMapperFactory = jaxbObjectMapperFactory;
         this.johnzonObjectMapperFactory = johnzonObjectMapperFactory;
+        this.jsonbObjectMapperFactory = jsonbObjectMapperFactory;
         this.isUserConfigured = isUserConfigured;
     }
 
@@ -110,7 +114,7 @@ public class ObjectMapperConfig implements Config {
     public ObjectMapperConfig defaultObjectMapperType(ObjectMapperType defaultObjectMapperType) {
         return new ObjectMapperConfig(defaultObjectMapper, defaultObjectMapperType, gsonObjectMapperFactory,
                 jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, jaxbObjectMapperFactory, 
-                    johnzonObjectMapperFactory, true);
+                    johnzonObjectMapperFactory, jsonbObjectMapperFactory, true);
     }
 
     public ObjectMapper defaultObjectMapper() {
@@ -142,7 +146,7 @@ public class ObjectMapperConfig implements Config {
     public ObjectMapperConfig gsonObjectMapperFactory(GsonObjectMapperFactory gsonObjectMapperFactory) {
         return new ObjectMapperConfig(defaultObjectMapper, defaultObjectMapperType, gsonObjectMapperFactory,
                 jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, jaxbObjectMapperFactory, 
-                    johnzonObjectMapperFactory, true);
+                    johnzonObjectMapperFactory, jsonbObjectMapperFactory, true);
     }
 
     public Jackson1ObjectMapperFactory jackson1ObjectMapperFactory() {
@@ -157,7 +161,7 @@ public class ObjectMapperConfig implements Config {
     public ObjectMapperConfig jackson1ObjectMapperFactory(Jackson1ObjectMapperFactory jackson1ObjectMapperFactory) {
         return new ObjectMapperConfig(defaultObjectMapper, defaultObjectMapperType, gsonObjectMapperFactory,
                 jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, jaxbObjectMapperFactory, 
-                    johnzonObjectMapperFactory, true);
+                    johnzonObjectMapperFactory, jsonbObjectMapperFactory, true);
     }
 
     public Jackson2ObjectMapperFactory jackson2ObjectMapperFactory() {
@@ -172,7 +176,7 @@ public class ObjectMapperConfig implements Config {
     public ObjectMapperConfig jackson2ObjectMapperFactory(Jackson2ObjectMapperFactory jackson2ObjectMapperFactory) {
         return new ObjectMapperConfig(defaultObjectMapper, defaultObjectMapperType, gsonObjectMapperFactory,
                 jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, jaxbObjectMapperFactory, 
-                   johnzonObjectMapperFactory, true);
+                   johnzonObjectMapperFactory, jsonbObjectMapperFactory, true);
     }
 
     public JAXBObjectMapperFactory jaxbObjectMapperFactory() {
@@ -181,6 +185,21 @@ public class ObjectMapperConfig implements Config {
     
     public JohnzonObjectMapperFactory johnzonObjectMapperFactory() {
         return johnzonObjectMapperFactory;
+    }
+    
+    public JsonbObjectMapperFactory jsonbObjectMapperFactory() {
+        return jsonbObjectMapperFactory;
+    }
+    
+    /**
+     * Specify a custom JSON-B object mapper factory.
+     *
+     * @param jsonbObjectMapperFactory The object mapper factory
+     */
+    public ObjectMapperConfig jsonbObjectMapperFactory(JsonbObjectMapperFactory jsonbObjectMapperFactory) {
+        return new ObjectMapperConfig(defaultObjectMapper, defaultObjectMapperType, gsonObjectMapperFactory,
+                jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, jaxbObjectMapperFactory, 
+                   johnzonObjectMapperFactory, jsonbObjectMapperFactory, true);
     }
 
     /**
@@ -191,7 +210,7 @@ public class ObjectMapperConfig implements Config {
     public ObjectMapperConfig jaxbObjectMapperFactory(JAXBObjectMapperFactory jaxbObjectMapperFactory) {
         return new ObjectMapperConfig(defaultObjectMapper, defaultObjectMapperType, gsonObjectMapperFactory,
                 jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, jaxbObjectMapperFactory, 
-                    johnzonObjectMapperFactory, true);
+                    johnzonObjectMapperFactory, jsonbObjectMapperFactory, true);
     }
 
     /**


### PR DESCRIPTION
Introduces a new mapper type for the Jakarta EE JSON Binding (JSON-B) specification. By default it will use Eclipse Yasson as the JSON-B implementation.

Testing is covered by `JsonPathBuiltinObjectDeserializationTest` which is parameterized to cover all values of `ObjectMapperType`.

Also adding a convenience configuration method to `RestAssured`, which simplifies user config for when they do want to override the default provider:
```java
// without new helper method
RestAssured.config = RestAssured.config.objectMapperConfig(ObjectMapperConfig.objectMapperConfig()
                                    .defaultObjectMapperType(ObjectMapperType.JSONB));

// with new helper method
RestAssured.objectMapper(ObjectMapperType.JSONB);
```