### PR TITLE
Fixes #1577 - Added support for ?., *. and ?[ to rootPath

### DIFF
--- a/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/RootPathITest.java
+++ b/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/RootPathITest.java
@@ -71,11 +71,40 @@ public class RootPathITest extends WithJetty {
     }
 
     @Test
+    public void specifyingRootPathThatDoesntEndWithDotAndBodyThatStartsWithSafeRefWorks() {
+        expect().
+                rootPath("store.book").
+                body("?.category.size()", equalTo(4)).
+                body("?.author.size()", equalTo(4)).
+                when().
+                get("/jsonStore");
+    }
+
+    @Test
+    public void specifyingRootPathThatDoesntEndWithDotAndBodyThatStartsWithSpreadWorks() {
+        expect().
+                rootPath("store.book").
+                body("*.category.size()", equalTo(4)).
+                body("*.author.size()", equalTo(4)).
+                when().
+                get("/jsonStore");
+    }
+
+    @Test
     public void specifyingRootPathAndBodyThatStartsWithArrayIndexingWorks() {
         expect().
                 rootPath("store.book").
                  body("[0].category", either(equalTo("reference")).or(equalTo("fiction"))).
         when().
+                get("/jsonStore");
+    }
+
+    @Test
+    public void specifyingRootPathAndBodyThatStartsWithSafeArrayIndexingWorks() {
+        expect().
+                rootPath("store.book").
+                body("?[0].category", either(equalTo("reference")).or(equalTo("fiction"))).
+                when().
                 get("/jsonStore");
     }
 

--- a/rest-assured/src/main/groovy/io/restassured/internal/ResponseSpecificationImpl.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/ResponseSpecificationImpl.groovy
@@ -46,6 +46,10 @@ class ResponseSpecificationImpl implements FilterableResponseSpecification {
 
   private static final String EMPTY = ""
   private static final String DOT = "."
+  private static final String SAFE_REF = "?."
+  private static final String SAFE_INDEX = "?["
+  private static final String SPREAD_REF = "*."
+
   private Matcher<Integer> expectedStatusCode
   private Matcher<String> expectedStatusLine
   private BodyMatcherGroup bodyMatchers = new BodyMatcherGroup()
@@ -641,7 +645,9 @@ class ResponseSpecificationImpl implements FilterableResponseSpecification {
     if (bodyRootPath != null && bodyRootPath != EMPTY) {
       if (bodyRootPath.endsWith(DOT) && key.startsWith(DOT)) {
         return bodyRootPath + substringAfter(key, DOT)
-      } else if (!bodyRootPath.endsWith(DOT) && !key.startsWith(DOT) && !key.startsWith("[")) {
+      } else if (!bodyRootPath.endsWith(DOT) && !key.startsWith(DOT)
+              && !key.startsWith(SAFE_REF) && !key.startsWith("[")
+              && !key.startsWith(SAFE_INDEX) && !key.startsWith(SPREAD_REF)) {
         return bodyRootPath + DOT + key
       }
       return bodyRootPath + key


### PR DESCRIPTION
Fixes #1577

Slightly modified `mergeKeyWithRootPath` function so it would not add dot between root path and key if key starts with `?.`, '?[' or `*.`.

Updated tests