### PR TITLE
Removed content assignment from asPrettyString()

### DIFF
--- a/rest-assured/src/main/groovy/io/restassured/internal/RestAssuredResponseOptionsGroovyImpl.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/RestAssuredResponseOptionsGroovyImpl.groovy
@@ -181,9 +181,7 @@ class RestAssuredResponseOptionsGroovyImpl {
   }
 
   String asPrettyString(ResponseOptions responseOptions, ResponseBody responseBody) {
-    def body = new Prettifier().getPrettifiedBodyIfPossible(responseOptions, responseBody)
-    content = body
-    body
+    new Prettifier().getPrettifiedBodyIfPossible(responseOptions, responseBody)
   }
 
   String asString(boolean forcePlatformDefaultCharsetIfNoCharsetIsSpecifiedInResponse) {


### PR DESCRIPTION
Content assignment in `asPrettyString()` was converting whole response body into string, which was problematic when `asPrettyString()` was used first, and then binary content of response was needed. 
What's more, this behaviour wasn't in line with the behaviour of `asString()` method.

It is explained more in depth in linked issue, please take a look at it: https://github.com/rest-assured/rest-assured/issues/1638