### PR TITLE
Describe non matching actual method with Hamcrest matcher format

### DIFF
--- a/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/ErrorMessageITest.java
+++ b/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/ErrorMessageITest.java
@@ -36,11 +36,11 @@ public class ErrorMessageITest extends WithJetty {
         exception.expectMessage("2 expectations failed.\n" +
                 "JSON path lotto.lottoId doesn't match.\n" +
                 "Expected: a value less than <2>\n" +
-                "  Actual: 5\n" +
+                "  Actual: <5>\n" +
                 "\n" +
                 "JSON path lotto.winning-numbers doesn't match.\n" +
                 "Expected: a collection containing <21>\n" +
-                "  Actual: [2, 45, 34, 23, 7, 5, 3]");
+                "  Actual: <[2, 45, 34, 23, 7, 5, 3]>");
 
         expect().
                 body("lotto.lottoId", lessThan(2)).
@@ -55,11 +55,11 @@ public class ErrorMessageITest extends WithJetty {
         exception.expectMessage("2 expectations failed.\n" +
                 "JSON path lotto.lottoId doesn't match.\n" +
                 "Expected: a value less than <2>\n" +
-                "  Actual: 5\n" +
+                "  Actual: <5>\n" +
                 "\n" +
                 "JSON path lotto.winning-numbers doesn't match.\n" +
                 "Expected: a collection containing <21>\n" +
-                "  Actual: [2, 45, 34, 23, 7, 5, 3]");
+                "  Actual: <[2, 45, 34, 23, 7, 5, 3]>");
 
         expect().
                 body("lotto.lottoId", greaterThan(4)).
@@ -77,11 +77,11 @@ public class ErrorMessageITest extends WithJetty {
                 "\n" +
                 "JSON path lotto.lottoId doesn't match.\n" +
                 "Expected: a value less than <2>\n" +
-                "  Actual: 5\n" +
+                "  Actual: <5>\n" +
                 "\n" +
                 "JSON path lotto.winning-numbers doesn't match.\n" +
                 "Expected: a collection containing <21>\n" +
-                "  Actual: [2, 45, 34, 23, 7, 5, 3]");
+                "  Actual: <[2, 45, 34, 23, 7, 5, 3]>");
 
         expect().
                 statusCode(201).
@@ -146,11 +146,11 @@ public class ErrorMessageITest extends WithJetty {
         exception.expectMessage("2 expectations failed.\n" +
                 "JSON path lotto.lottoId doesn't match.\n" +
                 "Expected: a value less than <2>\n" +
-                "  Actual: 5\n" +
+                "  Actual: <5>\n" +
                 "\n" +
                 "JSON path lotto.winning-numbers doesn't match.\n" +
                 "Expected: a collection containing <21>\n" +
-                "  Actual: [2, 45, 34, 23, 7, 5, 3]");
+                "  Actual: <[2, 45, 34, 23, 7, 5, 3]>");
 
         when().
                 get("/lotto").

--- a/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/JSONGetITest.java
+++ b/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/JSONGetITest.java
@@ -53,6 +53,28 @@ public class JSONGetITest extends WithJetty {
     }
 
     @Test
