### PR TITLE
feat: a way to add more specific log details

### DIFF
--- a/rest-assured/src/main/java/io/restassured/filter/log/RequestLoggingFilter.java
+++ b/rest-assured/src/main/java/io/restassured/filter/log/RequestLoggingFilter.java
@@ -26,7 +26,10 @@ import org.apache.commons.lang3.Validate;
 
 import java.io.PrintStream;
 import java.nio.charset.Charset;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 import static io.restassured.filter.log.LogDetail.ALL;
 import static io.restassured.filter.log.LogDetail.STATUS;
@@ -46,8 +49,7 @@ public class RequestLoggingFilter implements Filter {
     private final boolean shouldPrettyPrint;
     private final boolean showUrlEncodedUri;
     private final Set<String> blacklistedHeaders;
-
-    private Set<LogDetail> logDetailSet = new TreeSet<>();
+    private final Set<LogDetail> logDetailSet = new HashSet<>();
 
     /**
      * Logs to System.out

--- a/rest-assured/src/main/java/io/restassured/filter/log/RequestLoggingFilter.java
+++ b/rest-assured/src/main/java/io/restassured/filter/log/RequestLoggingFilter.java
@@ -165,7 +165,7 @@ public class RequestLoggingFilter implements Filter {
         return new RequestLoggingFilter().addLog(logDetails);
     }
 
-    public RequestLoggingFilter addLog(LogDetail... logDetails) {
+    private RequestLoggingFilter addLog(LogDetail... logDetails) {
         logDetailSet.addAll(Arrays.asList(logDetails));
         return this;
     }

--- a/rest-assured/src/main/java/io/restassured/internal/print/RequestPrinter.java
+++ b/rest-assured/src/main/java/io/restassured/internal/print/RequestPrinter.java
@@ -88,6 +88,46 @@ public class RequestPrinter {
         return logString;
     }
 
+    public static String print(FilterableRequestSpecification requestSpec, String requestMethod,
+                               String completeRequestUri,
+                               Set<LogDetail> logDetails, Set<String> blacklistedHeaders,
+                               PrintStream stream, boolean shouldPrettyPrint) {
+        final StringBuilder builder = new StringBuilder();
+
+        if (logDetails.contains(ALL)) {
+            return print(requestSpec, requestMethod, completeRequestUri, ALL, blacklistedHeaders, stream, shouldPrettyPrint);
+        } else {
+            if (logDetails.contains(METHOD)) {
+                addSingle(builder, "Request method:", requestMethod);
+            }
+            if (logDetails.contains(URI)) {
+                addSingle(builder, "Request URI:", completeRequestUri);
+            }
+            if (logDetails.contains(PARAMS)) {
+                addMapDetails(builder, "Request params:", requestSpec.getRequestParams());
+                addMapDetails(builder, "Query params:", requestSpec.getQueryParams());
+                addMapDetails(builder, "Form params:", requestSpec.getFormParams());
+                addMapDetails(builder, "Path params:", requestSpec.getNamedPathParams());
+            }
+            if (logDetails.contains(HEADERS)) {
+                addHeaders(requestSpec, blacklistedHeaders, builder);
+            }
+            if (logDetails.contains(COOKIES)) {
+                addCookies(requestSpec, builder);
+            }
+            if (logDetails.contains(PARAMS)) {
+                addMultiParts(requestSpec, builder);
+            }
+            if (logDetails.contains(BODY)) {
+                addBody(requestSpec, builder, shouldPrettyPrint);
+            }
+        }
+
+        final String logString = StringUtils.removeEnd(builder.toString(), SystemUtils.LINE_SEPARATOR);
+        stream.println(logString);
+        return logString;
+    }
+
     private static void addProxy(FilterableRequestSpecification requestSpec, StringBuilder builder) {
         builder.append("Proxy:");
         ProxySpecification proxySpec = requestSpec.getProxySpecification();


### PR DESCRIPTION
- Now: RequestLoggingFilter only have one option LogDetail, there is no way to choose which parts will be logged. 
- Expected: log which request parts that specify.

We can do something like this:
```
RequestLoggingFilter.with(METHOD, HEADERS, BODY)
```
