### PR TITLE
feat: added support for path parameters methods

### DIFF
--- a/modules/spring-commons/src/main/java/io/restassured/module/spring/commons/RequestLogger.java
+++ b/modules/spring-commons/src/main/java/io/restassured/module/spring/commons/RequestLogger.java
@@ -29,16 +29,25 @@ import java.io.FileNotFoundException;
 import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Scanner;
 
 import static org.apache.commons.lang3.SystemUtils.LINE_SEPARATOR;
 
-public class RequestLogger {
+public final class RequestLogger {
 
-    public static void logParamsAndHeaders(final RequestSpecificationImpl reqSpec, String method, String uri,
-                                           Object[] unnamedPathParams, Map<String, Object> params, Map<String,
-            Object> queryParams, Map<String, Object> formParams,
-                                           Headers headers, Cookies cookies) {
+    private RequestLogger() { }
+
+    public static void logParamsAndHeaders(
+            final RequestSpecificationImpl reqSpec,
+            final String method, String uri,
+            final Object[] unnamedPathParams,
+            final Map<String, Object> params,
+            final Map<String, Object> namedPathParams,
+            final Map<String, Object> queryParams,
+            final Map<String, Object> formParams,
+            final Headers headers, Cookies cookies
+    ) {
         reqSpec.setMethod(method);
         reqSpec.path(uri);
         reqSpec.buildUnnamedPathParameterTuples(unnamedPathParams);
@@ -54,6 +63,14 @@ public class RequestLogger {
             new ParamLogger(queryParams) {
                 protected void logParam(String paramName, Object paramValue) {
                     reqSpec.queryParam(paramName, paramValue);
+                }
+            }.logParams();
+        }
+
+        if (Objects.nonNull(namedPathParams)) {
+            new ParamLogger(namedPathParams) {
+                protected void logParam(String paramName, Object paramValue) {
+                    reqSpec.pathParams(paramName, paramValue);
                 }
             }.logParams();
         }

--- a/modules/spring-commons/src/main/java/io/restassured/module/spring/commons/config/ConfigConverter.java
+++ b/modules/spring-commons/src/main/java/io/restassured/module/spring/commons/config/ConfigConverter.java
@@ -21,7 +21,9 @@ import io.restassured.config.RestAssuredConfig;
 
 import java.lang.reflect.Field;
 
-public class ConfigConverter {
+public final class ConfigConverter {
+
+    private ConfigConverter() { }
 
     public static RestAssuredConfig convertToRestAssuredConfig(SpecificationConfig specificationConfig) {
         return new RestAssuredConfig().jsonConfig(specificationConfig.getJsonConfig()).xmlConfig(specificationConfig.getXmlConfig()).sessionConfig(specificationConfig.getSessionConfig()).
@@ -31,7 +33,7 @@ public class ConfigConverter {
     }
 
     private static ParamConfig toParamConfig(ParamConfig baseConfig) {
-        ParamConfig config = new ParamConfig(baseConfig.queryParamsUpdateStrategy(),
+        ParamConfig config = new ParamConfig(baseConfig.queryParamsUpdateStrategy(), baseConfig.pathParamsUpdateStrategy(),
                 baseConfig.formParamsUpdateStrategy(), baseConfig.requestParamsUpdateStrategy());
         // We need to set the user configured flag to false if needed
         if (!baseConfig.isUserConfigured()) {

--- a/modules/spring-mock-mvc/pom.xml
+++ b/modules/spring-mock-mvc/pom.xml
@@ -28,7 +28,7 @@
     <url>http://maven.apache.org</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring.version>4.3.23.RELEASE</spring.version>
+        <spring.version>5.1.0.RELEASE</spring.version>
         <spring.security.version>4.2.17.RELEASE</spring.security.version>
     </properties>
 

--- a/modules/spring-mock-mvc/pom.xml
+++ b/modules/spring-mock-mvc/pom.xml
@@ -28,7 +28,7 @@
     <url>http://maven.apache.org</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring.version>5.1.0.RELEASE</spring.version>
+        <spring.version>5.1.13.RELEASE</spring.version>
         <spring.security.version>4.2.17.RELEASE</spring.security.version>
     </properties>
 
@@ -37,6 +37,13 @@
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <version>5.3.1</version>
+            <exclusions>
+                <exclusion>
+                    <!-- Spring provides its own JCL implementation -->
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.rest-assured</groupId>
@@ -119,7 +126,7 @@
         <dependency>
             <groupId>org.springframework.restdocs</groupId>
             <artifactId>spring-restdocs-mockmvc</artifactId>
-            <version>1.0.0.RELEASE</version>
+            <version>2.0.2.RELEASE</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/modules/spring-mock-mvc/src/main/java/io/restassured/module/mockmvc/config/MockMvcParamConfig.java
+++ b/modules/spring-mock-mvc/src/main/java/io/restassured/module/mockmvc/config/MockMvcParamConfig.java
@@ -31,6 +31,7 @@ public class MockMvcParamConfig extends ParamConfig implements Config {
 
     private final boolean userConfigured;
     private final UpdateStrategy queryParamsUpdateStrategy;
+    private final UpdateStrategy pathParamsUpdateStrategy;
     private final UpdateStrategy formParamsUpdateStrategy;
     private final UpdateStrategy requestParameterUpdateStrategy;
     private final UpdateStrategy attributeUpdateStrategy;
@@ -40,7 +41,7 @@ public class MockMvcParamConfig extends ParamConfig implements Config {
      * Create a new instance where all parameters are merged
      */
     public MockMvcParamConfig() {
-        this(MERGE, MERGE, MERGE, MERGE, MERGE, false);
+        this(MERGE, REPLACE, MERGE, MERGE, MERGE, MERGE, false);
     }
 
     /**
@@ -52,22 +53,31 @@ public class MockMvcParamConfig extends ParamConfig implements Config {
      * @param sessionUpdateStrategy          The update strategy for session parameters
      */
     public MockMvcParamConfig(UpdateStrategy queryParamsUpdateStrategy,
+                              UpdateStrategy pathParamsUpdateStrategy,
                               UpdateStrategy formParamsUpdateStrategy,
                               UpdateStrategy requestParameterUpdateStrategy,
                               UpdateStrategy attributeUpdateStrategy,
                               UpdateStrategy sessionUpdateStrategy) {
-        this(queryParamsUpdateStrategy, formParamsUpdateStrategy, requestParameterUpdateStrategy, attributeUpdateStrategy, sessionUpdateStrategy, true);
+        this(queryParamsUpdateStrategy, pathParamsUpdateStrategy, formParamsUpdateStrategy, requestParameterUpdateStrategy, attributeUpdateStrategy, sessionUpdateStrategy, true);
     }
 
-    private MockMvcParamConfig(UpdateStrategy queryParamsUpdateStrategy, UpdateStrategy formParamsUpdateStrategy,
-                               UpdateStrategy requestParameterUpdateStrategy, UpdateStrategy attributeUpdateStrategy,
-                               UpdateStrategy sessionUpdateStrategy, boolean userConfigured) {
+    private MockMvcParamConfig(
+            UpdateStrategy queryParamsUpdateStrategy,
+            UpdateStrategy pathParamsUpdateStrategy,
+            UpdateStrategy formParamsUpdateStrategy,
+            UpdateStrategy requestParameterUpdateStrategy,
+            UpdateStrategy attributeUpdateStrategy,
+            UpdateStrategy sessionUpdateStrategy,
+            boolean userConfigured
+    ) {
         notNull(queryParamsUpdateStrategy, "Query param update strategy");
+        notNull(pathParamsUpdateStrategy, "Path param update strategy");
         notNull(requestParameterUpdateStrategy, "Request param update strategy");
         notNull(formParamsUpdateStrategy, "Form param update strategy");
         notNull(attributeUpdateStrategy, "Attribute update strategy");
         notNull(sessionUpdateStrategy, "Session update strategy");
         this.queryParamsUpdateStrategy = queryParamsUpdateStrategy;
+        this.pathParamsUpdateStrategy = pathParamsUpdateStrategy;
         this.formParamsUpdateStrategy = formParamsUpdateStrategy;
         this.requestParameterUpdateStrategy = requestParameterUpdateStrategy;
         this.attributeUpdateStrategy = attributeUpdateStrategy;
@@ -81,7 +91,7 @@ public class MockMvcParamConfig extends ParamConfig implements Config {
      * @return A new instance of {@link MockMvcParamConfig}
      */
     public MockMvcParamConfig mergeAllParameters() {
-        return new MockMvcParamConfig(MERGE, MERGE, MERGE, MERGE, MERGE, true);
+        return new MockMvcParamConfig(MERGE, REPLACE, MERGE, MERGE, MERGE, MERGE, true);
     }
 
     /**
@@ -90,7 +100,7 @@ public class MockMvcParamConfig extends ParamConfig implements Config {
      * @return A new instance of {@link MockMvcParamConfig}
      */
     public MockMvcParamConfig replaceAllParameters() {
-        return new MockMvcParamConfig(REPLACE, REPLACE, REPLACE, REPLACE, REPLACE, true);
+        return new MockMvcParamConfig(REPLACE, REPLACE, REPLACE, REPLACE, REPLACE, REPLACE, true);
     }
 
     /**
@@ -100,7 +110,7 @@ public class MockMvcParamConfig extends ParamConfig implements Config {
      * @return A new instance of {@link MockMvcParamConfig}
      */
     public MockMvcParamConfig formParamsUpdateStrategy(UpdateStrategy updateStrategy) {
-        return new MockMvcParamConfig(queryParamsUpdateStrategy, updateStrategy, requestParameterUpdateStrategy, attributeUpdateStrategy, sessionUpdateStrategy, true);
+        return new MockMvcParamConfig(queryParamsUpdateStrategy, pathParamsUpdateStrategy, updateStrategy, requestParameterUpdateStrategy, attributeUpdateStrategy, sessionUpdateStrategy, true);
     }
 
     /**
@@ -114,7 +124,7 @@ public class MockMvcParamConfig extends ParamConfig implements Config {
      * @return A new instance of {@link MockMvcParamConfig}
      */
     public MockMvcParamConfig requestParamsUpdateStrategy(UpdateStrategy updateStrategy) {
-        return new MockMvcParamConfig(queryParamsUpdateStrategy, formParamsUpdateStrategy, updateStrategy, attributeUpdateStrategy, sessionUpdateStrategy, true);
+        return new MockMvcParamConfig(queryParamsUpdateStrategy, pathParamsUpdateStrategy, formParamsUpdateStrategy, updateStrategy, attributeUpdateStrategy, sessionUpdateStrategy, true);
     }
 
     /**
@@ -124,7 +134,7 @@ public class MockMvcParamConfig extends ParamConfig implements Config {
      * @return A new instance of {@link MockMvcParamConfig}
      */
     public MockMvcParamConfig queryParamsUpdateStrategy(UpdateStrategy updateStrategy) {
-        return new MockMvcParamConfig(updateStrategy, formParamsUpdateStrategy, requestParameterUpdateStrategy, attributeUpdateStrategy, sessionUpdateStrategy, true);
+        return new MockMvcParamConfig(updateStrategy, pathParamsUpdateStrategy, formParamsUpdateStrategy, requestParameterUpdateStrategy, attributeUpdateStrategy, sessionUpdateStrategy, true);
     }
 
     /**
@@ -134,7 +144,7 @@ public class MockMvcParamConfig extends ParamConfig implements Config {
      * @return A new instance of {@link MockMvcParamConfig}
      */
     public MockMvcParamConfig attributeUpdateStrategy(UpdateStrategy updateStrategy) {
-        return new MockMvcParamConfig(queryParamsUpdateStrategy, formParamsUpdateStrategy, requestParameterUpdateStrategy, updateStrategy, sessionUpdateStrategy, true);
+        return new MockMvcParamConfig(queryParamsUpdateStrategy, pathParamsUpdateStrategy, formParamsUpdateStrategy, requestParameterUpdateStrategy, updateStrategy, sessionUpdateStrategy, true);
     }
 
     /**
@@ -144,7 +154,7 @@ public class MockMvcParamConfig extends ParamConfig implements Config {
      * @return A new instance of {@link MockMvcParamConfig}
      */
     public MockMvcParamConfig sessionAttributesUpdateStrategy(UpdateStrategy updateStrategy) {
-        return new MockMvcParamConfig(queryParamsUpdateStrategy, formParamsUpdateStrategy, requestParameterUpdateStrategy, attributeUpdateStrategy, updateStrategy, true);
+        return new MockMvcParamConfig(queryParamsUpdateStrategy, pathParamsUpdateStrategy, formParamsUpdateStrategy, requestParameterUpdateStrategy, attributeUpdateStrategy, updateStrategy, true);
     }
 
     /**
@@ -173,6 +183,13 @@ public class MockMvcParamConfig extends ParamConfig implements Config {
      */
     public UpdateStrategy queryParamsUpdateStrategy() {
         return queryParamsUpdateStrategy;
+    }
+
+    /**
+     * @return The update strategy for path parameters
+     */
+    public UpdateStrategy pathParamsUpdateStrategy() {
+        return pathParamsUpdateStrategy;
     }
 
     /**

--- a/modules/spring-mock-mvc/src/main/java/io/restassured/module/mockmvc/internal/MockMvcRequestSenderImpl.java
+++ b/modules/spring-mock-mvc/src/main/java/io/restassured/module/mockmvc/internal/MockMvcRequestSenderImpl.java
@@ -343,7 +343,7 @@ class MockMvcRequestSenderImpl implements MockMvcRequestSender, MockMvcRequestAs
         applyAttributes(request);
 
         if (RestDocsClassPathChecker.isSpringRestDocsInClasspath() && config.getMockMvcConfig().shouldAutomaticallyApplySpringRestDocsMockMvcSupport()) {
-            request.requestAttr(ATTRIBUTE_NAME_URL_TEMPLATE, PathSupport.getPath(uri));
+            request.requestAttr(ATTRIBUTE_NAME_URL_TEMPLATE, PathSupport.getPath(baseUri));
         }
 
         applyHeaders(request);

--- a/modules/spring-mock-mvc/src/main/java/io/restassured/module/mockmvc/internal/MockMvcRequestSpecificationImpl.java
+++ b/modules/spring-mock-mvc/src/main/java/io/restassured/module/mockmvc/internal/MockMvcRequestSpecificationImpl.java
@@ -76,6 +76,7 @@ public class MockMvcRequestSpecificationImpl implements MockMvcRequestSpecificat
     private final ResponseSpecification responseSpecification;
 
     private final Map<String, Object> params = new LinkedHashMap<>();
+    private final Map<String, Object> pathParams = new LinkedHashMap<>();
     private final Map<String, Object> queryParams = new LinkedHashMap<>();
     private final Map<String, Object> formParams = new LinkedHashMap<>();
     private final Map<String, Object> attributes = new LinkedHashMap<>();
@@ -298,6 +299,28 @@ public class MockMvcRequestSpecificationImpl implements MockMvcRequestSpecificat
         return this;
     }
 
+    @Override
+    public MockMvcRequestSpecification pathParams(String firstParameterName, Object firstParameterValue, Object... parameterNameValuePairs) {
+        notNull(firstParameterName, "firstParameterName");
+        notNull(firstParameterValue, "firstParameterValue");
+        return pathParams(MapCreator.createMapFromParams(CollisionStrategy.OVERWRITE, firstParameterName, firstParameterValue, parameterNameValuePairs));
+    }
+
+    @Override
+    public MockMvcRequestSpecification pathParams(Map<String, Object> parametersMap) {
+        notNull(parametersMap, "parametersMap");
+        parameterUpdater.updateParameters(convert(cfg.getParamConfig().pathParamsUpdateStrategy()), parametersMap, pathParams);
+        return this;
+    }
+
+    @Override
+    public MockMvcRequestSpecification pathParam(String parameterName, Object parameterValue) {
+        notNull(parameterName, "parameterName");
+        notNull(parameterValue, "parameterValue");
+        parameterUpdater.updateStandardParameter(convert(cfg.getParamConfig().pathParamsUpdateStrategy()), pathParams, parameterName, parameterValue);
+        return this;
+    }
+
     public MockMvcRequestSpecification formParams(String firstParameterName, Object firstParameterValue, Object... parameterNameValuePairs) {
         notNull(firstParameterName, "firstParameterName");
         notNull(firstParameterValue, "firstParameterValue");
@@ -508,6 +531,7 @@ public class MockMvcRequestSpecificationImpl implements MockMvcRequestSpecificat
 
         this.formParams(that.getFormParams());
         this.queryParams(that.getQueryParams());
+        this.pathParams(that.getPathParams());
         this.params(that.getParams());
         this.attributes(that.getAttributes());
 
@@ -574,7 +598,7 @@ public class MockMvcRequestSpecificationImpl implements MockMvcRequestSpecificat
             log().ifValidationFails(logConfig.logDetailOfRequestAndResponseIfValidationFails(), logConfig.isPrettyPrintingEnabled());
         }
         MockMvc mockMvc = mockMvcFactory.build(cfg.getMockMvcConfig());
-        return new MockMvcRequestSenderImpl(mockMvc, params, queryParams, formParams, attributes, cfg, requestBody,
+        return new MockMvcRequestSenderImpl(mockMvc, params, pathParams, queryParams, formParams, attributes, cfg, requestBody,
                 requestHeaders, cookies, sessionAttributes, multiParts, requestLoggingFilter, resultHandlers, requestPostProcessors, interceptor, basePath, responseSpecification, authentication,
                 logRepository);
     }
@@ -790,6 +814,10 @@ public class MockMvcRequestSpecificationImpl implements MockMvcRequestSpecificat
 
     public Map<String, Object> getQueryParams() {
         return queryParams;
+    }
+
+    public Map<String, Object> getPathParams() {
+        return pathParams;
     }
 
     public Map<String, Object> getFormParams() {

--- a/modules/spring-mock-mvc/src/main/java/io/restassured/module/mockmvc/specification/MockMvcRequestSpecBuilder.java
+++ b/modules/spring-mock-mvc/src/main/java/io/restassured/module/mockmvc/specification/MockMvcRequestSpecBuilder.java
@@ -17,7 +17,6 @@
 package io.restassured.module.mockmvc.specification;
 
 import io.restassured.config.LogConfig;
-import io.restassured.config.SessionConfig;
 import io.restassured.filter.log.LogDetail;
 import io.restassured.filter.log.RequestLoggingFilter;
 import io.restassured.http.ContentType;
@@ -291,6 +290,101 @@ public class MockMvcRequestSpecBuilder {
      */
     public MockMvcRequestSpecBuilder addQueryParam(String parameterName, Object... parameterValues) {
         spec.queryParam(parameterName, parameterValues);
+        return this;
+    }
+
+    /**
+     * Specify a path parameter. Path parameters are used to improve readability of the request path. E.g. instead
+     * of writing:
+     * <pre>
+     * expect().statusCode(200).when().get("/item/"+myItem.getItemNumber()+"/buy/"+2);
+     * </pre>
+     * you can write:
+     * <pre>
+     * given().
+     *         pathParam("itemNumber", myItem.getItemNumber()).
+     *         pathParam("amount", 2).
+     * expect().
+     *          statusCode(200).
+     * when().
+     *        get("/item/{itemNumber}/buy/{amount}");
+     * </pre>
+     * <p/>
+     * which improves readability and allows the path to be reusable in many tests. Another alternative is to use:
+     * <pre>
+     * expect().statusCode(200).when().get("/item/{itemNumber}/buy/{amount}", myItem.getItemNumber(), 2);
+     * </pre>
+     *
+     * @param parameterName  The parameter key
+     * @param parameterValue The parameter value
+     * @return The request specification
+     */
+    public MockMvcRequestSpecBuilder addPathParam(String parameterName, Object parameterValue) {
+        spec.pathParam(parameterName, parameterValue);
+        return this;
+    }
+
+    /**
+     * Specify multiple path parameter name-value pairs. Path parameters are used to improve readability of the request path. E.g. instead
+     * of writing:
+     * <pre>
+     * expect().statusCode(200).when().get("/item/"+myItem.getItemNumber()+"/buy/"+2);
+     * </pre>
+     * you can write:
+     * <pre>
+     * given().
+     *         pathParam("itemNumber", myItem.getItemNumber(), "amount", 2).
+     * expect().
+     *          statusCode(200).
+     * when().
+     *        get("/item/{itemNumber}/buy/{amount}");
+     * </pre>
+     * <p/>
+     * which improves readability and allows the path to be reusable in many tests. Another alternative is to use:
+     * <pre>
+     * expect().statusCode(200).when().get("/item/{itemNumber}/buy/{amount}", myItem.getItemNumber(), 2);
+     * </pre>
+     *
+     * @param firstParameterName      The name of the first parameter
+     * @param firstParameterValue     The value of the first parameter
+     * @param parameterNameValuePairs Additional parameters in name-value pairs.
+     * @return The request specification
+     */
+    public MockMvcRequestSpecBuilder addPathParams(String firstParameterName, Object firstParameterValue, Object... parameterNameValuePairs) {
+        spec.pathParams(firstParameterName, firstParameterValue, parameterNameValuePairs);
+        return this;
+    }
+
+    /**
+     * Specify multiple path parameter name-value pairs. Path parameters are used to improve readability of the request path. E.g. instead
+     * of writing:
+     * <pre>
+     * expect().statusCode(200).when().get("/item/"+myItem.getItemNumber()+"/buy/"+2);
+     * </pre>
+     * you can write:
+     * <pre>
+     * Map&lt;String,Object&gt; pathParams = new HashMap&lt;String,Object&gt;();
+     * pathParams.add("itemNumber",myItem.getItemNumber());
+     * pathParams.add("amount",2);
+     *
+     * given().
+     *         pathParameters(pathParams).
+     * expect().
+     *          statusCode(200).
+     * when().
+     *        get("/item/{itemNumber}/buy/{amount}");
+     * </pre>
+     * <p/>
+     * which improves readability and allows the path to be reusable in many tests. Another alternative is to use:
+     * <pre>
+     * expect().statusCode(200).when().get("/item/{itemNumber}/buy/{amount}", myItem.getItemNumber(), 2);
+     * </pre>
+     *
+     * @param parameterNameValuePairs A map containing the path parameters.
+     * @return The request specification
+     */
+    public MockMvcRequestSpecBuilder addPathParams(Map<String, Object> parameterNameValuePairs) {
+        spec.pathParams(parameterNameValuePairs);
         return this;
     }
 

--- a/modules/spring-mock-mvc/src/main/java/io/restassured/module/mockmvc/specification/MockMvcRequestSpecification.java
+++ b/modules/spring-mock-mvc/src/main/java/io/restassured/module/mockmvc/specification/MockMvcRequestSpecification.java
@@ -16,7 +16,6 @@
 
 package io.restassured.module.mockmvc.specification;
 
-import io.restassured.config.SessionConfig;
 import io.restassured.http.*;
 import io.restassured.mapper.ObjectMapper;
 import io.restassured.mapper.ObjectMapperType;
@@ -359,6 +358,55 @@ public interface MockMvcRequestSpecification extends MockMvcRequestSender {
      * @return The request specification
      */
     MockMvcRequestSpecification queryParam(String parameterName, Collection<?> parameterValues);
+
+    /**
+     * Specify the path parameters that'll be sent with the request.
+     *
+     * @param firstParameterName      The name of the first parameter
+     * @param firstParameterValue     The value of the first parameter
+     * @param parameterNameValuePairs The value of the first parameter followed by additional parameters in name-value pairs.
+     * @return The request specification
+     */
+    MockMvcRequestSpecification pathParams(String firstParameterName, Object firstParameterValue, Object... parameterNameValuePairs);
+
+    /**
+     * Specify the path parameters that'll be sent with the request.
+     *
+     * @param parametersMap The Map containing the parameter names and their values to send with the request.
+     * @return The request specification
+     */
+    MockMvcRequestSpecification pathParams(Map<String, Object> parametersMap);
+
+    /**
+     * Specify a path parameter. Path parameters are used to improve readability of the request path. E.g. instead
+     * of writing:
+     * <pre>
+     * when().
+     *        get("/item/"+myItem.getItemNumber()+"/buy/"+2).
+     * then().
+     *        statusCode(200);
+     * </pre>
+     * you can write:
+     * <pre>
+     * given().
+     *         pathParam("itemNumber", myItem.getItemNumber()).
+     *         pathParam("amount", 2).
+     * when().
+     *        get("/item/{itemNumber}/buy/{amount}").
+     * then().
+     *          statusCode(200);
+     * </pre>
+     * <p/>
+     * which improves readability and allows the path to be reusable in many tests. Another alternative is to use:
+     * <pre>
+     * when().get("/item/{itemNumber}/buy/{amount}", myItem.getItemNumber(), 2).then().statusCode(200).;
+     * </pre>
+     *
+     * @param parameterName  The parameter name
+     * @param parameterValue The parameter value
+     * @return The request specification
+     */
+    MockMvcRequestSpecification pathParam(String parameterName, Object parameterValue);
 
     /**
      * Specify the form parameters that'll be sent with the request. Note that this method is the same as {@link #params(String, Object, Object...)}

--- a/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/MockMvcParamConfigTest.java
+++ b/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/MockMvcParamConfigTest.java
@@ -72,6 +72,17 @@ public class MockMvcParamConfigTest {
     }
 
     @Test public void
+    replaces_path_params_by_default() {
+        RestAssuredMockMvc.given().
+                pathParam("value", "value1").
+                pathParam("value", "value2").
+            when().
+                get("/multiValueParam/{value}").
+            then().log().all().
+                body("value", equalTo("value2"));
+    }
+
+    @Test public void
     replaces_request_params_when_configured_to_do_so() {
         RestAssuredMockMvc.given().
                 config(config().paramConfig(paramConfig().requestParamsUpdateStrategy(REPLACE))).
@@ -135,12 +146,15 @@ public class MockMvcParamConfigTest {
                 queryParam("list2", "value4").
                 formParam("list3", "value5").
                 formParam("list3", "value6").
+                pathParam("value", "value7").
+                pathParam("value", "value8").
         when().
-                post("/threeMultiValueParam").
+                post("/threeMultiValueParam/{value}").
         then().
                 body("list", equalTo("value2")).
                 body("list2", equalTo("value4")).
-                body("list3", equalTo("value6"));
+                body("list3", equalTo("value6")).
+                body("value", equalTo("value8"));
     }
 
     @Test public void

--- a/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/MockMvcPathParamTest.java
+++ b/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/MockMvcPathParamTest.java
@@ -16,18 +16,35 @@
 
 package io.restassured.module.mockmvc;
 
+import io.restassured.http.Method;
 import io.restassured.module.mockmvc.http.GreetingController;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
 
 import static org.hamcrest.Matchers.equalTo;
 
 public class MockMvcPathParamTest {
+    @Before
+    public void configureMockMvcInstance() {
+        RestAssuredMockMvc.standaloneSetup(new GreetingController());
+    }
+
+    @After
+    public void restRestAssured() {
+        RestAssuredMockMvc.reset();
+    }
 // @formatter:off
 
     @Test
     public void unnamed_path_param_works() throws Exception {
         RestAssuredMockMvc.given().
-                standaloneSetup(new GreetingController()).
                 queryParam("name", "John").
         when().
                 get("/{x}", "greeting").
@@ -36,4 +53,187 @@ public class MockMvcPathParamTest {
                 body("content", equalTo("Hello, John!"));
     }
 // @formatter:on
+
+    @Test
+    public void should_succeed_with_get_method_when_named_parameter() {
+        RestAssuredMockMvc.given()
+                .pathParam("name", "John")
+            .when()
+                .get("/greeting/{name}")
+            .then()
+                .body("id", equalTo(1))
+                .body("content", equalTo("Hello, John!"));
+    }
+
+    @Test
+    public void should_succeed_with_get_method_when_unnamed_parameter() {
+        RestAssuredMockMvc.given()
+            .when()
+                .get("/greeting/{name}", "John")
+            .then()
+                .body("id", equalTo(1))
+                .body("content", equalTo("Hello, John!"));
+    }
+
+    @Test
+    public void should_succeed_with_get_method_with_named_parameter_and_unnamed_parameter() {
+        RestAssuredMockMvc.given()
+                .pathParam("date", "2023-08-31")
+            .when()
+                .get("/greeting/{name}/{date}", "John")
+            .then()
+                .body("id", equalTo(1))
+                .body("content", equalTo("Hello, John! Today is 2023-08-31"));
+    }
+
+    @Test
+    public void should_succeed_with_get_method_when_named_parameter_is_single_map_value() {
+        final Map<String, Object> pathParams = Collections.singletonMap("name", "John");
+        RestAssuredMockMvc.given()
+                .pathParams(pathParams)
+            .when()
+                .get("/greeting/{name}")
+            .then()
+                .body("id", equalTo(1))
+                .body("content", equalTo("Hello, John!"));
+    }
+
+    @Test
+    public void should_succeed_with_get_method_when_named_parameter_is_multi_map_value() {
+        final Map<String, Object> pathParams = new HashMap<>();
+        pathParams.put("name", "John");
+        pathParams.put("date", "2023-08-30");
+
+        RestAssuredMockMvc.given()
+                .pathParams(pathParams)
+            .when()
+                .get("/greeting/{name}/{date}")
+            .then()
+                .body("id", equalTo(1))
+                .body("content", equalTo("Hello, John! Today is 2023-08-30"));
+    }
+
+    @Test
+    public void should_succeed_with_get_method_when_named_parameter_per_add_method() {
+        RestAssuredMockMvc.given()
+                .pathParam("name", "John")
+                .pathParam("date", "2023-08-30")
+            .when()
+                .get("/greeting/{name}/{date}")
+            .then()
+                .body("id", equalTo(1))
+                .body("content", equalTo("Hello, John! Today is 2023-08-30"));
+    }
+
+    @Test
+    public void should_fail_with_get_method_when_does_not_has_params() {
+        // Supplier created to fix sonar error.
+        Supplier<Void> restAssuredExecutionSupplier = () -> {
+            RestAssuredMockMvc.given()
+                .when()
+                    .get("/greeting/{name}/{date}")
+                .then();
+
+            return null;
+        };
+
+        final Exception ex = Assert.assertThrows(IllegalArgumentException.class, restAssuredExecutionSupplier::get);
+        Assert.assertEquals("No values were found for the request's pathParams.", ex.getMessage());
+    }
+
+    @Test
+    public void should_succeed_with_request_method_when_named_parameter() {
+        RestAssuredMockMvc.given()
+                .pathParam("name", "John")
+            .when()
+                .request(Method.GET, "/greeting/{name}")
+            .then()
+                .body("id", equalTo(1))
+                .body("content", equalTo("Hello, John!"));
+    }
+
+    @Test
+    public void should_succeed_with_request_method_when_unnamed_parameter() {
+        RestAssuredMockMvc.given()
+            .when()
+                .request(Method.GET, "/greeting/{name}", "John")
+            .then()
+                .body("id", equalTo(1))
+                .body("content", equalTo("Hello, John!"));
+    }
+
+    @Test
+    public void should_succeed_with_request_method_with_named_parameter_and_unnamed_parameter() {
+        RestAssuredMockMvc.given()
+                .pathParam("date", "2023-08-31")
+            .when()
+                .request(Method.GET, "/greeting/{name}/{date}", "John")
+            .then()
+                .body("id", equalTo(1))
+                .body("content", equalTo("Hello, John! Today is 2023-08-31"));
+    }
+
+    @Test
+    public void should_succeed_with_request_method_when_named_parameter_is_single_map_value() {
+        final Map<String, Object> pathParams = Collections.singletonMap("name", "John");
+        RestAssuredMockMvc.given()
+                .pathParams(pathParams)
+            .when()
+                .request(Method.GET, "/greeting/{name}")
+            .then()
+                .body("id", equalTo(1))
+                .body("content", equalTo("Hello, John!"));
+    }
+
+    @Test
+    public void should_succeed_with_request_method_when_named_parameter_is_multi_map_value() {
+        final Map<String, Object> pathParams = new HashMap<>();
+        pathParams.put("name", "John");
+        pathParams.put("date", "2023-08-30");
+
+        RestAssuredMockMvc.given()
+                .pathParams(pathParams)
+            .when()
+                .request(Method.GET, "/greeting/{name}/{date}")
+            .then()
+                .body("id", equalTo(1))
+                .body("content", equalTo("Hello, John! Today is 2023-08-30"));
+    }
+
+    @Test
+    public void should_succeed_with_request_method_when_named_parameter_as_value_pairs() {
+        RestAssuredMockMvc.given()
+                .pathParams("name", "John", "date", "2023-08-30")
+            .when()
+                .request(Method.GET, "/greeting/{name}/{date}")
+            .then()
+                .body("id", equalTo(1))
+                .body("content", equalTo("Hello, John! Today is 2023-08-30"));
+    }
+
+    @Test
+    public void should_succeed_with_request_method_when_has_only_unnamed_parameter() {
+        RestAssuredMockMvc.given()
+            .when()
+                .request(Method.GET, "/greeting/{name}/{date}", "John", "2023-08-30")
+            .then()
+                .body("id", equalTo(1))
+                .body("content", equalTo("Hello, John! Today is 2023-08-30"));
+    }
+
+    @Test
+    public void should_fail_with_request_method_when_does_not_has_params() {
+        // Supplier created to fix sonar error.
+        Supplier<Void> restAssuredExecutionSupplier = () -> {
+            RestAssuredMockMvc.given()
+                .when()
+                    .request(Method.GET, "/greeting/{name}/{date}")
+                .then();
+
+            return null;
+        };
+
+        final Exception ex = Assert.assertThrows(IllegalArgumentException.class, restAssuredExecutionSupplier::get);
+        Assert.assertEquals("No values were found for the request's pathParams.", ex.getMessage());
+    }
 }

--- a/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/PutTest.java
+++ b/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/PutTest.java
@@ -59,7 +59,7 @@ public class PutTest {
                 log().all().
                 statusCode(415);
 
-        assertThat(writer.toString(), equalTo(String.format("415 Content type 'null' not supported%n" +
+        assertThat(writer.toString(), equalTo(String.format("415 Content type '' not supported%n" +
                 "Accept: application/x-www-form-urlencoded%n")));
     }
 

--- a/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/RestDocsTest.java
+++ b/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/RestDocsTest.java
@@ -21,7 +21,7 @@ import io.restassured.module.mockmvc.http.GreetingController;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.springframework.restdocs.RestDocumentation;
+import org.springframework.restdocs.JUnitRestDocumentation;
 
 import static io.restassured.module.mockmvc.config.MockMvcConfig.mockMvcConfig;
 import static org.hamcrest.Matchers.equalTo;
@@ -37,7 +37,7 @@ public class RestDocsTest {
     public ExpectedException exception = ExpectedException.none();
 
     @Rule
-    public final RestDocumentation restDocumentation = new RestDocumentation("target/generated-snippets");
+    public final JUnitRestDocumentation restDocumentation = new JUnitRestDocumentation("target/generated-snippets");
 
     @Test
     public void path_parameters_are_automatically_supported() {
@@ -47,7 +47,7 @@ public class RestDocsTest {
         when().
                get("/{path}", "greeting").
         then().
-                apply(document("greeting").snippets(
+                apply(document("greeting",
                         pathParameters(
                                 parameterWithName("path").description("The path to greeting")),
                         responseFields(
@@ -61,7 +61,7 @@ public class RestDocsTest {
     @Test
     public void can_disable_automatic_spring_rest_docks_mvc_support() {
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("urlTemplate not found. Did you use RestDocumentationRequestBuilders to build the request?");
+        exception.expectMessage("urlTemplate not found. If you are using MockMvc did you use RestDocumentationRequestBuilders to build the request?");
 
         RestAssuredMockMvc.given().
                 config(RestAssuredMockMvcConfig.config().mockMvcConfig(mockMvcConfig().dontAutomaticallyApplySpringRestDocsMockMvcSupport())).
@@ -70,7 +70,7 @@ public class RestDocsTest {
         when().
                get("/{path}", "greeting").
         then().
-                apply(document("greeting").snippets(
+                apply(document("greeting",
                         pathParameters(
                                 parameterWithName("path").description("The path to greeting")),
                         responseFields(

--- a/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/http/AttributeController.java
+++ b/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/http/AttributeController.java
@@ -17,6 +17,7 @@
 package io.restassured.module.mockmvc.http;
 
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
@@ -28,6 +29,7 @@ import java.util.Collections;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 
+@Controller
 public class AttributeController {
 
     @RequestMapping(value = "/attribute", method = GET, produces = APPLICATION_JSON_VALUE)

--- a/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/http/CookieController.java
+++ b/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/http/CookieController.java
@@ -16,6 +16,8 @@
 
 package io.restassured.module.mockmvc.http;
 
+import org.springframework.mock.web.MockCookie;
+import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -30,37 +32,8 @@ import javax.servlet.http.HttpServletResponse;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 
+@Controller
 public class CookieController {
-	
-    /**
-      * Mimics org.springframework.mock.web.MockCookie
-      */
-    public static class MockCookie extends Cookie {
-        private static final long serialVersionUID = 1L;
-		
-        private String sameSite;
-        private ZonedDateTime expires;
-
-        public MockCookie(String name, String value) {
-            super(name, value);
-        }
-
-        public String getSameSite() {
-            return sameSite;
-        }
-
-        public void setSameSite(String sameSite) {
-            this.sameSite = sameSite;
-        }
-
-        public ZonedDateTime getExpires() {
-            return expires;
-        }
-
-        public void setExpires(ZonedDateTime expires) {
-            this.expires = expires;
-        }
-    }
 
     @RequestMapping(value = "/cookie", method = GET, produces = APPLICATION_JSON_VALUE)
     public @ResponseBody String cookie(@CookieValue("cookieName1") String cookieValue1, @CookieValue(value = "cookieName2", required = false) String cookieValue2) {
@@ -69,17 +42,17 @@ public class CookieController {
 
     @RequestMapping(value = "/setCookies", method = GET, produces = APPLICATION_JSON_VALUE)
     public @ResponseBody String setCookies(HttpServletResponse response,
-                     @RequestParam("cookieName1") String cookieName1, @RequestParam("cookieValue1") String cookieValue1,
-                     @RequestParam("cookieName2") String cookieName2, @RequestParam("cookieValue2") String cookieValue2) {
+                                           @RequestParam("cookieName1") String cookieName1, @RequestParam("cookieValue1") String cookieValue1,
+                                           @RequestParam("cookieName2") String cookieName2, @RequestParam("cookieValue2") String cookieValue2) {
         response.addCookie(new Cookie(cookieName1, cookieValue1));
         response.addCookie(new Cookie(cookieName2, cookieValue2));
         return "{}";
     }
-    
+
     @RequestMapping(value = "/setDetailedCookies", method = GET, produces = APPLICATION_JSON_VALUE)
     public @ResponseBody String setDetailedCookies(HttpServletResponse response,
-                     @RequestParam("cookieName1") String cookieName1, @RequestParam("cookieValue1") String cookieValue1,
-                     @RequestParam("cookieName2") String cookieName2, @RequestParam("cookieValue2") String cookieValue2) {
+                                                   @RequestParam("cookieName1") String cookieName1, @RequestParam("cookieValue1") String cookieValue1,
+                                                   @RequestParam("cookieName2") String cookieName2, @RequestParam("cookieValue2") String cookieValue2) {
         MockCookie cookie1 = new MockCookie(cookieName1, cookieValue1);
         cookie1.setHttpOnly(true);
         cookie1.setSameSite("None");

--- a/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/http/GreetingController.java
+++ b/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/http/GreetingController.java
@@ -16,6 +16,7 @@
 package io.restassured.module.mockmvc.http;
 
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -31,13 +32,24 @@ import static org.springframework.web.bind.annotation.RequestMethod.POST;
 @Controller
 public class GreetingController {
 
-    private static final String template = "Hello, %s!";
+    private static final String TEMPLATE = "Hello, %s!";
+    private static final String TEMPLATE_WITH_DATE = TEMPLATE + " Today is %s";
     private final AtomicLong counter = new AtomicLong();
 
     @RequestMapping(value = "/greeting", method = GET)
     public @ResponseBody Greeting greeting(
             @RequestParam(value="name", required=false, defaultValue="World") String name) {
-        return new Greeting(counter.incrementAndGet(), String.format(template, name));
+        return new Greeting(counter.incrementAndGet(), String.format(TEMPLATE, name));
+    }
+
+    @RequestMapping(value = "/greeting/{name}", method = GET, produces = "application/json")
+    public @ResponseBody Greeting greetingWithPathParam(@PathVariable(value="name") String name) {
+        return greeting(name);
+    }
+
+    @RequestMapping(value = "/greeting/{name}/{date}", method = GET, produces = "application/json")
+    public @ResponseBody Greeting greetingWithPathParam(@PathVariable(value="name") String name, @PathVariable(value="date") String date) {
+        return new Greeting(counter.incrementAndGet(), String.format(TEMPLATE_WITH_DATE, name, date));
     }
 
     @RequestMapping(value = "/greeting", method = POST, consumes = "application/json", produces = "application/json")

--- a/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/http/HeaderController.java
+++ b/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/http/HeaderController.java
@@ -16,6 +16,7 @@
 
 package io.restassured.module.mockmvc.http;
 
+import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 
+@Controller
 public class HeaderController {
 
     @RequestMapping(value = "/header", method = GET, produces = APPLICATION_JSON_VALUE)

--- a/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/http/MultiValueController.java
+++ b/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/http/MultiValueController.java
@@ -18,6 +18,7 @@ package io.restassured.module.mockmvc.http;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -35,12 +36,19 @@ public class MultiValueController {
         return "{ \"list\" : \"" + StringUtils.join(listValues, ",") + "\" }";
     }
 
-    @RequestMapping(value = "/threeMultiValueParam", method = POST, produces = MediaType.APPLICATION_JSON_VALUE)
+    @RequestMapping(value = "/multiValueParam/{value}", method = {GET}, produces = MediaType.APPLICATION_JSON_VALUE)
+    public @ResponseBody String multiValueParam(@PathVariable("value") String value) {
+        return "{ \"value\" : \"" + value + "\" }";
+    }
+
+    @RequestMapping(value = { "/threeMultiValueParam", "/threeMultiValueParam/{value}" }, method = POST, produces = MediaType.APPLICATION_JSON_VALUE)
     public @ResponseBody String threeMultiValueParam(@RequestParam("list") List<String> list1Values,
                                                      @RequestParam("list2") List<String> list2Values,
-                                                     @RequestParam("list3") List<String> list3Values) {
+                                                     @RequestParam("list3") List<String> list3Values,
+                                                     @PathVariable(value = "value", required = false) String value) {
         return "{ \"list\" : \"" + StringUtils.join(list1Values, ",") + "\"," +
                 " \"list2\" : \"" + StringUtils.join(list2Values, ",") + "\", " +
-                " \"list3\" : \"" + StringUtils.join(list3Values, ",") + "\" }";
+                " \"list3\" : \"" + StringUtils.join(list3Values, ",") + "\" " +
+                (StringUtils.isBlank(value) ? " }" : ", \"value\" : \"" + value + "\" }");
     }
 }

--- a/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/http/ParserController.java
+++ b/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/http/ParserController.java
@@ -16,12 +16,14 @@
 
 package io.restassured.module.mockmvc.http;
 
+import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 
+@Controller
 public class ParserController {
 
     @RequestMapping(value = "/parserWithUnknownContentType", method = GET, produces = "some/thing")

--- a/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/http/RedirectController.java
+++ b/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/http/RedirectController.java
@@ -18,11 +18,13 @@ package io.restassured.module.mockmvc.http;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 
+@Controller
 public class RedirectController {
 
     @RequestMapping(value = "/redirect", method = GET, produces = APPLICATION_JSON_VALUE)

--- a/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/http/ResponseAwareMatcherController.java
+++ b/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/http/ResponseAwareMatcherController.java
@@ -16,12 +16,14 @@
 
 package io.restassured.module.mockmvc.http;
 
+import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 
+@Controller
 public class ResponseAwareMatcherController {
 
     @RequestMapping(value = "/responseAware", method = GET, produces = APPLICATION_JSON_VALUE)

--- a/modules/spring-web-test-client/src/main/java/io/restassured/module/webtestclient/config/WebTestClientParamConfig.java
+++ b/modules/spring-web-test-client/src/main/java/io/restassured/module/webtestclient/config/WebTestClientParamConfig.java
@@ -25,23 +25,31 @@ public class WebTestClientParamConfig extends ParamConfig {
 
 	private final boolean userConfigured;
 	private final UpdateStrategy queryParamsUpdateStrategy;
+	private final UpdateStrategy pathParamsUpdateStrategy;
 	private final UpdateStrategy formParamsUpdateStrategy;
 	private final UpdateStrategy requestParameterUpdateStrategy;
 	private final UpdateStrategy attributeUpdateStrategy;
 
 
 	public WebTestClientParamConfig() {
-		this(MERGE, MERGE, MERGE, MERGE, false);
+		this(MERGE, REPLACE, MERGE, MERGE, MERGE, false);
 	}
 
-	public WebTestClientParamConfig(UpdateStrategy queryParamsUpdateStrategy, UpdateStrategy formParamsUpdateStrategy,
-	                                UpdateStrategy requestParameterUpdateStrategy, UpdateStrategy attributeUpdateStrategy,
-	                                boolean userConfigured) {
+	public WebTestClientParamConfig(
+			UpdateStrategy queryParamsUpdateStrategy,
+			UpdateStrategy pathParamsUpdateStrategy,
+			UpdateStrategy formParamsUpdateStrategy,
+			UpdateStrategy requestParameterUpdateStrategy,
+			UpdateStrategy attributeUpdateStrategy,
+			boolean userConfigured
+	) {
 		notNull(queryParamsUpdateStrategy, "Query param update strategy");
+		notNull(pathParamsUpdateStrategy, "Path param update strategy");
 		notNull(requestParameterUpdateStrategy, "Request param update strategy");
 		notNull(formParamsUpdateStrategy, "Form param update strategy");
 		notNull(attributeUpdateStrategy, "Attribute update strategy");
 		this.queryParamsUpdateStrategy = queryParamsUpdateStrategy;
+		this.pathParamsUpdateStrategy = pathParamsUpdateStrategy;
 		this.formParamsUpdateStrategy = formParamsUpdateStrategy;
 		this.requestParameterUpdateStrategy = requestParameterUpdateStrategy;
 		this.attributeUpdateStrategy = attributeUpdateStrategy;
@@ -78,6 +86,13 @@ public class WebTestClientParamConfig extends ParamConfig {
 	}
 
 	/**
+	 * @return The update strategy for path parameters
+	 */
+	public UpdateStrategy pathParamsUpdateStrategy() {
+		return pathParamsUpdateStrategy;
+	}
+
+	/**
 	 * {@inheritDoc}
 	 */
 	public boolean isUserConfigured() {
@@ -98,7 +113,7 @@ public class WebTestClientParamConfig extends ParamConfig {
 	 * @return A new instance of {@link WebTestClientParamConfig}
 	 */
 	public WebTestClientParamConfig mergeAllParameters() {
-		return new WebTestClientParamConfig(MERGE, MERGE, MERGE, MERGE, true);
+		return new WebTestClientParamConfig(MERGE, REPLACE, MERGE, MERGE, MERGE, true);
 	}
 
 	/**
@@ -107,7 +122,7 @@ public class WebTestClientParamConfig extends ParamConfig {
 	 * @return A new instance of {@link WebTestClientParamConfig}
 	 */
 	public WebTestClientParamConfig replaceAllParameters() {
-		return new WebTestClientParamConfig(REPLACE, REPLACE, REPLACE, REPLACE, true);
+		return new WebTestClientParamConfig(REPLACE, REPLACE, REPLACE, REPLACE, REPLACE, true);
 	}
 
 	/**
@@ -117,7 +132,7 @@ public class WebTestClientParamConfig extends ParamConfig {
 	 * @return A new instance of {@link WebTestClientParamConfig}
 	 */
 	public WebTestClientParamConfig formParamsUpdateStrategy(UpdateStrategy updateStrategy) {
-		return new WebTestClientParamConfig(queryParamsUpdateStrategy, updateStrategy,
+		return new WebTestClientParamConfig(queryParamsUpdateStrategy, pathParamsUpdateStrategy, updateStrategy,
 				requestParameterUpdateStrategy, attributeUpdateStrategy, true);
 	}
 
@@ -132,7 +147,7 @@ public class WebTestClientParamConfig extends ParamConfig {
 	 * @return A new instance of {@link WebTestClientParamConfig}
 	 */
 	public WebTestClientParamConfig requestParamsUpdateStrategy(UpdateStrategy updateStrategy) {
-		return new WebTestClientParamConfig(queryParamsUpdateStrategy, formParamsUpdateStrategy,
+		return new WebTestClientParamConfig(queryParamsUpdateStrategy, pathParamsUpdateStrategy, formParamsUpdateStrategy,
 				updateStrategy, attributeUpdateStrategy, true);
 	}
 
@@ -144,7 +159,7 @@ public class WebTestClientParamConfig extends ParamConfig {
 	 * @return A new instance of {@link WebTestClientParamConfig}
 	 */
 	public WebTestClientParamConfig queryParamsUpdateStrategy(UpdateStrategy updateStrategy) {
-		return new WebTestClientParamConfig(updateStrategy, formParamsUpdateStrategy,
+		return new WebTestClientParamConfig(updateStrategy, pathParamsUpdateStrategy, formParamsUpdateStrategy,
 				requestParameterUpdateStrategy, attributeUpdateStrategy, true);
 	}
 
@@ -173,7 +188,7 @@ public class WebTestClientParamConfig extends ParamConfig {
 	 * @return A new instance of {@link WebTestClientParamConfig}
 	 */
 	public WebTestClientParamConfig attributeUpdateStrategy(UpdateStrategy updateStrategy) {
-		return new WebTestClientParamConfig(queryParamsUpdateStrategy, formParamsUpdateStrategy,
+		return new WebTestClientParamConfig(queryParamsUpdateStrategy, pathParamsUpdateStrategy, formParamsUpdateStrategy,
 				requestParameterUpdateStrategy, updateStrategy, true);
 	}
 

--- a/modules/spring-web-test-client/src/main/java/io/restassured/module/webtestclient/internal/UriContainer.java
+++ b/modules/spring-web-test-client/src/main/java/io/restassured/module/webtestclient/internal/UriContainer.java
@@ -1,0 +1,57 @@
+package io.restassured.module.webtestclient.internal;
+
+import org.springframework.lang.NonNull;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static io.restassured.internal.common.assertion.AssertParameter.notNull;
+
+public class UriContainer {
+    private final String uri;
+    private final Map<String, Object> uriVariables;
+
+    private UriContainer(Builder builder) {
+        this.uri = builder.uri;
+        this.uriVariables = builder.uriVariables;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public Map<String, Object> getUriVariables() {
+        return uriVariables;
+    }
+
+    public static Builder newBuilder(@NonNull String uri) {
+        notNull(uri, "uri");
+        return new Builder(uri);
+    }
+
+    public static final class Builder {
+        private String uri;
+        private Map<String, Object> uriVariables = new LinkedHashMap<>();
+
+        private Builder(@NonNull String uri) {
+            notNull(uri, "uri");
+            this.uri = uri;
+        }
+
+        public Builder uri(@NonNull String uri) {
+            notNull(uri, "uri");
+            this.uri = uri;
+            return this;
+        }
+
+        public Builder uriVariables(@NonNull Map<String, Object> uriVariables) {
+            notNull(uriVariables, "uriVariables");
+            this.uriVariables = new LinkedHashMap<>(uriVariables);
+            return this;
+        }
+
+        public UriContainer build() {
+            return new UriContainer(this);
+        }
+    }
+}

--- a/modules/spring-web-test-client/src/main/java/io/restassured/module/webtestclient/internal/WebTestClientRequestSenderImpl.java
+++ b/modules/spring-web-test-client/src/main/java/io/restassured/module/webtestclient/internal/WebTestClientRequestSenderImpl.java
@@ -41,6 +41,7 @@ import io.restassured.module.webtestclient.specification.WebTestClientRequestSen
 import io.restassured.specification.RequestSpecification;
 import io.restassured.specification.ResponseSpecification;
 import org.apache.commons.codec.Charsets;
+import org.apache.commons.lang3.ArrayUtils;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.client.MultipartBodyBuilder;
@@ -56,8 +57,11 @@ import java.io.File;
 import java.net.URI;
 import java.net.URL;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static io.restassured.internal.common.assertion.AssertParameter.notNull;
@@ -75,9 +79,11 @@ import static org.springframework.http.MediaType.parseMediaType;
 public class WebTestClientRequestSenderImpl implements WebTestClientRequestSender {
 
 	private static final String CONTENT_TYPE = "Content-Type";
+	private static final Pattern PATH_PARAM_PATTERN = Pattern.compile("\\{([^/]+?)\\}");
 
 	private final WebTestClient webTestClient;
 	private final Map<String, Object> params;
+	private final Map<String, Object> namedPathParams;
 	private final Map<String, Object> queryParams;
 	private final Map<String, Object> formParams;
 	private final Map<String, Object> attributes;
@@ -151,15 +157,26 @@ public class WebTestClientRequestSenderImpl implements WebTestClientRequestSende
 		return sendRequest(GET, path, pathParams);
 	}
 
-	public WebTestClientRequestSenderImpl(WebTestClient webTestClient, Map<String, Object> params, Map<String,
-			Object> queryParams, Map<String, Object> formParams, Map<String, Object> attributes,
-										  RestAssuredWebTestClientConfig config, Object requestBody, Headers headers,
-										  Cookies cookies, List<MultiPartInternal> multiParts,
-										  RequestLoggingFilter requestLoggingFilter, String basePath,
-										  ResponseSpecification responseSpecification,
-										  LogRepository logRepository) {
+	public WebTestClientRequestSenderImpl(
+			WebTestClient webTestClient,
+			Map<String, Object> params,
+			Map<String,Object> namedPathParams,
+			Map<String,Object> queryParams,
+			Map<String, Object> formParams,
+			Map<String, Object> attributes,
+			RestAssuredWebTestClientConfig config,
+			Object requestBody,
+			Headers headers,
+			Cookies cookies,
+			List<MultiPartInternal> multiParts,
+			RequestLoggingFilter requestLoggingFilter,
+			String basePath,
+			ResponseSpecification responseSpecification,
+			LogRepository logRepository
+	) {
 		this.webTestClient = webTestClient;
 		this.params = params;
+		this.namedPathParams = namedPathParams;
 		this.queryParams = queryParams;
 		this.formParams = formParams;
 		this.attributes = attributes;
@@ -390,20 +407,24 @@ public class WebTestClientRequestSenderImpl implements WebTestClientRequestSende
 		return request(method, notNull(url, URL.class).toString());
 	}
 
-	private WebTestClientResponse sendRequest(HttpMethod method, String path, Object[] pathParams) {
+	private WebTestClientResponse sendRequest(HttpMethod method, String path, Object[] unnamedPathParams) {
 		String requestContentType = HeaderHelper.findContentType(headers, (List<Object>) (List<?>) multiParts, config);
-		WebTestClient.RequestBodySpec requestBodySpec = buildFromPath(method, requestContentType, path, pathParams);
+		WebTestClient.RequestBodySpec requestBodySpec = buildFromPath(method, requestContentType, path, unnamedPathParams);
 		addRequestElements(method, requestContentType, requestBodySpec);
-		logRequestIfApplicable(method, getBaseUri(path), path, pathParams);
+		logRequestIfApplicable(method, getBaseUri(path), path, unnamedPathParams);
 		return performRequest(requestBodySpec);
 	}
 
-	private WebTestClient.RequestBodySpec buildFromPath(HttpMethod method, String requestContentType, String path,
-														Object[] pathParams) {
+	private WebTestClient.RequestBodySpec buildFromPath(
+			HttpMethod method,
+			String requestContentType,
+			String path,
+			Object[] unnamedPathParams
+	) {
 		notNull(path, "Path");
 		String baseUri = getBaseUri(path);
-		String uri = buildUri(method, requestContentType, baseUri);
-		return webTestClient.method(method).uri(uri, resolvePathParams(pathParams));
+		String uri = buildUri(method, requestContentType, baseUri, unnamedPathParams);
+		return webTestClient.method(method).uri(uri);
 	}
 
 	private void addRequestElements(HttpMethod method, String requestContentType, WebTestClient.RequestBodySpec requestBodySpec) {
@@ -425,7 +446,7 @@ public class WebTestClientRequestSenderImpl implements WebTestClientRequestSende
 		final RequestSpecificationImpl reqSpec = new RequestSpecificationImpl("http://localhost",
 				RestAssured.UNDEFINED_PORT, "", new NoAuthScheme(), Collections.emptyList(),
 				null, true, ConfigConverter.convertToRestAssuredConfig(config), logRepository, null, true, true);
-		logParamsAndHeaders(reqSpec, method.toString(), uri, unnamedPathParams, params, queryParams, formParams, headers, cookies);
+		logParamsAndHeaders(reqSpec, method.toString(), uri, unnamedPathParams, params, namedPathParams, queryParams, formParams, headers, cookies);
 		logRequestBody(reqSpec, requestBody, headers, (List<Object>) (List<?>) multiParts, config);
 		ofNullable(multiParts).map(List::stream).orElseGet(Stream::empty)
 				.forEach(multiPart -> addMultipartToReqSpec(reqSpec, multiPart));
@@ -465,21 +486,27 @@ public class WebTestClientRequestSenderImpl implements WebTestClientRequestSende
 		return restAssuredResponse;
 	}
 
-	private String buildUri(HttpMethod method, String requestContentType, String baseUri) {
+	private String buildUri(HttpMethod method, String requestContentType, String baseUri, Object[] unnamedPathParams) {
 		final UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.fromUriString(baseUri);
 		applyQueryParams(uriComponentsBuilder);
+		applyPathParams(uriComponentsBuilder, baseUri, unnamedPathParams);
 		applyParams(method, uriComponentsBuilder, requestContentType);
 		applyFormParams(method, uriComponentsBuilder, requestContentType);
 		return uriComponentsBuilder.build().toUriString();
 	}
 
-	private Object[] resolvePathParams(Object[] pathParams) {
-		Arrays.stream(pathParams).filter(param -> !(param instanceof String))
+	private void validateUnnamedPathParams(final Object[] unnamedPathParams) {
+		Arrays.stream(unnamedPathParams).filter(param -> !(param instanceof String))
 				.findAny().ifPresent(param -> {
 			throw new IllegalArgumentException("Only Strings allowed in path parameters.");
 		});
-		return Arrays.stream(pathParams)
-				.map(param -> UriUtils.encode((String) param, Charsets.UTF_8)).toArray();
+	}
+
+	private void validateNamedPathParams(final Map<String, Object> namedPathParams) {
+		namedPathParams.entrySet().stream().filter(e -> !(e.getValue() instanceof String))
+				.findAny().ifPresent(param -> {
+					throw new IllegalArgumentException("Only Strings allowed in path parameters.");
+				});
 	}
 
 	private void verifyNoBodyAndMultipartTogether() {
@@ -539,6 +566,47 @@ public class WebTestClientRequestSenderImpl implements WebTestClientRequestSende
 				}
 			}.applyParams();
 		}
+	}
+
+	private void applyPathParams(
+			final UriComponentsBuilder uriComponentsBuilder,
+			final String baseUri,
+			final Object[] unnamedPathParams
+	) {
+		validateUnnamedPathParams(unnamedPathParams);
+		validateNamedPathParams(namedPathParams);
+
+		final Matcher pathParamMatcher = PATH_PARAM_PATTERN.matcher(baseUri);
+		if (!pathParamMatcher.find()) {
+			return;
+		}
+
+		if (namedPathParams.isEmpty() && ArrayUtils.isEmpty(unnamedPathParams)) {
+			throw new IllegalArgumentException("No values were found for the request's pathParams.");
+		}
+
+		final AtomicInteger nextUnnamedPathParamIndex = new AtomicInteger(0);
+		final Function<String, Optional<Object>> getPathParamValueFunction = param -> {
+			if (namedPathParams.containsKey(param)) {
+				return Optional.of(namedPathParams.get(param));
+			}
+
+			if (unnamedPathParams.length > 0) {
+				return Optional.of(unnamedPathParams[nextUnnamedPathParamIndex.getAndIncrement()]);
+			}
+
+			return Optional.empty();
+		};
+
+		final Map<String, Object> uriVariables = new HashMap<>();
+		do {
+			final String paramName = pathParamMatcher.group(1);
+			getPathParamValueFunction.apply(paramName).ifPresent(paramValue ->
+					uriVariables.put(paramName, UriUtils.encode((String) paramValue, Charsets.UTF_8))
+			);
+		} while (pathParamMatcher.find());
+
+		uriComponentsBuilder.uriVariables(uriVariables);
 	}
 
 	private void applyParams(HttpMethod method, UriComponentsBuilder uriComponentsBuilder, String requestContentType) {
@@ -611,7 +679,7 @@ public class WebTestClientRequestSenderImpl implements WebTestClientRequestSende
 				RestAssured.UNDEFINED_PORT, "", new NoAuthScheme(), Collections.emptyList(),
 				null, true, ConfigConverter.convertToRestAssuredConfig(config), logRepository, null, true, true);
 		logParamsAndHeaders(reqSpec, method.toString(), "Request from uri function" + uriFunction.toString(),
-				null, params, queryParams, formParams,
+				null, params, namedPathParams, queryParams, formParams,
 				headers, cookies);
 		logRequestBody(reqSpec, requestBody, headers, (List<Object>) (List<?>) multiParts, config);
 		ofNullable(multiParts).map(List::stream).orElseGet(Stream::empty)

--- a/modules/spring-web-test-client/src/main/java/io/restassured/module/webtestclient/specification/WebTestClientRequestSpecBuilder.java
+++ b/modules/spring-web-test-client/src/main/java/io/restassured/module/webtestclient/specification/WebTestClientRequestSpecBuilder.java
@@ -16,7 +16,6 @@
 package io.restassured.module.webtestclient.specification;
 
 import io.restassured.config.LogConfig;
-import io.restassured.config.SessionConfig;
 import io.restassured.filter.log.LogDetail;
 import io.restassured.filter.log.RequestLoggingFilter;
 import io.restassured.http.ContentType;
@@ -242,6 +241,101 @@ public class WebTestClientRequestSpecBuilder {
 	 */
 	public WebTestClientRequestSpecBuilder addQueryParam(String parameterName, Object... parameterValues) {
 		spec.queryParam(parameterName, parameterValues);
+		return this;
+	}
+
+	/**
+	 * Specify a path parameter. Path parameters are used to improve readability of the request path. E.g. instead
+	 * of writing:
+	 * <pre>
+	 * expect().statusCode(200).when().get("/item/"+myItem.getItemNumber()+"/buy/"+2);
+	 * </pre>
+	 * you can write:
+	 * <pre>
+	 * given().
+	 *         pathParam("itemNumber", myItem.getItemNumber()).
+	 *         pathParam("amount", 2).
+	 * expect().
+	 *          statusCode(200).
+	 * when().
+	 *        get("/item/{itemNumber}/buy/{amount}");
+	 * </pre>
+	 * <p/>
+	 * which improves readability and allows the path to be reusable in many tests. Another alternative is to use:
+	 * <pre>
+	 * expect().statusCode(200).when().get("/item/{itemNumber}/buy/{amount}", myItem.getItemNumber(), 2);
+	 * </pre>
+	 *
+	 * @param parameterName  The parameter key
+	 * @param parameterValue The parameter value
+	 * @return The request specification
+	 */
+	public WebTestClientRequestSpecBuilder addPathParam(String parameterName, Object parameterValue) {
+		spec.pathParam(parameterName, parameterValue);
+		return this;
+	}
+
+	/**
+	 * Specify multiple path parameter name-value pairs. Path parameters are used to improve readability of the request path. E.g. instead
+	 * of writing:
+	 * <pre>
+	 * expect().statusCode(200).when().get("/item/"+myItem.getItemNumber()+"/buy/"+2);
+	 * </pre>
+	 * you can write:
+	 * <pre>
+	 * given().
+	 *         pathParam("itemNumber", myItem.getItemNumber(), "amount", 2).
+	 * expect().
+	 *          statusCode(200).
+	 * when().
+	 *        get("/item/{itemNumber}/buy/{amount}");
+	 * </pre>
+	 * <p/>
+	 * which improves readability and allows the path to be reusable in many tests. Another alternative is to use:
+	 * <pre>
+	 * expect().statusCode(200).when().get("/item/{itemNumber}/buy/{amount}", myItem.getItemNumber(), 2);
+	 * </pre>
+	 *
+	 * @param firstParameterName      The name of the first parameter
+	 * @param firstParameterValue     The value of the first parameter
+	 * @param parameterNameValuePairs Additional parameters in name-value pairs.
+	 * @return The request specification
+	 */
+	public WebTestClientRequestSpecBuilder addPathParams(String firstParameterName, Object firstParameterValue, Object... parameterNameValuePairs) {
+		spec.pathParams(firstParameterName, firstParameterValue, parameterNameValuePairs);
+		return this;
+	}
+
+	/**
+	 * Specify multiple path parameter name-value pairs. Path parameters are used to improve readability of the request path. E.g. instead
+	 * of writing:
+	 * <pre>
+	 * expect().statusCode(200).when().get("/item/"+myItem.getItemNumber()+"/buy/"+2);
+	 * </pre>
+	 * you can write:
+	 * <pre>
+	 * Map&lt;String,Object&gt; pathParams = new HashMap&lt;String,Object&gt;();
+	 * pathParams.add("itemNumber",myItem.getItemNumber());
+	 * pathParams.add("amount",2);
+	 *
+	 * given().
+	 *         pathParameters(pathParams).
+	 * expect().
+	 *          statusCode(200).
+	 * when().
+	 *        get("/item/{itemNumber}/buy/{amount}");
+	 * </pre>
+	 * <p/>
+	 * which improves readability and allows the path to be reusable in many tests. Another alternative is to use:
+	 * <pre>
+	 * expect().statusCode(200).when().get("/item/{itemNumber}/buy/{amount}", myItem.getItemNumber(), 2);
+	 * </pre>
+	 *
+	 * @param parameterNameValuePairs A map containing the path parameters.
+	 * @return The request specification
+	 */
+	public WebTestClientRequestSpecBuilder addPathParams(Map<String, Object> parameterNameValuePairs) {
+		spec.pathParams(parameterNameValuePairs);
 		return this;
 	}
 

--- a/modules/spring-web-test-client/src/main/java/io/restassured/module/webtestclient/specification/WebTestClientRequestSpecification.java
+++ b/modules/spring-web-test-client/src/main/java/io/restassured/module/webtestclient/specification/WebTestClientRequestSpecification.java
@@ -16,7 +16,6 @@
 
 package io.restassured.module.webtestclient.specification;
 
-import io.restassured.config.SessionConfig;
 import io.restassured.http.*;
 import io.restassured.mapper.ObjectMapper;
 import io.restassured.mapper.ObjectMapperType;
@@ -356,6 +355,55 @@ public interface WebTestClientRequestSpecification extends WebTestClientRequestS
 	 * @return The request specification
 	 */
 	WebTestClientRequestSpecification queryParam(String parameterName, Collection<?> parameterValues);
+
+	/**
+	 * Specify the path parameters that'll be sent with the request.
+	 *
+	 * @param firstParameterName      The name of the first parameter
+	 * @param firstParameterValue     The value of the first parameter
+	 * @param parameterNameValuePairs The value of the first parameter followed by additional parameters in name-value pairs.
+	 * @return The request specification
+	 */
+	WebTestClientRequestSpecification pathParams(String firstParameterName, Object firstParameterValue, Object... parameterNameValuePairs);
+
+	/**
+	 * Specify the path parameters that'll be sent with the request.
+	 *
+	 * @param parametersMap The Map containing the parameter names and their values to send with the request.
+	 * @return The request specification
+	 */
+	WebTestClientRequestSpecification pathParams(Map<String, Object> parametersMap);
+
+	/**
+	 * Specify a path parameter. Path parameters are used to improve readability of the request path. E.g. instead
+	 * of writing:
+	 * <pre>
+	 * when().
+	 *        get("/item/"+myItem.getItemNumber()+"/buy/"+2).
+	 * then().
+	 *        statusCode(200);
+	 * </pre>
+	 * you can write:
+	 * <pre>
+	 * given().
+	 *         pathParam("itemNumber", myItem.getItemNumber()).
+	 *         pathParam("amount", 2).
+	 * when().
+	 *        get("/item/{itemNumber}/buy/{amount}").
+	 * then().
+	 *          statusCode(200);
+	 * </pre>
+	 * <p/>
+	 * which improves readability and allows the path to be reusable in many tests. Another alternative is to use:
+	 * <pre>
+	 * when().get("/item/{itemNumber}/buy/{amount}", myItem.getItemNumber(), 2).then().statusCode(200).;
+	 * </pre>
+	 *
+	 * @param parameterName  The parameter name
+	 * @param parameterValue The parameter value
+	 * @return The request specification
+	 */
+	WebTestClientRequestSpecification pathParam(String parameterName, Object parameterValue);
 
 	/**
 	 * Specify the form parameters that'll be sent with the request. Note that this method is the same as {@link #params(String, Object, Object...)}

--- a/modules/spring-web-test-client/src/test/java/io/restassured/module/webtestclient/WebTestClientParamConfigTest.java
+++ b/modules/spring-web-test-client/src/test/java/io/restassured/module/webtestclient/WebTestClientParamConfigTest.java
@@ -75,6 +75,17 @@ public class WebTestClientParamConfigTest {
 				.body("list", equalTo("value1,value2"));
 	}
 
+	@Test public void
+	replaces_path_params_by_default() {
+		RestAssuredWebTestClient.given().
+				pathParam("value", "value1").
+				pathParam("value", "value2").
+			when().
+				get("/multiValueParam/{value}").
+			then().
+				body("value", equalTo("value2"));
+	}
+
 	@Test
 	public void
 	replaces_request_params_when_configured_to_do_so() {
@@ -143,12 +154,15 @@ public class WebTestClientParamConfigTest {
 				.queryParam("list2", "value4")
 				.formParam("list3", "value5")
 				.formParam("list3", "value6")
+				.pathParam("value", "value7")
+				.pathParam("value", "value8")
 				.when()
-				.post("/threeMultiValueParam")
+				.post("/threeMultiValueParam/{value}")
 				.then()
 				.body("list", equalTo("value2"))
 				.body("list2", equalTo("value4"))
-				.body("list3", equalTo("value6"));
+				.body("list3", equalTo("value6"))
+				.body("value", equalTo("value8"));
 	}
 
 	@Test

--- a/modules/spring-web-test-client/src/test/java/io/restassured/module/webtestclient/WebTestClientPathParamTest.java
+++ b/modules/spring-web-test-client/src/test/java/io/restassured/module/webtestclient/WebTestClientPathParamTest.java
@@ -16,22 +16,223 @@
 
 package io.restassured.module.webtestclient;
 
+import io.restassured.http.Method;
 import io.restassured.module.webtestclient.setup.GreetingController;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
 
 import static org.hamcrest.Matchers.equalTo;
 
 public class WebTestClientPathParamTest {
 
+	@Before
+	public void configureMockMvcInstance() {
+		RestAssuredWebTestClient.standaloneSetup(new GreetingController());
+	}
+
+	@After
+	public void restRestAssured() {
+		RestAssuredWebTestClient.reset();
+	}
+
 	@Test
 	public void unnamed_path_param_works() {
 		RestAssuredWebTestClient.given()
-				.standaloneSetup(new GreetingController())
 				.queryParam("name", "John")
-				.when()
+			.when()
 				.get("/{x}", "greeting")
-				.then()
+			.then()
 				.body("id", equalTo(1))
 				.body("content", equalTo("Hello, John!"));
+	}
+
+	@Test
+	public void should_succeed_with_get_method_when_named_parameter() {
+		RestAssuredWebTestClient.given()
+				.pathParam("name", "John")
+			.when()
+				.get("/greeting/{name}")
+			.then()
+				.body("id", equalTo(1))
+				.body("content", equalTo("Hello, John!"));
+	}
+
+	@Test
+	public void should_succeed_with_get_method_when_unnamed_parameter() {
+		RestAssuredWebTestClient.given()
+			.when()
+				.get("/greeting/{name}", "John")
+			.then()
+				.body("id", equalTo(1))
+				.body("content", equalTo("Hello, John!"));
+	}
+
+	@Test
+	public void should_succeed_with_get_method_with_named_parameter_and_unnamed_parameter() {
+		RestAssuredWebTestClient.given()
+				.pathParam("date", "2023-08-31")
+			.when()
+				.get("/greeting/{name}/{date}", "John")
+			.then()
+				.body("id", equalTo(1))
+				.body("content", equalTo("Hello, John! Today is 2023-08-31"));
+	}
+
+	@Test
+	public void should_succeed_with_get_method_when_named_parameter_is_single_map_value() {
+		final Map<String, Object> pathParams = Collections.singletonMap("name", "John");
+		RestAssuredWebTestClient.given()
+				.pathParams(pathParams)
+			.when()
+				.get("/greeting/{name}")
+			.then()
+				.body("id", equalTo(1))
+				.body("content", equalTo("Hello, John!"));
+	}
+
+	@Test
+	public void should_succeed_with_get_method_when_named_parameter_is_multi_map_value() {
+		final Map<String, Object> pathParams = new HashMap<>();
+		pathParams.put("name", "John");
+		pathParams.put("date", "2023-08-30");
+
+		RestAssuredWebTestClient.given()
+				.pathParams(pathParams)
+			.when()
+				.get("/greeting/{name}/{date}")
+			.then()
+				.body("id", equalTo(1))
+				.body("content", equalTo("Hello, John! Today is 2023-08-30"));
+	}
+
+	@Test
+	public void should_succeed_with_get_method_when_named_parameter_per_add_method() {
+		RestAssuredWebTestClient.given()
+				.pathParam("name", "John")
+				.pathParam("date", "2023-08-30")
+			.when()
+				.get("/greeting/{name}/{date}")
+			.then()
+				.body("id", equalTo(1))
+				.body("content", equalTo("Hello, John! Today is 2023-08-30"));
+	}
+
+	@Test
+	public void should_fail_with_get_method_when_does_not_has_params() {
+		// Supplier created to fix sonar error.
+		Supplier<Void> restAssuredExecutionSupplier = () -> {
+			RestAssuredWebTestClient.given()
+				.when()
+					.get("/greeting/{name}/{date}")
+				.then();
+
+			return null;
+		};
+
+		final Exception ex = Assert.assertThrows(IllegalArgumentException.class, restAssuredExecutionSupplier::get);
+		Assert.assertEquals("No values were found for the request's pathParams.", ex.getMessage());
+	}
+
+	@Test
+	public void should_succeed_with_request_method_when_named_parameter() {
+		RestAssuredWebTestClient.given()
+				.pathParam("name", "John")
+			.when()
+				.request(Method.GET, "/greeting/{name}")
+			.then()
+				.body("id", equalTo(1))
+				.body("content", equalTo("Hello, John!"));
+	}
+
+	@Test
+	public void should_succeed_with_request_method_when_unnamed_parameter() {
+		RestAssuredWebTestClient.given()
+			.when()
+				.request(Method.GET, "/greeting/{name}", "John")
+			.then()
+				.body("id", equalTo(1))
+				.body("content", equalTo("Hello, John!"));
+	}
+
+	@Test
+	public void should_succeed_with_request_method_with_named_parameter_and_unnamed_parameter() {
+		RestAssuredWebTestClient.given()
+				.pathParam("date", "2023-08-31")
+			.when()
+				.request(Method.GET, "/greeting/{name}/{date}", "John")
+			.then()
+				.body("id", equalTo(1))
+				.body("content", equalTo("Hello, John! Today is 2023-08-31"));
+	}
+
+	@Test
+	public void should_succeed_with_request_method_when_named_parameter_is_single_map_value() {
+		final Map<String, Object> pathParams = Collections.singletonMap("name", "John");
+		RestAssuredWebTestClient.given()
+				.pathParams(pathParams)
+			.when()
+				.request(Method.GET, "/greeting/{name}")
+			.then()
+				.body("id", equalTo(1))
+				.body("content", equalTo("Hello, John!"));
+	}
+
+	@Test
+	public void should_succeed_with_request_method_when_named_parameter_is_multi_map_value() {
+		final Map<String, Object> pathParams = new HashMap<>();
+		pathParams.put("name", "John");
+		pathParams.put("date", "2023-08-30");
+
+		RestAssuredWebTestClient.given()
+				.pathParams(pathParams)
+			.when()
+				.request(Method.GET, "/greeting/{name}/{date}")
+			.then()
+				.body("id", equalTo(1))
+				.body("content", equalTo("Hello, John! Today is 2023-08-30"));
+	}
+
+	@Test
+	public void should_succeed_with_request_method_when_named_parameter_as_value_pairs() {
+		RestAssuredWebTestClient.given()
+				.pathParams("name", "John", "date", "2023-08-30")
+			.when()
+				.request(Method.GET, "/greeting/{name}/{date}")
+			.then()
+				.body("id", equalTo(1))
+				.body("content", equalTo("Hello, John! Today is 2023-08-30"));
+	}
+
+	@Test
+	public void should_succeed_with_request_method_when_has_only_unnamed_parameter() {
+		RestAssuredWebTestClient.given()
+			.when()
+				.request(Method.GET, "/greeting/{name}/{date}", "John", "2023-08-30")
+			.then()
+				.body("id", equalTo(1))
+				.body("content", equalTo("Hello, John! Today is 2023-08-30"));
+	}
+
+	@Test
+	public void should_fail_with_request_method_when_does_not_has_params() {
+		// Supplier created to fix sonar error.
+		Supplier<Void> restAssuredExecutionSupplier = () -> {
+			RestAssuredWebTestClient.given()
+				.when()
+					.request(Method.GET, "/greeting/{name}/{date}")
+				.then();
+
+			return null;
+		};
+
+		final Exception ex = Assert.assertThrows(IllegalArgumentException.class, restAssuredExecutionSupplier::get);
+		Assert.assertEquals("No values were found for the request's pathParams.", ex.getMessage());
 	}
 }

--- a/modules/spring-web-test-client/src/test/java/io/restassured/module/webtestclient/setup/GreetingController.java
+++ b/modules/spring-web-test-client/src/test/java/io/restassured/module/webtestclient/setup/GreetingController.java
@@ -17,6 +17,7 @@ package io.restassured.module.webtestclient.setup;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -30,14 +31,25 @@ import java.util.concurrent.atomic.AtomicLong;
 @RestController
 public class GreetingController {
 
-    private static final String template = "Hello, %s!";
+    private static final String TEMPLATE = "Hello, %s!";
+    private static final String TEMPLATE_WITH_DATE = TEMPLATE + " Today is %s";
     private final AtomicLong counter = new AtomicLong();
 
 	@GetMapping(produces = "application/json")
     public Mono<ResponseEntity> simpleGreeting() {
         ResponseEntity responseEntity = ResponseEntity.ok(new Greeting(counter.incrementAndGet(),
-                String.format(template, "World")));
+                String.format(TEMPLATE, "World")));
         return Mono.justOrEmpty(responseEntity);
+    }
+
+    @GetMapping(value = "/greeting/{name}", produces = "application/json")
+    public Mono<Greeting> greetingWithPathParam(@PathVariable(value="name") String name) {
+        return greeting(name);
+    }
+
+    @GetMapping(value = "/greeting/{name}/{date}", produces = "application/json")
+    public Mono<Greeting> greetingWithPathParam(@PathVariable(value="name") String name, @PathVariable(value="date") String date) {
+        return Mono.just(new Greeting(counter.incrementAndGet(), String.format(TEMPLATE_WITH_DATE, name, date)));
     }
 
 	@PostMapping(value = "/greeting", consumes = "application/json", produces = "application/json")
@@ -49,6 +61,6 @@ public class GreetingController {
 	@GetMapping(value = "/greeting")
 	public Mono<Greeting> greeting(
             @RequestParam(value="name", required=false, defaultValue="World") String name) {
-		return Mono.just(new Greeting(counter.incrementAndGet(), String.format(template, name)));
+		return Mono.just(new Greeting(counter.incrementAndGet(), String.format(TEMPLATE, name)));
     }
 }

--- a/modules/spring-web-test-client/src/test/java/io/restassured/module/webtestclient/setup/MultiValueController.java
+++ b/modules/spring-web-test-client/src/test/java/io/restassured/module/webtestclient/setup/MultiValueController.java
@@ -15,7 +15,9 @@
  */
 package io.restassured.module.webtestclient.setup;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -35,12 +37,19 @@ public class MultiValueController {
         return Mono.just("{ \"list\" : \"" + String.join(",", listValues) + "\" }");
     }
 
-    @PostMapping(value = "/threeMultiValueParam", produces = MediaType.APPLICATION_JSON_VALUE)
+    @RequestMapping(value = "/multiValueParam/{value}", method = {GET}, produces = MediaType.APPLICATION_JSON_VALUE)
+    public Mono<String> multiValueParam(@PathVariable("value") String value) {
+        return Mono.just("{ \"value\" : \"" + value + "\" }");
+    }
+
+    @PostMapping(value = { "/threeMultiValueParam", "/threeMultiValueParam/{value}" }, produces = MediaType.APPLICATION_JSON_VALUE)
     public Mono<String> threeMultiValueParam(@RequestParam("list") List<String> list1Values,
                                              @RequestParam("list2") List<String> list2Values,
-                                             @RequestParam("list3") List<String> list3Values) {
-        return Mono.just("{ \"list\" : \"" + String.join(",", list1Values) + "\"," +
-                " \"list2\" : \"" + String.join(",", list2Values) + "\", " +
-                " \"list3\" : \"" + String.join(",", list3Values) + "\" }");
+                                             @RequestParam("list3") List<String> list3Values,
+                                             @PathVariable(value = "value", required = false) String value) {
+        return Mono.just("{ \"list\" : \"" + StringUtils.join(list1Values, ",") + "\"," +
+                " \"list2\" : \"" + StringUtils.join(list2Values, ",") + "\", " +
+                " \"list3\" : \"" + StringUtils.join(list3Values, ",") + "\" " +
+                (StringUtils.isBlank(value) ? " }" : ", \"value\" : \"" + value + "\" }"));
     }
 }

--- a/rest-assured/src/main/groovy/io/restassured/assertion/DetailedCookieAssertion.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/assertion/DetailedCookieAssertion.groovy
@@ -35,6 +35,9 @@ class DetailedCookieAssertion {
         Cookie cookie = cookiesInHeader.get(cookieName)
         if (cookie == null) {
             cookie = responseCookies.get(cookieName)
+        } else if (cookie.getExpiryDate() == null) {
+            Cookie cookieFromResponse = responseCookies.get(cookieName);
+            cookie = new Cookie.Builder(cookie).setExpiryDate(cookieFromResponse.getExpiryDate()).build()
         }
 
         success = matcher.matches(cookie)

--- a/rest-assured/src/main/java/io/restassured/config/ParamConfig.java
+++ b/rest-assured/src/main/java/io/restassured/config/ParamConfig.java
@@ -29,6 +29,7 @@ public class ParamConfig implements Config {
 
     private final boolean userConfigured;
     private final UpdateStrategy queryParamsUpdateStrategy;
+    private final UpdateStrategy pathParamsUpdateStrategy;
     private final UpdateStrategy formParamsUpdateStrategy;
     private final UpdateStrategy requestParameterUpdateStrategy;
 
@@ -36,28 +37,37 @@ public class ParamConfig implements Config {
      * Create a new instance where all parameters are merged
      */
     public ParamConfig() {
-        this(MERGE, MERGE, MERGE, false);
+        this(MERGE, REPLACE, MERGE, MERGE, false);
     }
 
     /**
      * Create a new instance and specify update strategies for all parameter types.
      *
      * @param queryParamsUpdateStrategy      The update strategy for query parameters
+     * @param pathParamsUpdateStrategy       The update strategy for path parameters
      * @param formParamsUpdateStrategy       The update strategy for form parameters
      * @param requestParameterUpdateStrategy The update strategy for request parameters
      */
     public ParamConfig(UpdateStrategy queryParamsUpdateStrategy,
+                       UpdateStrategy pathParamsUpdateStrategy,
                        UpdateStrategy formParamsUpdateStrategy,
                        UpdateStrategy requestParameterUpdateStrategy) {
-        this(queryParamsUpdateStrategy, formParamsUpdateStrategy, requestParameterUpdateStrategy, true);
+        this(queryParamsUpdateStrategy, pathParamsUpdateStrategy, formParamsUpdateStrategy, requestParameterUpdateStrategy, true);
     }
 
-    private ParamConfig(UpdateStrategy queryParamsUpdateStrategy, UpdateStrategy formParamsUpdateStrategy,
-                        UpdateStrategy requestParameterUpdateStrategy, boolean userConfigured) {
+    private ParamConfig(
+            UpdateStrategy queryParamsUpdateStrategy,
+            UpdateStrategy pathParamsUpdateStrategy,
+            UpdateStrategy formParamsUpdateStrategy,
+            UpdateStrategy requestParameterUpdateStrategy,
+            boolean userConfigured
+    ) {
         AssertParameter.notNull(queryParamsUpdateStrategy, "Query param update strategy");
+        AssertParameter.notNull(pathParamsUpdateStrategy, "Path param update strategy");
         AssertParameter.notNull(requestParameterUpdateStrategy, "Request param update strategy");
         AssertParameter.notNull(formParamsUpdateStrategy, "Form param update strategy");
         this.queryParamsUpdateStrategy = queryParamsUpdateStrategy;
+        this.pathParamsUpdateStrategy = pathParamsUpdateStrategy;
         this.formParamsUpdateStrategy = formParamsUpdateStrategy;
         this.requestParameterUpdateStrategy = requestParameterUpdateStrategy;
         this.userConfigured = userConfigured;
@@ -69,7 +79,7 @@ public class ParamConfig implements Config {
      * @return A new instance of {@link ParamConfig}
      */
     public ParamConfig mergeAllParameters() {
-        return new ParamConfig(MERGE, MERGE, MERGE, true);
+        return new ParamConfig(MERGE, REPLACE, MERGE, MERGE, true);
     }
 
     /**
@@ -78,7 +88,7 @@ public class ParamConfig implements Config {
      * @return A new instance of {@link ParamConfig}
      */
     public ParamConfig replaceAllParameters() {
-        return new ParamConfig(REPLACE, REPLACE, REPLACE, true);
+        return new ParamConfig(REPLACE, REPLACE, REPLACE, REPLACE, true);
     }
 
     /**
@@ -88,7 +98,7 @@ public class ParamConfig implements Config {
      * @return A new instance of {@link ParamConfig}
      */
     public ParamConfig formParamsUpdateStrategy(UpdateStrategy updateStrategy) {
-        return new ParamConfig(queryParamsUpdateStrategy, updateStrategy, requestParameterUpdateStrategy, true);
+        return new ParamConfig(queryParamsUpdateStrategy, pathParamsUpdateStrategy, updateStrategy, requestParameterUpdateStrategy, true);
     }
 
     /**
@@ -102,7 +112,7 @@ public class ParamConfig implements Config {
      * @return A new instance of {@link ParamConfig}
      */
     public ParamConfig requestParamsUpdateStrategy(UpdateStrategy updateStrategy) {
-        return new ParamConfig(queryParamsUpdateStrategy, formParamsUpdateStrategy, updateStrategy, true);
+        return new ParamConfig(queryParamsUpdateStrategy, pathParamsUpdateStrategy, formParamsUpdateStrategy, updateStrategy, true);
     }
 
     /**
@@ -112,7 +122,7 @@ public class ParamConfig implements Config {
      * @return A new instance of {@link ParamConfig}
      */
     public ParamConfig queryParamsUpdateStrategy(UpdateStrategy updateStrategy) {
-        return new ParamConfig(updateStrategy, formParamsUpdateStrategy, requestParameterUpdateStrategy, true);
+        return new ParamConfig(updateStrategy, pathParamsUpdateStrategy, formParamsUpdateStrategy, requestParameterUpdateStrategy, true);
     }
 
     /**
@@ -134,6 +144,13 @@ public class ParamConfig implements Config {
      */
     public UpdateStrategy queryParamsUpdateStrategy() {
         return queryParamsUpdateStrategy;
+    }
+
+    /**
+     * @return The update strategy for path parameters
+     */
+    public UpdateStrategy pathParamsUpdateStrategy() {
+        return pathParamsUpdateStrategy;
     }
 
     /**

--- a/rest-assured/src/main/java/io/restassured/http/Cookie.java
+++ b/rest-assured/src/main/java/io/restassured/http/Cookie.java
@@ -357,6 +357,25 @@ public class Cookie implements NameAndValue {
         }
 
         /**
+         * Create a cookie builder with cookie props
+         * @param cookie The cookie
+         */
+        public Builder(Cookie cookie) {
+            notNull(cookie, "Cookie");
+            this.name = cookie.name;
+            this.value = cookie.value;
+            this.comment = cookie.comment;
+            this.expiryDate = cookie.expiryDate;
+            this.domain = cookie.domain;
+            this.path = cookie.path;
+            this.secured = cookie.secured;
+            this.httpOnly = cookie.httpOnly;
+            this.version = cookie.version;
+            this.maxAge = cookie.maxAge;
+            this.sameSite = cookie.sameSite;
+        }
+
+        /**
          * Set the comment describing the purpose of this cookie.
          *
          * @param comment The comment


### PR DESCRIPTION
This PR adds support for `addPathParam` methods for `RestAssuredMockMvc` and `RestAssuredWebTestClient`.

Fixes #1720;