+    public void decimalNumberTypeMismatchIsRecognizable() {
+        exception.expect(AssertionError.class);
+        exception.expectMessage(equalTo("1 expectation failed.\n" +
+                "JSON path values.pi doesn't match.\n" +
+                "Expected: <3.14>\n" +
+                "  Actual: <3.14F>\n"));
+
+        expect().body("values.pi", equalTo(3.14)).when().get("/numbers");
+    }
+
+    @Test
+    public void integerNumberTypeMismatchIsRecognizable() {
+        exception.expect(AssertionError.class);
+        exception.expectMessage(equalTo("1 expectation failed.\n" +
+                "JSON path values.answer doesn't match.\n" +
+                "Expected: <42L>\n" +
+                "  Actual: <42>\n"));
+
+        expect().body("values.answer", equalTo(42L)).when().get("/numbers");
+    }
+
+    @Test
     public void parameterSupportWithStandardHashMap() {
         Map<String, String> parameters = new HashMap<>();
         parameters.put("firstName", "John");
@@ -256,7 +278,7 @@ public class JSONGetITest extends WithJetty {
         exception.expect(AssertionError.class);
         exception.expectMessage(containsString("JSON path lotto.winning-numbers doesn't match."));
         exception.expectMessage(containsString("Expected: a collection containing <43>"));
-        exception.expectMessage(containsString("  Actual: [2, 45, 34, 23, 7, 5, 3]"));
+        exception.expectMessage(containsString("  Actual: <[2, 45, 34, 23, 7, 5, 3]>"));
 
         expect().body("lotto.lottoId", greaterThan(2), "lotto.winning-numbers", hasItem(43)).when().get("/lotto");
     }
@@ -586,7 +608,7 @@ public class JSONGetITest extends WithJetty {
     throws_assertion_error_when_multiple_keys_are_the_same_in_a_multi_body_expectation_and_the_non_last_fails() {
         exception.expect(AssertionError.class);
         exception.expectMessage("Expected: <7>\n" +
-                "  Actual: 5");
+                "  Actual: <5>");
 
         when().
                 get("/lotto").

--- a/examples/scalatra-example/src/main/scala/io/restassured/scalatra/ScalatraRestExample.scala
+++ b/examples/scalatra-example/src/main/scala/io/restassured/scalatra/ScalatraRestExample.scala
@@ -304,6 +304,14 @@ class ScalatraRestExample extends ScalatraServlet {
     compact(render(json))
   }
 
+  get("/numbers") {
+    val json = ("values" ->
+      ("pi" -> 3.14) ~
+      ("answer" -> 42)
+    )
+    compact(render(json))
+  }
+
   get("/reflect") {
     reflect
   }

--- a/rest-assured/src/main/groovy/io/restassured/assertion/BodyMatcher.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/assertion/BodyMatcher.groovy
@@ -101,7 +101,11 @@ class BodyMatcher {
           if (result instanceof Object[]) {
             result = result.join(",")
           }
-          errorMessage = format("%s %s doesn't match.\nExpected: %s\n  Actual: %s\n", assertion.description(), key, removeQuotesIfString(matcher.toString()), result)
+          errorMessage = format("%s %s doesn't match.\nExpected: %s\n  Actual: %s\n",
+                  assertion.description(),
+                  key,
+                  removeQuotesIfString(matcher.toString()),
+                  removeQuotesIfString(new StringDescription().appendValue(result).toString()))
         } else {
           errorMessage = format("%s %s doesn't match.\n%s", assertion.description(), key, getDescription(matcher, result))
         }

--- a/rest-assured/src/test/java/io/restassured/assertion/BodyMatcherTest.java
+++ b/rest-assured/src/test/java/io/restassured/assertion/BodyMatcherTest.java
@@ -1,0 +1,91 @@
+package io.restassured.assertion;
+
+import io.restassured.builder.ResponseBuilder;
+import io.restassured.config.MatcherConfig;
+import io.restassured.config.RestAssuredConfig;
+import io.restassured.http.ContentType;
+import io.restassured.internal.ContentParser;
+import io.restassured.internal.ResponseParserRegistrar;
+import io.restassured.response.Response;
+import org.hamcrest.core.IsEqual;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+@RunWith(Parameterized.class)
+public class BodyMatcherTest {
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {MatcherConfig.ErrorDescriptionType.REST_ASSURED, 123, "123", true, ""},
+                {MatcherConfig.ErrorDescriptionType.REST_ASSURED, 123, "123.0", false, "JSON path foo doesn't match.\nExpected: <123>\n  Actual: <123.0F>\n"},
+                {MatcherConfig.ErrorDescriptionType.REST_ASSURED, 123L, "123", false, "JSON path foo doesn't match.\nExpected: <123L>\n  Actual: <123>\n"},
+                {MatcherConfig.ErrorDescriptionType.REST_ASSURED, 123L, "123.0", false, "JSON path foo doesn't match.\nExpected: <123L>\n  Actual: <123.0F>\n"},
+                {MatcherConfig.ErrorDescriptionType.REST_ASSURED, 3.14d, "3.14", false, "JSON path foo doesn't match.\nExpected: <3.14>\n  Actual: <3.14F>\n"},
+                {MatcherConfig.ErrorDescriptionType.REST_ASSURED, 3.14f, "3.14", true, ""},
+                {MatcherConfig.ErrorDescriptionType.REST_ASSURED, "3.14", "\"3.14\"", true, ""},
+                {MatcherConfig.ErrorDescriptionType.REST_ASSURED, "3.14", "\"2.34\"", false, "JSON path foo doesn't match.\nExpected: 3.14\n  Actual: 2.34\n"},
+                {MatcherConfig.ErrorDescriptionType.HAMCREST, 123, "123", true, ""},
+                {MatcherConfig.ErrorDescriptionType.HAMCREST, 123, "123.0", false, "JSON path foo doesn't match.\n\nExpected: <123>\n  Actual: was <123.0F>"},
+                {MatcherConfig.ErrorDescriptionType.HAMCREST, 123L, "123", false, "JSON path foo doesn't match.\n\nExpected: <123L>\n  Actual: was <123>"},
+                {MatcherConfig.ErrorDescriptionType.HAMCREST, 123L, "123.0", false, "JSON path foo doesn't match.\n\nExpected: <123L>\n  Actual: was <123.0F>"},
+                {MatcherConfig.ErrorDescriptionType.HAMCREST, 3.14d, "3.14", false, "JSON path foo doesn't match.\n\nExpected: <3.14>\n  Actual: was <3.14F>"},
+                {MatcherConfig.ErrorDescriptionType.HAMCREST, 3.14f, "3.14", true, ""},
+                {MatcherConfig.ErrorDescriptionType.HAMCREST, "3.14", "\"3.14\"", true, ""},
+                {MatcherConfig.ErrorDescriptionType.HAMCREST, "3.14", "\"2.34\"", false, "JSON path foo doesn't match.\n\nExpected: \"3.14\"\n  Actual: was \"2.34\""},
+        });
+    }
+
+    private final ResponseParserRegistrar responseParserRegistrar;
+
+    private final MatcherConfig.ErrorDescriptionType errorDescriptionType;
+    private final Object isEqualValue;
+    private final Object jsonValue;
+    private final boolean expectedSuccess;
+    private final String expectedMessage;
+
+    public BodyMatcherTest(MatcherConfig.ErrorDescriptionType errorDescriptionType,
+                           Object isEqualValue,
+                           Object jsonValue,
+                           boolean expectedSuccess,
+                           String expectedMessage) {
+        this.responseParserRegistrar = new ResponseParserRegistrar();
+        this.errorDescriptionType = errorDescriptionType;
+        this.isEqualValue = isEqualValue;
+        this.jsonValue = jsonValue;
+        this.expectedSuccess = expectedSuccess;
+        this.expectedMessage = expectedMessage;
+    }
+
+    @Test
+    public void expectedMessageFormatWithTypeDetails() {
+        final RestAssuredConfig config = RestAssuredConfig.newConfig()
+                .matcherConfig(MatcherConfig.matcherConfig()
+                        .errorDescriptionType(errorDescriptionType));
+
+        final BodyMatcher bodyMatcher = new BodyMatcher();
+        bodyMatcher.setKey("foo");
+        bodyMatcher.setMatcher(new IsEqual<>(isEqualValue));
+        bodyMatcher.setRpr(responseParserRegistrar);
+
+        final Response response = new ResponseBuilder()
+                .setStatusCode(200)
+                .setBody("{\"foo\": " + jsonValue + "}")
+                .setContentType(ContentType.JSON)
+                .build();
+
+        final Map<String, Object> result = (Map<String, Object>) bodyMatcher.validate(response,
+                new ContentParser().parse(response, responseParserRegistrar, config, true),
+                config);
+
+        assertThat(result.get("success"), equalTo(expectedSuccess));
+        assertThat(result.get("errorMessage"), equalTo(expectedMessage));
+    }
+}


### PR DESCRIPTION
Hi,
I found that when I want to match json-path with float/double value Hamcrest matcher and this matcher fails, I am getting cryptic message that says that `3.14` is not equal to `3.14`.
This problem is when I put double constant to matcher, but value is parsed as float from Json payload. 
That do you think about this change?
Thx,
Ivos


original:
```
JSON path values.pi doesn't match.
Expected: <3.14>
  Actual: 3.14
``` 
after my change:
```
JSON path values.pi doesn't match.
Expected: <3.14>
  Actual: <3.14F>
``` 