### PR TITLE
Fix convertCookies to copy missing attributes

### DIFF
--- a/modules/spring-mock-mvc/src/main/java/io/restassured/module/mockmvc/internal/MockMvcRequestSenderImpl.java
+++ b/modules/spring-mock-mvc/src/main/java/io/restassured/module/mockmvc/internal/MockMvcRequestSenderImpl.java
@@ -65,6 +65,7 @@ import java.lang.reflect.Constructor;
 import java.net.URI;
 import java.net.URL;
 import java.security.Principal;
+import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
@@ -182,6 +183,27 @@ class MockMvcRequestSenderImpl implements MockMvcRequestSender, MockMvcRequestAs
             cookieBuilder.setMaxAge(getMaxAge);
             cookieBuilder.setVersion(invokeMethod(servletCookie, "getVersion"));
             cookieBuilder.setSecured(invokeMethod(servletCookie, "getSecure"));
+            cookieBuilder.setHttpOnly(invokeMethod(servletCookie, "isHttpOnly"));
+
+            // Attempt to copy properties from org.springframework.mock.web.MockCookie
+            try {
+            	String sameSite = invokeMethod(servletCookie, "getSameSite");
+            	if(sameSite != null) {
+                    cookieBuilder.setSameSite(sameSite);
+            	}
+            } catch(IllegalArgumentException e) {
+            	// Do nothing as only found on MockCookie
+            }
+            
+            try {
+                ZonedDateTime expires = invokeMethod(servletCookie, "getExpires");
+                if(expires != null) {
+                    cookieBuilder.setExpiryDate(Date.from(expires.toInstant()));
+                }
+            } catch(IllegalArgumentException e) {
+            	// Do nothing as only found on MockCookie
+            }
+
             cookies.add(cookieBuilder.build());
         }
         return new Cookies(cookies);

--- a/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/CookieTest.java
+++ b/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/CookieTest.java
@@ -24,9 +24,13 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
+import static io.restassured.matcher.RestAssuredMatchers.detailedCookie;
 import static org.hamcrest.Matchers.equalTo;
 
 public class CookieTest {
@@ -117,6 +121,31 @@ public class CookieTest {
                 statusCode(200).
                 cookie("name", "John Doe").
                 cookie("project", "rest assured");
+    }
+    
+    @Test public void
+    can_receive_detailed_cookies() {
+        RestAssuredMockMvc.given().
+                queryParam("cookieName1", "name").
+                queryParam("cookieValue1", "John Doe").
+                queryParam("cookieName2", "project").
+                queryParam("cookieValue2", "rest assured").
+        when().
+                get("/setDetailedCookies").
+        then().
+                statusCode(200).
+                cookie("name", detailedCookie().
+                    value("John Doe").
+                    httpOnly(true).
+                    secured(true).
+                    sameSite("None").
+                    expiryDate(Date.from(ZonedDateTime.of(2023, 1, 1, 12, 30, 0, 0, ZoneId.of("Z")).toInstant()))).
+                cookie("project", detailedCookie().
+                    value("rest assured").
+                    httpOnly(false).
+                    secured(false).
+                    sameSite("Lax").
+                    expiryDate(Date.from(ZonedDateTime.of(2023, 1, 1, 12, 30, 0, 0, ZoneId.of("Z")).toInstant())));
     }
 }
 

--- a/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/http/CookieController.java
+++ b/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/http/CookieController.java
@@ -21,6 +21,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 
@@ -28,6 +31,36 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 
 public class CookieController {
+	
+    /**
+      * Mimics org.springframework.mock.web.MockCookie
+      */
+    public static class MockCookie extends Cookie {
+        private static final long serialVersionUID = 1L;
+		
+        private String sameSite;
+        private ZonedDateTime expires;
+
+        public MockCookie(String name, String value) {
+            super(name, value);
+        }
+
+        public String getSameSite() {
+            return sameSite;
+        }
+
+        public void setSameSite(String sameSite) {
+            this.sameSite = sameSite;
+        }
+
+        public ZonedDateTime getExpires() {
+            return expires;
+        }
+
+        public void setExpires(ZonedDateTime expires) {
+            this.expires = expires;
+        }
+    }
 
     @RequestMapping(value = "/cookie", method = GET, produces = APPLICATION_JSON_VALUE)
     public @ResponseBody String cookie(@CookieValue("cookieName1") String cookieValue1, @CookieValue(value = "cookieName2", required = false) String cookieValue2) {
@@ -40,6 +73,26 @@ public class CookieController {
                      @RequestParam("cookieName2") String cookieName2, @RequestParam("cookieValue2") String cookieValue2) {
         response.addCookie(new Cookie(cookieName1, cookieValue1));
         response.addCookie(new Cookie(cookieName2, cookieValue2));
+        return "{}";
+    }
+    
+    @RequestMapping(value = "/setDetailedCookies", method = GET, produces = APPLICATION_JSON_VALUE)
+    public @ResponseBody String setDetailedCookies(HttpServletResponse response,
+                     @RequestParam("cookieName1") String cookieName1, @RequestParam("cookieValue1") String cookieValue1,
+                     @RequestParam("cookieName2") String cookieName2, @RequestParam("cookieValue2") String cookieValue2) {
+        MockCookie cookie1 = new MockCookie(cookieName1, cookieValue1);
+        cookie1.setHttpOnly(true);
+        cookie1.setSameSite("None");
+        cookie1.setSecure(true);
+        cookie1.setExpires(ZonedDateTime.of(2023, 1, 1, 12, 30, 0, 0, ZoneId.of("Z")));
+        response.addCookie(cookie1);
+
+        MockCookie cookie2 = new MockCookie(cookieName2, cookieValue2);
+        cookie2.setHttpOnly(false);
+        cookie2.setSameSite("Lax");
+        cookie2.setSecure(false);
+        cookie2.setExpires(ZonedDateTime.of(2023, 1, 1, 12, 30, 0, 0, ZoneId.of("Z")));
+        response.addCookie(cookie2);
         return "{}";
     }
 }


### PR DESCRIPTION
Fixes #1462

Copies `isHttpOnly` from the servlet cookie and copies `getExpires` and `getSameSite` which can be found on `org.springframework.mock.web.MockCookie`.

See https://github.com/spring-projects/spring-framework/blob/main/spring-test/src/main/java/org/springframework/mock/web/MockCookie.java

Fix convertCookies to copy missing attributes