### PR TITLE
pom: update the URL of the project's website

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <artifactId>rest-assured-parent</artifactId>
     <packaging>pom</packaging>
     <version>4.4.1-SNAPSHOT</version>
-    <url>http://code.google.com/p/rest-assured</url>
+    <url>https://rest-assured.io/</url>
     <name>REST Assured Parent POM</name>
     <description>Java DSL for easy testing of REST services</description>
     <inceptionYear>2010</inceptionYear>


### PR DESCRIPTION
So that Maven central points to the right place.

https://search.maven.org/artifact/io.rest-assured/rest-assured/4.4.0/bundle