### PR TITLE
fix(sec): upgrade org.springframework.security:spring-security-web to 5.5.7

### DIFF
--- a/examples/spring-mvc-webapp/pom.xml
+++ b/examples/spring-mvc-webapp/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring.version>4.3.23.RELEASE</spring.version>
-        <spring.security.version>4.1.0.RELEASE</spring.security.version>
+        <spring.security.version>5.5.7</spring.security.version>
         <jetty.version>9.4.34.v20201102</jetty.version>
     </properties>
 


### PR DESCRIPTION
### What happened？
There are 5 security vulnerabilities found in org.springframework.security:spring-security-web 4.1.0.RELEASE
- [CVE-2022-22978](https://www.oscs1024.com/hd/CVE-2022-22978)
- [MPS-2022-11893](https://www.oscs1024.com/hd/MPS-2022-11893)
- [CVE-2016-9879](https://www.oscs1024.com/hd/CVE-2016-9879)
- [CVE-2016-5007](https://www.oscs1024.com/hd/CVE-2016-5007)
- [CVE-2018-1199](https://www.oscs1024.com/hd/CVE-2018-1199)


### What did I do？
Upgrade org.springframework.security:spring-security-web from 4.1.0.RELEASE to 5.5.7 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS