### PR TITLE
Support POSTing of InputStreams with custom contentType

### DIFF
--- a/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/XMLPostITest.java
+++ b/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/XMLPostITest.java
@@ -16,6 +16,9 @@
 
 package io.restassured.itest.java;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
 import io.restassured.itest.java.support.WithJetty;
 import org.junit.Test;
 
@@ -73,6 +76,19 @@ public class XMLPostITest extends WithJetty {
         expect().
                 body(equalTo("Some Text")).
         when().
+                put("/reflect");
+
+    }
+
+    @Test
+    public void customXmlCompatibleContentTypeWithBodyAsInputStream() throws Exception {
+        InputStream inputStream = new ByteArrayInputStream("Some Text".getBytes());
+        given().
+                contentType("application/vnd.myitem+xml").
+                body(inputStream).
+                expect().
+                body(equalTo("Some Text")).
+                when().
                 put("/reflect");
 
     }

--- a/rest-assured/src/main/java/io/restassured/internal/http/EncoderRegistry.java
+++ b/rest-assured/src/main/java/io/restassured/internal/http/EncoderRegistry.java
@@ -297,6 +297,8 @@ public class EncoderRegistry {
     private HttpEntity createEntity(String ct, Object object) throws UnsupportedEncodingException {
         if (object instanceof byte[]) {
             return createEntity(ct, (byte[]) object);
+        } else if (object instanceof InputStream) {
+            return createEntity(ct, (InputStream) object);
         } else {
             return createEntity(ct, object.toString());
         }
@@ -306,6 +308,12 @@ public class EncoderRegistry {
         final ByteArrayEntity byteArrayEntity = new ByteArrayEntity(byteArray);
         byteArrayEntity.setContentType(ct);
         return byteArrayEntity;
+    }
+
+    protected HttpEntity createEntity(String ct, InputStream inputStream) {
+        final InputStreamEntity inputStreamEntity = new InputStreamEntity(inputStream);
+        inputStreamEntity.setContentType(ct);
+        return inputStreamEntity;
     }
 
     /**


### PR DESCRIPTION
The EncoderRegistry has a special treatment for byte arrays, so that they are handled as is and no .toString() is called upon them. The same handling needs to be done for InputStreams.

Fixes #1160 