### PR TITLE
Strict Matcher requires same response String instance as argument

### DIFF
--- a/rest-assured/src/main/groovy/io/restassured/assertion/BodyMatcher.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/assertion/BodyMatcher.groovy
@@ -73,12 +73,15 @@ class BodyMatcher {
             errorMessage = getDescription(matcher, contentParser)
           }
         }
-      } else if (!matcher.matches(response.asString())) {
-        success = false
-        if (config.matcherConfig.hasErrorDescriptionType(REST_ASSURED)) {
-          errorMessage = "Response body doesn't match expectation.\nExpected: $matcher\n  Actual: $contentParser\n"
-        } else {
-          errorMessage = format("Response body doesn't match expectation.\n%s", getDescription(matcher, response.asString()))
+      } else {
+        def responseString = response.asString()
+        if (!matcher.matches(responseString)) {
+          success = false
+          if (config.matcherConfig.hasErrorDescriptionType(REST_ASSURED)) {
+            errorMessage = "Response body doesn't match expectation.\nExpected: $matcher\n  Actual: $contentParser\n"
+          } else {
+            errorMessage = format("Response body doesn't match expectation.\n%s", getDescription(matcher, responseString))
+          }
         }
       }
     } else {


### PR DESCRIPTION
JsonPartMatcher from JsonUnit requires the same object instance as argument between `matches` and `describeMismatch` method.

https://github.com/lukas-krecan/JsonUnit/blob/4bb39ae2bf308b8ca6f1ac67725c08e07c0d7bcd/json-unit/src/main/java/net/javacrumbs/jsonunit/JsonMatchers.java#L199-L228