### PR TITLE
Allow CookieFilter to decide if cookie name has to be checked when storing cookies

### DIFF
--- a/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/LoggingITest.java
+++ b/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/LoggingITest.java
@@ -1193,46 +1193,46 @@ public class LoggingITest extends WithJetty {
                         "Content-Length: ")),
                 endsWith(String.format("Server: Jetty(9.3.2.v20150730)%n" +
                         "%n" +
-                        "<!--%n" +
-                        "  ~ Copyright 2019 the original author or authors.%n" +
-                        "  ~%n" +
-                        "  ~ Licensed under the Apache License, Version 2.0 (the \"License\");%n" +
-                        "  ~ you may not use this file except in compliance with the License.%n" +
-                        "  ~ You may obtain a copy of the License at%n" +
-                        "  ~%n" +
-                        "  ~        http://www.apache.org/licenses/LICENSE-2.0%n" +
-                        "  ~%n" +
-                        "  ~ Unless required by applicable law or agreed to in writing, software%n" +
-                        "  ~ distributed under the License is distributed on an \"AS IS\" BASIS,%n" +
-                        "  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.%n" +
-                        "  ~ See the License for the specific language governing permissions and%n" +
-                        "  ~ limitations under the License.%n" +
-                        "  -->%n" +
-                        "<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" elementFormDefault=\"qualified\">%n" +
-                        "  <xs:element name=\"records\">%n" +
-                        "    <xs:complexType>%n" +
-                        "      <xs:sequence>%n" +
-                        "        <xs:element maxOccurs=\"unbounded\" ref=\"car\"/>%n" +
-                        "      </xs:sequence>%n" +
-                        "    </xs:complexType>%n" +
-                        "  </xs:element>%n" +
-                        "  <xs:element name=\"car\">%n" +
-                        "    <xs:complexType>%n" +
-                        "      <xs:sequence>%n" +
-                        "        <xs:element ref=\"country\"/>%n" +
-                        "        <xs:element ref=\"record\"/>%n" +
-                        "      </xs:sequence>%n" +
-                        "      <xs:attribute name=\"make\" use=\"required\" type=\"xs:NCName\"/>%n" +
-                        "      <xs:attribute name=\"name\" use=\"required\"/>%n" +
-                        "      <xs:attribute name=\"year\" use=\"required\" type=\"xs:integer\"/>%n" +
-                        "    </xs:complexType>%n" +
-                        "  </xs:element>%n" +
-                        "  <xs:element name=\"country\" type=\"xs:string\"/>%n" +
-                        "  <xs:element name=\"record\">%n" +
-                        "    <xs:complexType mixed=\"true\">%n" +
-                        "      <xs:attribute name=\"type\" use=\"required\" type=\"xs:NCName\"/>%n" +
-                        "    </xs:complexType>%n" +
-                        "  </xs:element>%n" +
+                        "<!--\n" +
+                        "  ~ Copyright 2019 the original author or authors.\n" +
+                        "  ~\n" +
+                        "  ~ Licensed under the Apache License, Version 2.0 (the \"License\");\n" +
+                        "  ~ you may not use this file except in compliance with the License.\n" +
+                        "  ~ You may obtain a copy of the License at\n" +
+                        "  ~\n" +
+                        "  ~        http://www.apache.org/licenses/LICENSE-2.0\n" +
+                        "  ~\n" +
+                        "  ~ Unless required by applicable law or agreed to in writing, software\n" +
+                        "  ~ distributed under the License is distributed on an \"AS IS\" BASIS,\n" +
+                        "  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n" +
+                        "  ~ See the License for the specific language governing permissions and\n" +
+                        "  ~ limitations under the License.\n" +
+                        "  -->\n" +
+                        "<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" elementFormDefault=\"qualified\">\n" +
+                        "  <xs:element name=\"records\">\n" +
+                        "    <xs:complexType>\n" +
+                        "      <xs:sequence>\n" +
+                        "        <xs:element maxOccurs=\"unbounded\" ref=\"car\"/>\n" +
+                        "      </xs:sequence>\n" +
+                        "    </xs:complexType>\n" +
+                        "  </xs:element>\n" +
+                        "  <xs:element name=\"car\">\n" +
+                        "    <xs:complexType>\n" +
+                        "      <xs:sequence>\n" +
+                        "        <xs:element ref=\"country\"/>\n" +
+                        "        <xs:element ref=\"record\"/>\n" +
+                        "      </xs:sequence>\n" +
+                        "      <xs:attribute name=\"make\" use=\"required\" type=\"xs:NCName\"/>\n" +
+                        "      <xs:attribute name=\"name\" use=\"required\"/>\n" +
+                        "      <xs:attribute name=\"year\" use=\"required\" type=\"xs:integer\"/>\n" +
+                        "    </xs:complexType>\n" +
+                        "  </xs:element>\n" +
+                        "  <xs:element name=\"country\" type=\"xs:string\"/>\n" +
+                        "  <xs:element name=\"record\">\n" +
+                        "    <xs:complexType mixed=\"true\">\n" +
+                        "      <xs:attribute name=\"type\" use=\"required\" type=\"xs:NCName\"/>\n" +
+                        "    </xs:complexType>\n" +
+                        "  </xs:element>\n" +
                         "</xs:schema>%n"))
         ));
     }

--- a/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/SpecificationBuilderITest.java
+++ b/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/SpecificationBuilderITest.java
@@ -386,10 +386,10 @@ public class SpecificationBuilderITest extends WithJetty {
                 "Content-Length: 59%n" +
                 "Server: Jetty(9.3.2.v20150730)%n" +
                 "%n" +
-                "{%n" +
-                "    \"firstName\": \"John\",%n" +
-                "    \"lastName\": \"Doe\",%n" +
-                "    \"fullName\": \"John Doe\"%n" +
+                "{\n" +
+                "    \"firstName\": \"John\",\n" +
+                "    \"lastName\": \"Doe\",\n" +
+                "    \"fullName\": \"John Doe\"\n" +
                 "}%n")));
     }
 
@@ -413,10 +413,10 @@ public class SpecificationBuilderITest extends WithJetty {
                 "Content-Length: 59%n" +
                 "Server: Jetty(9.3.2.v20150730)%n" +
                 "%n" +
-                "{%n" +
-                "    \"firstName\": \"John\",%n" +
-                "    \"lastName\": \"Doe\",%n" +
-                "    \"fullName\": \"John Doe\"%n" +
+                "{\n" +
+                "    \"firstName\": \"John\",\n" +
+                "    \"lastName\": \"Doe\",\n" +
+                "    \"fullName\": \"John Doe\"\n" +
                 "}%n")));
     }
 

--- a/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/AsyncTest.java
+++ b/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/AsyncTest.java
@@ -45,7 +45,7 @@ public class AsyncTest {
     @Test public void
     can_supply_string_as_body_for_async_post_with_config_in_given() {
         RestAssuredMockMvc.given().
-                config(newConfig().asyncConfig(withTimeout(10, TimeUnit.MILLISECONDS))).
+                config(newConfig().asyncConfig(withTimeout(10, TimeUnit.SECONDS))).
                 body("a string").
         when().
                 async().post("/stringBody").


### PR DESCRIPTION
Hi,
I found that when I have have two cookies with same name eg. `JSESSIONID` with different paths eg. `/` and `/bar`, and called URI is like `/bar/xxx`, current implementation of `CookieFilter` does not send second cookie (in Chrome this kind of cookies are normally send to server).
I have created PR, so please check it if it is correct. I made this check configurable because of backward compatibility.
Thx,
Ivos