### PR TITLE
Make tests more stable by using JSONAssert equals

### DIFF
--- a/modules/spring-web-test-client/pom.xml
+++ b/modules/spring-web-test-client/pom.xml
@@ -33,6 +33,7 @@
         <spring.restdocs.version>2.0.2.RELEASE</spring.restdocs.version>
         <powermock-module-junit4.version>1.7.4</powermock-module-junit4.version>
         <commons-io.version>2.5</commons-io.version>
+        <org.skyscreamer>1.5.0</org.skyscreamer>
     </properties>
 
     <build>
@@ -140,6 +141,12 @@
             <groupId>org.springframework.restdocs</groupId>
             <artifactId>spring-restdocs-webtestclient</artifactId>
             <version>${spring.restdocs.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <version>${org.skyscreamer}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/modules/spring-web-test-client/src/test/java/io/restassured/module/webtestclient/ResponseLoggingTest.java
+++ b/modules/spring-web-test-client/src/test/java/io/restassured/module/webtestclient/ResponseLoggingTest.java
@@ -21,6 +21,7 @@ import io.restassured.config.LogConfig;
 import io.restassured.module.webtestclient.config.RestAssuredWebTestClientConfig;
 import io.restassured.module.webtestclient.setup.PostController;
 import org.apache.commons.io.output.WriterOutputStream;
+import org.json.JSONException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,6 +32,7 @@ import java.io.StringWriter;
 import static java.nio.charset.Charset.defaultCharset;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
@@ -55,7 +57,7 @@ public class ResponseLoggingTest {
 
 	@Test
 	public void
-	logging_if_response_validation_fails_works() {
+	logging_if_response_validation_fails_works() throws JSONException {
 		try {
 			RestAssuredWebTestClient.given()
 					.standaloneSetup(new PostController())
@@ -69,16 +71,19 @@ public class ResponseLoggingTest {
 
 			fail("Should throw AssertionError");
 		} catch (AssertionError e) {
-			assertThat(writer.toString(), equalTo(String.format("200%n" +
+			String writerString = writer.toString();
+			String headerString = String.format("200%n" +
 					"Content-Type: application/json;charset=UTF-8%n" +
 					"Content-Length: 34%n" +
-					"%n" +
+					"%n"
+			);
+			assertThat(writerString, startsWith(headerString));
+			LoggingIfValidationFailsTest.assertJSONEqual(writerString.replace(headerString, "").trim(),
 					"{" +
 					"\n    \"id\": 1,\n" +
 					"    \"content\": \"Hello, Johan!\"" +
 					"\n" +
-					"}%n"
-			)));
+					"}%n");
 		}
 	}
 


### PR DESCRIPTION
Similar to the change you already merged for `ResponseLoggingTest.java`(#1236):

Tests in `io.restassured.module.webtestclient.LoggingIfValidationFailsTest.java` and `io.restassured.module.webtestclient.ResponseLoggingTest.java` use `jackson` to serialize objects into json and assert the serialized results with several hard-coded strings. However, the order of serialized json is not guaranteed so tests may fail if the order is different. So tests may fail or pass without any changes made to the source code.

This PR proposes to use JSONAssert and change test assertions to check JSON results in a safer way.