### PR TITLE
Upgrade json-schema-validator to 2.2.14

### DIFF
--- a/modules/json-schema-validator/pom.xml
+++ b/modules/json-schema-validator/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>com.github.java-json-tools</groupId>
             <artifactId>json-schema-validator</artifactId>
-            <version>2.2.10</version>
+            <version>2.2.14</version>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
See https://github.com/quarkusio/quarkus/issues/12913 for more details.

The old `json-schema-validator` version uses an old `jackson-coreutils` and is not compatible with the one we now use on Quarkus.

If you have the ability to release a 4.3.2 with this fix, that would be awesome!

Thanks!