### PR TITLE
Upgrade activation 1.1.1 to 1.2.1 + use groupId jakarta.activation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -318,22 +318,19 @@
             <dependency>
                 <groupId>jakarta.xml.bind</groupId>
                 <artifactId>jakarta.xml.bind-api</artifactId>
-                <version>2.3.2</version>
+                <version>2.3.3</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.xml.bind</groupId>
-                <artifactId>jaxb-osgi</artifactId>
-                <version>2.3.0.1</version>
-            </dependency>
-            <dependency>
-                <groupId>javax.activation</groupId>
-                <artifactId>activation</artifactId>
-                <version>1.1.1</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.sling</groupId>
-                <artifactId>org.apache.sling.javax.activation</artifactId>
-                <version>0.1.0</version>
+                <artifactId>jaxb-impl</artifactId>
+                <version>2.3.3</version>
+                <exclusions>
+                    <exclusion>
+                        <!-- jakarta.xml.bind-api already brings in jakarta.activation:jakarta.activation-api -->
+                        <groupId>com.sun.activation</groupId>
+                        <artifactId>jakarta.activation</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>

--- a/xml-path/pom.xml
+++ b/xml-path/pom.xml
@@ -86,12 +86,7 @@
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-osgi</artifactId>
-        </dependency>
-        <!-- Note that we're not using the standard 'javax.activation:activation:1.1.1' since it doesn't work with OSGi-->
-        <dependency>
-            <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.javax.activation</artifactId>
+            <artifactId>jaxb-impl</artifactId>
         </dependency>
 
         <!-- Test -->


### PR DESCRIPTION
Removes dependencies javax.activation, com.sun.activation and org.apache.sling.javax.activation in favor of jakarta.activation