### PR TITLE
Fix for #1069: fails to parse responses with cookies that has numbers out of signed decimal range

### DIFF
--- a/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/CookieITest.java
+++ b/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/CookieITest.java
@@ -58,7 +58,7 @@ public class CookieITest extends WithJetty {
 
     @Test
     public void supportsDetailedCookieMatchingUsingDsl() {
-        expect().cookie("cookie1", detailedCookie().maxAge(1234567).path(Matchers.notNullValue()))
+        expect().cookie("cookie1", detailedCookie().maxAge(1234567L).path(Matchers.notNullValue()))
                 .when().get("/multiCookie");
     }
 
@@ -67,7 +67,7 @@ public class CookieITest extends WithJetty {
         given()
                 .get("/multiCookie")
                 .then()
-                .cookie("cookie1", detailedCookie().maxAge(1234567).path(Matchers.notNullValue()));
+                .cookie("cookie1", detailedCookie().maxAge(1234567L).path(Matchers.notNullValue()));
     }
 
     @Test
@@ -199,7 +199,7 @@ public class CookieITest extends WithJetty {
         assertThat(secondCookie.getValue(), equalTo("cookieValue2"));
         assertThat(secondCookie.getDomain(), equalTo("localhost"));
         assertThat(secondCookie.getPath(), equalTo("/"));
-        assertThat(secondCookie.getMaxAge(), is(1234567));
+        assertThat(secondCookie.getMaxAge(), is(1234567L));
         assertThat(secondCookie.isSecured(), is(true));
     }
 

--- a/modules/spring-mock-mvc/src/main/java/io/restassured/module/mockmvc/internal/MockMvcRequestSenderImpl.java
+++ b/modules/spring-mock-mvc/src/main/java/io/restassured/module/mockmvc/internal/MockMvcRequestSenderImpl.java
@@ -370,7 +370,7 @@ class MockMvcRequestSenderImpl implements MockMvcRequestSender, MockMvcRequestAs
                     servletCookie.setDomain(cookie.getDomain());
                 }
                 if (cookie.hasMaxAge()) {
-                    servletCookie.setMaxAge(cookie.getMaxAge());
+                    servletCookie.setMaxAge((int) cookie.getMaxAge());
                 }
                 if (cookie.hasPath()) {
                     servletCookie.setPath(cookie.getPath());

--- a/rest-assured/src/main/groovy/io/restassured/assertion/CookieMatcher.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/assertion/CookieMatcher.groovy
@@ -137,7 +137,7 @@ class CookieMatcher {
             } else if(equalsIgnoreCase(name, DOMAIN)) {
                 builder.setDomain(value)
             } else if(equalsIgnoreCase(name, MAX_AGE)) {
-                builder.setMaxAge(Integer.parseInt(value))
+                builder.setMaxAge(Long.parseLong(value))
             } else if(equalsIgnoreCase(name, SECURE)) {
                 builder.setSecured(true)
             } else if(equalsIgnoreCase(name, HTTP_ONLY)) {

--- a/rest-assured/src/main/java/io/restassured/http/Cookie.java
+++ b/rest-assured/src/main/java/io/restassured/http/Cookie.java
@@ -23,6 +23,7 @@ import java.util.Date;
 import java.util.TimeZone;
 
 import static io.restassured.internal.common.assertion.AssertParameter.notNull;
+import static jdk.nashorn.internal.runtime.JSType.UNDEFINED_LONG;
 
 /**
  * Cookie class represents a token or short packet of state information
@@ -53,7 +54,7 @@ public class Cookie implements NameAndValue {
     private static final String COOKIE_ATTRIBUTE_SEPARATOR = ";";
     private static final String EQUALS = "=";
     private static final int UNDEFINED = -1;
-
+    private static final long UNDEFINED_LONG = -1;
     private final String name;
     private final String value;
     private final String comment;
@@ -63,12 +64,12 @@ public class Cookie implements NameAndValue {
     private final boolean secured;
     private final boolean httpOnly;
     private final int version;
-    private final int maxAge;
+    private final long maxAge;
     private final String sameSite;
 
     private Cookie(String name, String value, String comment, Date expiryDate,
                    String domain, String path, boolean secured, boolean httpOnly, int version,
-                   int maxAge, String sameSite) {
+                   long maxAge, String sameSite) {
         this.name = name;
         this.value = value;
         this.comment = comment;
@@ -217,7 +218,7 @@ public class Cookie implements NameAndValue {
      *				cookie in seconds; if negative, means
      *				the cookie persists until browser shutdown
      */
-    public int getMaxAge() {
+    public long getMaxAge() {
         return maxAge;
     }
 
@@ -278,7 +279,7 @@ public class Cookie implements NameAndValue {
         result = 31 * result + (secured ? 1 : 0);
         result = 31 * result + (httpOnly ? 1 : 0);
         result = 31 * result + version;
-        result = 31 * result + maxAge;
+        result = 31 * result + (int) maxAge;
         result = 31 * result + (sameSite != null ? sameSite.hashCode() : 0);
         return result;
     }
@@ -332,7 +333,7 @@ public class Cookie implements NameAndValue {
         private boolean secured = false;
         private boolean httpOnly = false;
         private int version = UNDEFINED;
-        private int maxAge = UNDEFINED;
+        private long maxAge = UNDEFINED_LONG;
         private String sameSite;
 
         /**
@@ -412,7 +413,7 @@ public class Cookie implements NameAndValue {
          *
          * @return an integer specifying the maximum age of the cookie in seconds; if negative, means the cookie persists until browser shutdown
          */
-        public Builder setMaxAge(int maxAge) {
+        public Builder setMaxAge(long maxAge) {
             this.maxAge = maxAge;
             return this;
         }

--- a/rest-assured/src/main/java/io/restassured/matcher/DetailedCookieMatcher.java
+++ b/rest-assured/src/main/java/io/restassured/matcher/DetailedCookieMatcher.java
@@ -187,7 +187,7 @@ public class DetailedCookieMatcher extends CombinableMatcher<Cookie> {
      * @param expectedMaxAgeValue expected max age of cookie
      * @return A {@link DetailedCookieMatcher} instance with and-composed max age property assertion
      */
-    public DetailedCookieMatcher maxAge(int expectedMaxAgeValue) {
+    public DetailedCookieMatcher maxAge(long expectedMaxAgeValue) {
         return maxAge(equalTo(expectedMaxAgeValue));
     }
 

--- a/rest-assured/src/test/java/io/restassured/assertion/CookieMatcherTest.java
+++ b/rest-assured/src/test/java/io/restassured/assertion/CookieMatcherTest.java
@@ -50,25 +50,25 @@ public class CookieMatcherTest {
         assertEquals("12345", sprintCookie.getValue());
         assertEquals(".test.com", sprintCookie.getDomain());
         assertEquals("/", sprintCookie.getPath());
-        assertEquals(1209600, sprintCookie.getMaxAge());
+        assertEquals(1209600L, sprintCookie.getMaxAge());
         assertEquals(false, sprintCookie.isSecured());
         assertEquals(false, sprintCookie.isHttpOnly());
 
         Cookie cookieWithZeroMaxAge = result.get("COOKIE_WITH_ZERO_MAX_AGE");
-        assertEquals(0, cookieWithZeroMaxAge.getVersion());
+        assertEquals(0L, cookieWithZeroMaxAge.getVersion());
         assertEquals("1234", cookieWithZeroMaxAge.getValue());
         assertEquals(".test.com", cookieWithZeroMaxAge.getDomain());
         assertEquals("/", cookieWithZeroMaxAge.getPath());
-        assertEquals(0, cookieWithZeroMaxAge.getMaxAge());
+        assertEquals(0L, cookieWithZeroMaxAge.getMaxAge());
         assertEquals(false, cookieWithZeroMaxAge.isSecured());
         assertEquals(false, cookieWithZeroMaxAge.isHttpOnly());
 
         Cookie cookieWithNegativeMaxAge = result.get("COOKIE_WITH_NEGATIVE_MAX_AGE");
-        assertEquals(0, cookieWithNegativeMaxAge.getVersion());
+        assertEquals(0L, cookieWithNegativeMaxAge.getVersion());
         assertEquals("123456", cookieWithNegativeMaxAge.getValue());
         assertEquals(".test.com", cookieWithNegativeMaxAge.getDomain());
         assertEquals("/", cookieWithNegativeMaxAge.getPath());
-        assertEquals(-1, cookieWithNegativeMaxAge.getMaxAge());
+        assertEquals(-1L, cookieWithNegativeMaxAge.getMaxAge());
         assertEquals(false, cookieWithNegativeMaxAge.isSecured());
         assertEquals(false, cookieWithNegativeMaxAge.isHttpOnly());
 

--- a/rest-assured/src/test/java/io/restassured/http/CookieTest.java
+++ b/rest-assured/src/test/java/io/restassured/http/CookieTest.java
@@ -25,9 +25,9 @@ public class CookieTest {
     @Test public void
     can_use_negative_values_as_max_age() {
         // When
-        Cookie cookie = new Cookie.Builder("hello", "world").setMaxAge(-3600).build();
+        Cookie cookie = new Cookie.Builder("hello", "world").setMaxAge(-3600L).build();
 
         // Then
-        assertThat(cookie.getMaxAge()).isEqualTo(-3600);
+        assertThat(cookie.getMaxAge()).isEqualTo(-3600L);
     }
 }


### PR DESCRIPTION
Changed cookie maxAge from int to long as suggested by @Mjl33