### PR TITLE
 Fix for decoder config not being set on the RestAssuredResponse.

### DIFF
--- a/modules/spring-mock-mvc/src/main/java/io/restassured/module/mockmvc/internal/MockMvcRequestSenderImpl.java
+++ b/modules/spring-mock-mvc/src/main/java/io/restassured/module/mockmvc/internal/MockMvcRequestSenderImpl.java
@@ -206,6 +206,7 @@ class MockMvcRequestSenderImpl implements MockMvcRequestSender, MockMvcRequestAs
             response = mvcResult.getResponse();
             restAssuredResponse = new MockMvcRestAssuredResponseImpl(perform, logRepository);
             restAssuredResponse.setConfig(ConfigConverter.convertToRestAssuredConfig(config));
+            restAssuredResponse.setDecoderConfig(config.getDecoderConfig());
             restAssuredResponse.setContent(response.getContentAsByteArray());
             restAssuredResponse.setContentType(response.getContentType());
             restAssuredResponse.setHasExpectations(false);


### PR DESCRIPTION
 If the decoder config is not set on the response, lookup of default charset for a content-type defaults to using standard charset of the jvm. Standard charset of the jvm is partially controlled by system property `file.encoding`.