### PR TITLE
properly parse primitive JSON values

### DIFF
--- a/json-path/src/main/groovy/io/restassured/internal/path/json/ConfigurableJsonSlurper.groovy
+++ b/json-path/src/main/groovy/io/restassured/internal/path/json/ConfigurableJsonSlurper.groovy
@@ -105,10 +105,12 @@ class ConfigurableJsonSlurper {
       content = parseObject(lexer)
     } else if (token.getType() == OPEN_BRACKET) {
       content = parseArray(lexer)
+    } else if (token.getType().ordinal() >= NULL.ordinal()) {
+      content = token.getValue()
     } else {
       throw new JsonException(
               "A JSON payload should start with " + OPEN_CURLY.getLabel() +
-                      " or " + OPEN_BRACKET.getLabel() + ".\n" +
+                      ", " + OPEN_BRACKET.getLabel() + " or a primitive value.\n" +
                       "Instead, '" + token.getText() + "' was found " +
                       "on line: " + token.getStartLine() + ", " +
                       "column: " + token.getStartColumn()

--- a/json-path/src/test/java/io/restassured/path/json/JsonPathNumberTest.java
+++ b/json-path/src/test/java/io/restassured/path/json/JsonPathNumberTest.java
@@ -17,6 +17,7 @@
 package io.restassured.path.json;
 
 import io.restassured.path.json.config.JsonPathConfig;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.math.BigDecimal;
@@ -105,6 +106,20 @@ public class JsonPathNumberTest {
 
         // Then
         assertThat(orderNumber, equalTo(new BigInteger(EXPECTED_LONG)));
+    }
+
+    @Ignore("Depends on GROOVY-11123")
+    @Test public void
+    json_path_returns_big_integer_for_primitive_number_when_configured_accordingly() {
+        // Given
+        final JsonPath jsonPath = new JsonPath(
+                "12345").using(new JsonPathConfig().numberReturnType(JsonPathConfig.NumberReturnType.BIG_INTEGER));
+
+        // When
+        BigInteger number = jsonPath.get("$");
+
+        // Then
+        assertThat(number, equalTo(new BigInteger("12345")));
     }
 
 }

--- a/json-path/src/test/java/io/restassured/path/json/JsonPathNumberTest.java
+++ b/json-path/src/test/java/io/restassured/path/json/JsonPathNumberTest.java
@@ -108,7 +108,6 @@ public class JsonPathNumberTest {
         assertThat(orderNumber, equalTo(new BigInteger(EXPECTED_LONG)));
     }
 
-    @Ignore("Depends on GROOVY-11123")
     @Test public void
     json_path_returns_big_integer_for_primitive_number_when_configured_accordingly() {
         // Given

--- a/json-path/src/test/java/io/restassured/path/json/JsonPathTest.java
+++ b/json-path/src/test/java/io/restassured/path/json/JsonPathTest.java
@@ -803,4 +803,51 @@ public class JsonPathTest {
         // Then   no exception should be thrown
         assertThat(jsonPath.getString("root.items[0]"), is(nullValue()));
     }
+
+    @Test public void
+    does_not_fail_on_primitive_string() {
+        // When
+        String json = "\"foo\"";
+
+        // When
+        JsonPath jsonPath = JsonPath.from(json);
+
+        // Then
+        assertThat(jsonPath.get("$"), is("foo"));
+    }
+
+    @Test public void
+    does_not_fail_on_primitive_true() {
+        // When
+        String json = "true";
+
+        // When
+        JsonPath jsonPath = JsonPath.from(json);
+
+        // Then
+        assertThat(jsonPath.get("$"), is(true));
+    }
+
+    @Test public void
+    does_not_fail_on_primitive_false() {
+        // When
+        String json = "false";
+
+        // When
+        JsonPath jsonPath = JsonPath.from(json);
+
+        // Then
+        assertThat(jsonPath.get("$"), is(false));
+    }
+    @Test public void
+    does_not_fail_on_primitive_null() {
+        // When
+        String json = "null";
+
+        // When
+        JsonPath jsonPath = JsonPath.from(json);
+
+        // Then
+        assertThat(jsonPath.get("$"), nullValue());
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <properties>
         <scm.branch>master</scm.branch>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <groovy.version>4.0.11</groovy.version>
+        <groovy.version>4.0.14</groovy.version>
         <groovy.range>[4.0,5.0)</groovy.range>
         <gmaven.version>1.5</gmaven.version>
         <hamcrest.version>2.2</hamcrest.version>


### PR DESCRIPTION
fixes #949

REST-assured should really ditch the "old" JsonLexer for the "new" JsonSlurper (see comments on [GROOVY-11123](https://issues.apache.org/jira/browse/GROOVY-11123)), but that will be a rather huge change I am afraid.