### PR TITLE
chore: allow contentType() to accept Spring MediaType

### DIFF
--- a/modules/spring-mock-mvc/src/main/java/io/restassured/module/mockmvc/internal/MockMvcRequestSpecificationImpl.java
+++ b/modules/spring-mock-mvc/src/main/java/io/restassured/module/mockmvc/internal/MockMvcRequestSpecificationImpl.java
@@ -191,6 +191,11 @@ public class MockMvcRequestSpecificationImpl implements MockMvcRequestSpecificat
         return header(CONTENT_TYPE, contentType.toString());
     }
 
+    public MockMvcRequestSpecification contentType(MediaType mediaType) {
+        notNull(mediaType, "mediaType");
+        return header(CONTENT_TYPE, mediaType.toString());
+    }
+
     public MockMvcRequestSpecification contentType(String contentType) {
         notNull(contentType, "contentType");
         return header(CONTENT_TYPE, contentType);

--- a/modules/spring-mock-mvc/src/main/java/io/restassured/module/mockmvc/specification/MockMvcRequestSpecification.java
+++ b/modules/spring-mock-mvc/src/main/java/io/restassured/module/mockmvc/specification/MockMvcRequestSpecification.java
@@ -60,6 +60,16 @@ public interface MockMvcRequestSpecification extends MockMvcRequestSender {
     /**
      * Specify the content type of the request.
      *
+     * @param mediaType The content type of the request
+     * @return The request specification
+     * @see ContentType
+     * @see MediaType
+     */
+    MockMvcRequestSpecification contentType(MediaType mediaType);
+
+    /**
+     * Specify the content type of the request.
+     *
      * @param contentType The content type of the request
      * @return The request specification
      * @see ContentType

--- a/modules/spring-web-test-client/src/main/java/io/restassured/module/webtestclient/internal/WebTestClientRequestSpecificationImpl.java
+++ b/modules/spring-web-test-client/src/main/java/io/restassured/module/webtestclient/internal/WebTestClientRequestSpecificationImpl.java
@@ -119,6 +119,12 @@ public class WebTestClientRequestSpecificationImpl implements WebTestClientReque
     }
 
     @Override
+    public WebTestClientRequestSpecification contentType(MediaType mediaType) {
+        notNull(mediaType, "mediaType");
+        return header(CONTENT_TYPE, mediaType.toString());
+    }
+
+    @Override
     public WebTestClientRequestSpecification contentType(String contentType) {
         notNull(contentType, "contentType");
         return header(CONTENT_TYPE, contentType);

--- a/modules/spring-web-test-client/src/main/java/io/restassured/module/webtestclient/specification/WebTestClientRequestSpecification.java
+++ b/modules/spring-web-test-client/src/main/java/io/restassured/module/webtestclient/specification/WebTestClientRequestSpecification.java
@@ -49,6 +49,16 @@ public interface WebTestClientRequestSpecification extends WebTestClientRequestS
 	/**
 	 * Specify the content type of the request.
 	 *
+	 * @param mediaType The content type of the request
+	 * @return The request specification
+	 *
+	 * @see ContentType
+	 */
+	WebTestClientRequestSpecification contentType(MediaType mediaType);
+
+	/**
+	 * Specify the content type of the request.
+	 *
 	 * @param contentType The content type of the request
 	 * @return The request specification
 	 *


### PR DESCRIPTION
Similar to `accept` which allows developers to use Spring Mediatype as Content Type, add `contentType(...)` to accept Spring MediaType.