### PR TITLE
fix(sec): upgrade org.scala-lang:scala-library to 2.13.9

### DIFF
--- a/examples/scala-example/pom.xml
+++ b/examples/scala-example/pom.xml
@@ -13,9 +13,7 @@
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
-  -->
-
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>io.rest-assured.examples</groupId>
         <artifactId>example-parent</artifactId>
@@ -29,7 +27,7 @@
     <description>Scala example of using REST Assured</description>
 
     <properties>
-        <scala.version>2.13.0</scala.version>
+        <scala.version>2.13.9</scala.version>
     </properties>
 
     <build>

--- a/examples/scala-mock-mvc-example/pom.xml
+++ b/examples/scala-mock-mvc-example/pom.xml
@@ -13,9 +13,7 @@
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
-  -->
-
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>io.rest-assured.examples</groupId>
         <artifactId>example-parent</artifactId>
@@ -29,7 +27,7 @@
     <description>Scala example of using REST Assured with Spring MockMvc</description>
 
     <properties>
-        <scala.version>2.13.0</scala.version>
+        <scala.version>2.13.9</scala.version>
     </properties>
 
     <build>

--- a/examples/scalatra-example/pom.xml
+++ b/examples/scalatra-example/pom.xml
@@ -13,9 +13,7 @@
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
-  -->
-
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>io.rest-assured.examples</groupId>
         <artifactId>example-parent</artifactId>
@@ -29,7 +27,7 @@
     <description>Scalatra service example that's used for integration testing rest-assured</description>
 
     <properties>
-        <scala.version>2.12.13</scala.version>
+        <scala.version>2.13.9</scala.version>
         <scalatra.scala.version>2.12</scalatra.scala.version>
         <scalatra.version>2.5.4</scalatra.version>
     </properties>

--- a/modules/scala-support/pom.xml
+++ b/modules/scala-support/pom.xml
@@ -13,9 +13,7 @@
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
-  -->
-
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>io.rest-assured</groupId>
         <artifactId>modules</artifactId>
@@ -29,7 +27,7 @@
     <description>Scala support for REST Assured</description>
 
     <properties>
-        <scala.version>2.13.0</scala.version>
+        <scala.version>2.13.9</scala.version>
     </properties>
 
     <build>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.scala-lang:scala-library 2.13.0
- [CVE-2022-36944](https://www.oscs1024.com/hd/CVE-2022-36944)


### What did I do？
Upgrade org.scala-lang:scala-library from 2.13.0 to 2.13.9 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS