### PR TITLE
Overwrite responseLogDetail when merging ResponseSpecificationImpl.

### DIFF
--- a/rest-assured/src/main/groovy/io/restassured/internal/SpecificationMerger.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/SpecificationMerger.groovy
@@ -53,6 +53,7 @@ class SpecificationMerger {
     thisOne.contentType = with.contentType
     thisOne.rpr.defaultParser = with.rpr.defaultParser
     thisOne.rpr.additional.putAll(with.rpr.additional)
+    thisOne.responseLogDetail = with.responseLogDetail
     thisOne.bodyMatchers.add(with.bodyMatchers)
     thisOne.bodyRootPath = with.bodyRootPath
     thisOne.cookieAssertions.addAll(with.cookieAssertions)

--- a/rest-assured/src/test/groovy/io/restassured/SpecificationMergerTest.groovy
+++ b/rest-assured/src/test/groovy/io/restassured/SpecificationMergerTest.groovy
@@ -22,6 +22,7 @@ import io.restassured.builder.ResponseSpecBuilder
 import io.restassured.config.RestAssuredConfig
 import io.restassured.filter.Filter
 import io.restassured.filter.FilterContext
+import io.restassured.filter.log.LogDetail
 import io.restassured.http.ContentType
 import io.restassured.internal.SpecificationMerger
 import io.restassured.internal.filter.FormAuthFilter
@@ -174,6 +175,16 @@ class SpecificationMergerTest {
     SpecificationMerger.merge(merge, with)
 
     assertEquals Parser.JSON, merge.rpr.defaultParser
+  }
+
+  @Test
+  void overwritesLogDetail() throws Exception {
+    def merge = new ResponseSpecBuilder().log(LogDetail.COOKIES).build()
+    def with = new ResponseSpecBuilder().log(LogDetail.URI).build()
+
+    SpecificationMerger.merge(merge, with)
+
+    assertEquals LogDetail.URI, merge.getLogDetail()
   }
 
   @Test


### PR DESCRIPTION
Calls to `setLogDetail` on `RestAssured.responseSpecification` had no effect because the field wasn't copied when creating the request.

fixes: #1493