### PR TITLE
Fix 1543 - jsonPath: return null if list(array) does not exists in input document

### DIFF
--- a/json-path/src/main/groovy/io/restassured/internal/path/json/JSONAssertion.groovy
+++ b/json-path/src/main/groovy/io/restassured/internal/path/json/JSONAssertion.groovy
@@ -50,8 +50,12 @@ class JSONAssertion implements Assertion {
         throw new IllegalArgumentException(error, e);
       } catch (Exception e) {
         // Check if exception is due to a missing property
-        if (e instanceof NullPointerException && e.getMessage().startsWith("Cannot get property") && e.getMessage().endsWith("on null object")) {
-          return null
+        if (e instanceof NullPointerException){
+          def message = e.getMessage();
+          if (message.equals("Cannot invoke method getAt() on null object") ||
+             (message.startsWith("Cannot get property") && e.getMessage().endsWith("on null object"))) {
+            return null
+          }
         }
         String error = e.getMessage().replace("startup failed:", "Invalid JSON expression:").replace("$root.", generateWhitespace(root.length()));
         throw new IllegalArgumentException(error, e);

--- a/json-path/src/main/groovy/io/restassured/internal/path/json/JSONAssertion.groovy
+++ b/json-path/src/main/groovy/io/restassured/internal/path/json/JSONAssertion.groovy
@@ -53,7 +53,7 @@ class JSONAssertion implements Assertion {
         if (e instanceof NullPointerException){
           def message = e.getMessage();
           if (message.equals("Cannot invoke method getAt() on null object") ||
-             (message.startsWith("Cannot get property") && e.getMessage().endsWith("on null object"))) {
+             (message.startsWith("Cannot get property") && message.endsWith("on null object"))) {
             return null
           }
         }

--- a/json-path/src/test/java/io/restassured/path/json/JsonPathTest.java
+++ b/json-path/src/test/java/io/restassured/path/json/JsonPathTest.java
@@ -789,4 +789,18 @@ public class JsonPathTest {
         // Then
         assertThat(jsonPath.getString("some-list[0]"), equalTo("one"));
     }
+
+
+    /** Tests #1543 is fixed    */
+    @Test public void
+    does_not_fail_on_absent_lists() {
+        // Given
+        String json = "{ \"root\" : { }";
+
+        // When
+        JsonPath jsonPath = JsonPath.from(json);
+
+        // Then   no exception should be thrown
+        assertThat(jsonPath.getString("root.items[0]"), is(nullValue()));
+    }
 }


### PR DESCRIPTION
See #1543 
Closes #1543 