### PR TITLE
Spring Framework 6 is never resolved

### DIFF
--- a/modules/spring-mock-mvc/src/main/java/io/restassured/module/mockmvc/internal/MockMvcRequestSenderImpl.java
+++ b/modules/spring-mock-mvc/src/main/java/io/restassured/module/mockmvc/internal/MockMvcRequestSenderImpl.java
@@ -84,7 +84,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 class MockMvcRequestSenderImpl implements MockMvcRequestSender, MockMvcRequestAsyncConfigurer, MockMvcRequestAsyncSender {
     private static final String ATTRIBUTE_NAME_URL_TEMPLATE = "org.springframework.restdocs.urlTemplate";
     private static final String CONTENT_TYPE = "Content-Type";
-    private static final boolean isSpring6OrLater = existInCP("org.springframework.core.annotation.CoreAnnotationsRuntimeHintsRegistrar");
+    private static final boolean isSpring6OrLater = existInCP("org.springframework.aot.AotDetector");
 
     private final MockMvc mockMvc;
     private final Map<String, Object> params;


### PR DESCRIPTION

with this change Spring Framework 6 version is never actually found cause we're looking at a non-existant class

with Spring Framework 6 GA out we can safely use another class that was introduced in 6.0 - org.springframework.aot.AotDetector