### PR TITLE
Fix content type name before charset recognition

### DIFF
--- a/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/ContentTypeTest.java
+++ b/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/ContentTypeTest.java
@@ -39,14 +39,14 @@ public class ContentTypeTest {
 
         RestAssuredMockMvc.given().
                 standaloneSetup(new GreetingController()).
-                contentType(ContentType.JSON).
+                contentType(ContentType.XML).
                 interceptor(requestBuilder -> contentType.set(extractContentType(requestBuilder))).
         when().
                 get("/greeting?name={name}", "Johan").
         then().
                statusCode(200);
 
-        assertThat(contentType.get()).isEqualTo("application/json;charset=" + RestAssuredMockMvc.config().getEncoderConfig().defaultContentCharset());
+        assertThat(contentType.get()).isEqualTo("application/xml;charset=" + RestAssuredMockMvc.config().getEncoderConfig().defaultContentCharset());
     }
 
     @Test public void
@@ -101,23 +101,6 @@ public class ContentTypeTest {
     }
 
     @Test public void
-    doesnt_duplication_of_content_type_with_default_charset() {
-        final List<String> contentTypes = new ArrayList<>();
-
-        RestAssuredMockMvc.given().
-                standaloneSetup(new GreetingController()).
-                contentType(ContentType.JSON).
-                interceptor(requestBuilder -> contentTypes.add(extractContentType(requestBuilder))).
-        when().
-                get("/greeting?name={name}", "Johan").
-        then().
-                statusCode(200);
-
-        assertThat(contentTypes.size()).isEqualTo(1);
-        assertThat(contentTypes.get(0)).isEqualTo("application/json;charset=ISO-8859-1");
-    }
-
-    @Test public void
     doesnt_duplication_of_content_type() {
         final List<String> contentTypes = new ArrayList<>();
 
@@ -133,6 +116,22 @@ public class ContentTypeTest {
 
         assertThat(contentTypes.size()).isEqualTo(1);
         assertThat(contentTypes.get(0)).isEqualTo("application/json");
+    }
+
+    @Test public void
+    adds_default_charset_to_content_type_if_specified_in_default_charsets() {
+        final AtomicReference<String> contentType = new AtomicReference<>();
+
+        RestAssuredMockMvc.given().
+                standaloneSetup(new GreetingController()).
+                contentType(ContentType.JSON).
+                interceptor(requestBuilder -> contentType.set(extractContentType(requestBuilder))).
+                when().
+                get("/greeting?name={name}", "Johan").
+                then().
+                statusCode(200);
+
+        assertThat(contentType.get()).isEqualTo("application/json;charset=UTF-8");
     }
 
     private String extractContentType(MockHttpServletRequestBuilder requestBuilder) {

--- a/modules/spring-web-test-client/src/test/java/io/restassured/module/webtestclient/ContentTypeTest.java
+++ b/modules/spring-web-test-client/src/test/java/io/restassured/module/webtestclient/ContentTypeTest.java
@@ -44,11 +44,11 @@ public class ContentTypeTest {
 	public void
 	adds_default_charset_to_content_type_by_default() {
 		RestAssuredWebTestClient.given()
-				.contentType(ContentType.JSON)
+				.contentType(ContentType.XML)
 				.when()
 				.get("/contentType")
 				.then()
-				.body("requestContentType", equalTo("application/json;charset="
+				.body("requestContentType", equalTo("application/xml;charset="
 						+ RestAssuredWebTestClient.config().getEncoderConfig().defaultContentCharset()));
 	}
 
@@ -93,5 +93,15 @@ public class ContentTypeTest {
 				.then()
 				.statusCode(200)
 				.body("requestContentType", equalTo("application/json"));
+	}
+
+	@Test public void
+	adds_default_charset_to_content_type_if_specified_in_default_charsets() {
+		RestAssuredWebTestClient.given()
+				.contentType(ContentType.JSON)
+				.when()
+				.get("/contentType")
+				.then()
+				.body("requestContentType", equalTo("application/json;charset=UTF-8"));
 	}
 }


### PR DESCRIPTION
Hi. I faced little bug in `HeaderHelper.class`. It is building default charset for content type in a such way:
```
if (encoderConfig.shouldAppendDefaultContentCharsetToContentTypeIfUndefined()) {
     contentType += "; charset=";
     if (encoderConfig.hasDefaultCharsetForContentType(contentType)) {
         contentType += encoderConfig.defaultCharsetForContentType(contentType);
     } else {
         contentType += encoderConfig.defaultContentCharset();
     }
}
return contentType;
```
So it means that content type is modified with "; charset=" part before passing this value to EncoderConfig#hasDefaultCharsetForContentType. And in my case with "application/json" I've got 
"application/json; charset=". Instead of getting charset as UTF-8 that is configured in EncoderConfig#DEFAULT_CHARSET_FOR_CONTENT_TYPE as default for json content type I've got ISO-8859-1 that is used as global default charset. 

Pls review and share your thoughts. Thanks. 