### PR TITLE
Make header blacklisting case-insensitive

### DIFF
--- a/rest-assured/src/main/java/io/restassured/filter/log/RequestLoggingFilter.java
+++ b/rest-assured/src/main/java/io/restassured/filter/log/RequestLoggingFilter.java
@@ -107,7 +107,15 @@ public class RequestLoggingFilter implements Filter {
      * @param showUrlEncodedUri Whether or not to show the request URI as url encoded
      */
     public RequestLoggingFilter(LogDetail logDetail, boolean shouldPrettyPrint, PrintStream stream, boolean showUrlEncodedUri) {
-        this(logDetail, shouldPrettyPrint, stream, showUrlEncodedUri, Collections.emptySet());
+        this(logDetail, shouldPrettyPrint, stream, showUrlEncodedUri, defaultBlacklistedHeaders());
+    }
+
+    private static Set<String> defaultBlacklistedHeaders() {
+        TreeSet<String> caseInsensitiveBlacklistedHeaders = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        caseInsensitiveBlacklistedHeaders.add("Authorization");
+        caseInsensitiveBlacklistedHeaders.add("Proxy-Authorization");
+        caseInsensitiveBlacklistedHeaders.add("Cookie");
+        return caseInsensitiveBlacklistedHeaders;
     }
 
     /**

--- a/rest-assured/src/main/java/io/restassured/filter/log/RequestLoggingFilter.java
+++ b/rest-assured/src/main/java/io/restassured/filter/log/RequestLoggingFilter.java
@@ -27,9 +27,9 @@ import org.apache.commons.lang3.Validate;
 import java.io.PrintStream;
 import java.nio.charset.Charset;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.TreeSet;
 
 import static io.restassured.filter.log.LogDetail.ALL;
 import static io.restassured.filter.log.LogDetail.STATUS;
@@ -127,7 +127,9 @@ public class RequestLoggingFilter implements Filter {
         }
         this.stream = stream;
         this.logDetail = logDetail;
-        this.blacklistedHeaders = new HashSet<>(blacklistedHeaders);
+        TreeSet<String> caseInsensitiveBlacklistedHeaders = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        caseInsensitiveBlacklistedHeaders.addAll(blacklistedHeaders);
+        this.blacklistedHeaders = caseInsensitiveBlacklistedHeaders;
         this.shouldPrettyPrint = shouldPrettyPrint;
         this.showUrlEncodedUri = showUrlEncodedUri;
     }


### PR DESCRIPTION
Motivation: 

Many load balancers override header values, and developers grow a habit to ignore case sensitivity of the headers. 
In practice header names are treated as case-insensitive and it can potentially lead to leaking credentials in logs. 
Speaking of standards and HTTP RFCs: some of them state header fields are case insensitive, some of them state otherwise. 


Also, having some sensible secure defaults can be beneficial.

This can prevent many security incidents of type "credentials in build pipeline logs".