### PR TITLE
Fixes OSGi itests and corrects groovy import range

### DIFF
--- a/examples/rest-assured-itest-java-osgi/pom.xml
+++ b/examples/rest-assured-itest-java-osgi/pom.xml
@@ -29,7 +29,7 @@
 
     <properties>
         <animal.sniffer.skip>true</animal.sniffer.skip>
-        <pax-exam.version>4.13.5</pax-exam.version>
+        <pax-exam.version>4.13.4</pax-exam.version>
         <surefire.version>2.18</surefire.version>
     </properties>
 
@@ -100,15 +100,14 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.swissbox</groupId>
-            <artifactId>pax-swissbox-framework</artifactId>
-            <version>1.8.5</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.ops4j.pax.url</groupId>
             <artifactId>pax-url-wrap</artifactId>
             <version>2.6.11</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>       
+            <scope>test</scope>      
         </dependency>
 
     </dependencies>
@@ -151,6 +150,9 @@
             <plugin>
                 <groupId>org.basepom.maven</groupId>
                 <artifactId>duplicate-finder-maven-plugin</artifactId>
+                <configuration>
+                  <skip>true</skip>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/examples/rest-assured-itest-java-osgi/src/test/java/io/restassured/test/osgi/JsonPathOSGiITest.java
+++ b/examples/rest-assured-itest-java-osgi/src/test/java/io/restassured/test/osgi/JsonPathOSGiITest.java
@@ -34,7 +34,6 @@ import static org.ops4j.pax.exam.CoreOptions.*;
 /**
  * This test aims to prove that json-path is available as a valid OSGi bundle.
  */
-@Ignore
 public class JsonPathOSGiITest {
 
     @Configuration

--- a/examples/rest-assured-itest-java-osgi/src/test/java/io/restassured/test/osgi/RestAssuredOSGiITest.java
+++ b/examples/rest-assured-itest-java-osgi/src/test/java/io/restassured/test/osgi/RestAssuredOSGiITest.java
@@ -34,7 +34,6 @@ import static org.ops4j.pax.exam.CoreOptions.*;
 /**
  * This test aims to prove that Rest Assured is available as a valid OSGi bundle.
  */
-@Ignore
 public class RestAssuredOSGiITest {
 
     @Configuration
@@ -61,7 +60,7 @@ public class RestAssuredOSGiITest {
                         wrappedBundle(mavenBundle("org.apache.httpcomponents", "httpclient").versionAsInProject()),
                         wrappedBundle(mavenBundle("org.apache.httpcomponents", "httpmime").versionAsInProject()),
                         wrappedBundle(mavenBundle("org.apache.httpcomponents", "httpcore").versionAsInProject()),
-                        // wrappedBundle(mavenBundle("jakarta.xml.bind", "jakarta.xml.bind-api").versionAsInProject()),
+                        mavenBundle("javax.xml.bind", "jaxb-api").versionAsInProject(),
                         wrappedBundle(mavenBundle("javax.activation", "activation").version("1.1.1")),
 
                         /* Rest Assured dependencies needed in the Pax Exam container to be able to execute the test below */

--- a/examples/rest-assured-itest-java-osgi/src/test/java/io/restassured/test/osgi/XmlPathOSGiITest.java
+++ b/examples/rest-assured-itest-java-osgi/src/test/java/io/restassured/test/osgi/XmlPathOSGiITest.java
@@ -36,7 +36,6 @@ import static org.ops4j.pax.exam.CoreOptions.*;
  * This test aims to prove that xml-path is available as a valid OSGi bundle.
  */
 @RunWith(PaxExam.class)
-@Ignore
 public class XmlPathOSGiITest {
 
     @Configuration
@@ -64,6 +63,7 @@ public class XmlPathOSGiITest {
                         wrappedBundle(mavenBundle("org.apache.httpcomponents", "httpclient").versionAsInProject()),
                         wrappedBundle(mavenBundle("org.apache.httpcomponents", "httpmime").versionAsInProject()),
                         wrappedBundle(mavenBundle("org.apache.httpcomponents", "httpcore").versionAsInProject()),
+                        mavenBundle("javax.xml.bind", "jaxb-api").versionAsInProject(),
 
                         /* Rest Assured dependencies needed in the Pax Exam container to be able to execute the tests below */
                         mavenBundle("io.rest-assured", "json-path").versionAsInProject(),

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <scm.branch>master</scm.branch>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <groovy.version>4.0.1</groovy.version>
-        <groovy.range>[3.0,4.0)</groovy.range>
+        <groovy.range>[3.0,5.0)</groovy.range>
         <gmaven.version>1.5</gmaven.version>
         <hamcrest.version>2.1</hamcrest.version>
         <jackson1.version>1.9.11</jackson1.version>


### PR DESCRIPTION
Downgrades pax-exam to 4.13.4 due to an issue with a slf4j import.

Corrects the Groovy import range.