### PR TITLE
How about add more Forked VM when run all tests in build

### DIFF
--- a/examples/rest-assured-itest-java-osgi/pom.xml
+++ b/examples/rest-assured-itest-java-osgi/pom.xml
@@ -128,7 +128,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <forkCount>1</forkCount>
+                    <forkCount>1.5C</forkCount>
                     <reuseForks>false</reuseForks>
                     <excludes>
                         <exclude>none</exclude>


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
