### PR TITLE
According to RFC 7159, application/json should not have charset

### DIFF
--- a/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/UnicodeITest.java
+++ b/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/UnicodeITest.java
@@ -60,15 +60,4 @@ public class UnicodeITest extends WithJetty {
                 body("value", equalTo("啊 ☆"));
     }
 
-    @Test public void
-    unicode_values_works_in_json_content() {
-        given().
-                contentType(ContentType.JSON).
-                body(new HashMap<String, String>() {{put("title", "äöüß€’");}}).
-        when().
-                post("/reflect").
-        then().
-                statusCode(200).
-                body("title", equalTo("äöüß€’"));
-    }
 }

--- a/modules/spring-commons/src/main/java/io/restassured/module/spring/commons/HeaderHelper.java
+++ b/modules/spring-commons/src/main/java/io/restassured/module/spring/commons/HeaderHelper.java
@@ -93,6 +93,10 @@ public class HeaderHelper {
         if (StringUtils.isBlank(baseContentType) && !multiParts.isEmpty()) {
             baseContentType = "multipart/" + config.getMultiPartConfig().defaultSubtype();
         }
+        if (StringUtils.equals(baseContentType, "application/json")
+                && !config.getEncoderConfig().hasDefaultCharsetForContentType("application/json")) {
+            return baseContentType;
+        }
 
         if (StringUtils.containsIgnoreCase(baseContentType, CHARSET)) {
             return baseContentType;

--- a/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/ContentTypeTest.java
+++ b/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/ContentTypeTest.java
@@ -50,6 +50,22 @@ public class ContentTypeTest {
     }
 
     @Test public void
+    doesnt_add_default_charset_to_application_json_by_default() {
+        final AtomicReference<String> contentType = new AtomicReference<>();
+
+        RestAssuredMockMvc.given().
+                standaloneSetup(new GreetingController()).
+                contentType(ContentType.JSON).
+                interceptor(requestBuilder -> contentType.set(extractContentType(requestBuilder))).
+                when().
+                get("/greeting?name={name}", "Johan").
+                then().
+                statusCode(200);
+
+        assertThat(contentType.get()).isEqualTo("application/json");
+    }
+
+    @Test public void
     adds_specific_charset_to_content_type_by_default() {
         final AtomicReference<String> contentType = new AtomicReference<>();
 
@@ -118,21 +134,6 @@ public class ContentTypeTest {
         assertThat(contentTypes.get(0)).isEqualTo("application/json");
     }
 
-    @Test public void
-    adds_default_charset_to_content_type_if_specified_in_default_charsets() {
-        final AtomicReference<String> contentType = new AtomicReference<>();
-
-        RestAssuredMockMvc.given().
-                standaloneSetup(new GreetingController()).
-                contentType(ContentType.JSON).
-                interceptor(requestBuilder -> contentType.set(extractContentType(requestBuilder))).
-                when().
-                get("/greeting?name={name}", "Johan").
-                then().
-                statusCode(200);
-
-        assertThat(contentType.get()).isEqualTo("application/json;charset=UTF-8");
-    }
 
     private String extractContentType(MockHttpServletRequestBuilder requestBuilder) {
         Object contentType = Whitebox.getInternalState(requestBuilder, "contentType");

--- a/modules/spring-web-test-client/src/test/java/io/restassured/module/webtestclient/ContentTypeTest.java
+++ b/modules/spring-web-test-client/src/test/java/io/restassured/module/webtestclient/ContentTypeTest.java
@@ -95,13 +95,4 @@ public class ContentTypeTest {
 				.body("requestContentType", equalTo("application/json"));
 	}
 
-	@Test public void
-	adds_default_charset_to_content_type_if_specified_in_default_charsets() {
-		RestAssuredWebTestClient.given()
-				.contentType(ContentType.JSON)
-				.when()
-				.get("/contentType")
-				.then()
-				.body("requestContentType", equalTo("application/json;charset=UTF-8"));
-	}
 }

--- a/rest-assured/src/main/java/io/restassured/config/EncoderConfig.java
+++ b/rest-assured/src/main/java/io/restassured/config/EncoderConfig.java
@@ -36,11 +36,6 @@ public class EncoderConfig implements Config {
     private static final String UTF_8 = "UTF-8";
     private static final String ISO_8859_1 = "ISO-8859-1";
 
-    private static final Map<String, String> DEFAULT_CHARSET_FOR_CONTENT_TYPE = new HashMap<String, String>() {{
-        put(ContentType.JSON.toString(), UTF_8);
-        put("text/json", UTF_8);
-    }};
-
     private final String defaultContentCharset;
     private final String defaultQueryParameterCharset;
     private final boolean shouldAppendDefaultContentCharsetToContentTypeIfUndefined;
@@ -59,11 +54,11 @@ public class EncoderConfig implements Config {
      * </p>
      */
     public EncoderConfig() {
-        this(ISO_8859_1, UTF_8, true, new HashMap<>(), DEFAULT_CHARSET_FOR_CONTENT_TYPE, true);
+        this(ISO_8859_1, UTF_8, true, new HashMap<>(), new HashMap<>(), true);
     }
 
     public EncoderConfig(String defaultContentCharset, String defaultQueryParameterCharset) {
-        this(defaultContentCharset, defaultQueryParameterCharset, true, new HashMap<>(), DEFAULT_CHARSET_FOR_CONTENT_TYPE, true);
+        this(defaultContentCharset, defaultQueryParameterCharset, true, new HashMap<>(), new HashMap<>(), true);
     }
 
     private EncoderConfig(String defaultContentCharset, String defaultQueryParameterCharset,


### PR DESCRIPTION
RFC 7159:

> Added a note to the "IANA Considerations" clarifying the absence of a "charset" parameter for the application/json media type.

I know this effect can be achieved by flag "`shouldAppendDefaultContentCharsetToContentTypeIfUndefined`". My intention is change default behavior for application/json.

EncoderConfig: if application/json is removed from DEFAULT_CHARSET_FOR_CONTENT_TYPE, only text/json will remain. text/json is non-standard, undefined content type, so is't behavior is also undefined. I removed text/json and whole DEFAULT_CHARSET_FOR_CONTENT_TYPE. (text/json is abandoned concept, replaced by application/json)

UnicodeITest: I removed failing test. I debug the case and I found that response content type is set to "application/json; charset=ISO-8591-1". This content type is undefined, therefore expectation is undefined. I decide remove the test.