### PR TITLE
Jaxb migration and upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -336,8 +336,8 @@
                 <version>2.3.3</version>
             </dependency>
             <dependency>
-                <groupId>com.sun.xml.bind</groupId>
-                <artifactId>jaxb-impl</artifactId>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>jaxb-runtime</artifactId>
                 <version>2.3.3</version>
                 <exclusions>
                     <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -338,7 +338,7 @@
             <dependency>
                 <groupId>org.glassfish.jaxb</groupId>
                 <artifactId>jaxb-runtime</artifactId>
-                <version>2.3.3</version>
+                <version>2.3.5</version>
                 <exclusions>
                     <exclusion>
                         <!-- jakarta.xml.bind-api already brings in jakarta.activation:jakarta.activation-api -->

--- a/xml-path/pom.xml
+++ b/xml-path/pom.xml
@@ -85,8 +85,8 @@
             <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
         </dependency>
 
         <!-- Test -->


### PR DESCRIPTION
Migrated the dependency from old com.sun artifact to the reference implementation org.glassfish
https://mvnrepository.com/artifact/com.sun.xml.bind/jaxb-impl/2.3.3
https://mvnrepository.com/artifact/org.glassfish.jaxb/jaxb-runtime/2.3.3

Also, upgraded to the last 2.3.X -> 2.3.5

See issue #1514