### PR TITLE
Ensure subclasses of ResponseOptions do not break Prettifier

### DIFF
--- a/rest-assured/src/main/groovy/io/restassured/internal/support/Prettifier.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/support/Prettifier.groovy
@@ -42,7 +42,7 @@ class Prettifier {
   String getPrettifiedBodyIfPossible(ResponseOptions responseOptions, ResponseBody responseBody) {
     def contentType = responseOptions.getContentType()
     def responseAsString = responseBody.asString()
-    if (isBlank(contentType) || !responseOptions instanceof RestAssuredResponseOptionsImpl) {
+    if (isBlank(contentType) || !(responseOptions instanceof RestAssuredResponseOptionsImpl)) {
       return responseAsString
     }
 


### PR DESCRIPTION
In Prettifier, when working with a subclass of `ResponseOptions` which is not a `RestAssuredResponseOptionsImpl`, a casting error occurs.

Seems like the `instanceof` check was missing some `()`.