### PR TITLE
Upgrade httpclient library

### DIFF
--- a/rest-assured/pom.xml
+++ b/rest-assured/pom.xml
@@ -17,7 +17,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <properties>
-        <httpclient.version>4.5.3</httpclient.version>
+        <httpclient.version>4.5.13</httpclient.version>
     </properties>
     <parent>
         <groupId>io.rest-assured</groupId>


### PR DESCRIPTION
rest-assured makes use of the vulnerable httpclient library at version 4.5.3. The CVSS v2 score for this vulnerability is [rated](https://sca.analysiscenter.veracode.com/vulnerability-database/libraries/Apache-HttpClient/JAVA/MAVEN/lid-133/versions/4.5.3) high. This vulnerability is fixed in httpclient's latest release 4.5.13.