### PR TITLE
add onFailMessage into validatable response

### DIFF
--- a/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/ErrorMessageITest.java
+++ b/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/ErrorMessageITest.java
@@ -110,8 +110,30 @@ public class ErrorMessageITest extends WithJetty {
                 body("lotto.lottoId", lessThan(2)).
                 body("lotto.winning-numbers", hasItem(21)).
                 onFailMessage("An additional information to find the cause of the error").
-                when().
+        when().
                 get("/lotto");
+    }
+
+    @Test public void
+    error_message_look_ok_with_on_fail_message_validatable_response() {
+        exception.expect(AssertionError.class);
+        exception.expectMessage("2 expectations failed.\n" +
+          "JSON path lotto.lottoId doesn't match.\n" +
+          "Expected: a value less than <2>\n" +
+          "  Actual: <5>\n" +
+          "\n" +
+          "JSON path lotto.winning-numbers doesn't match.\n" +
+          "Expected: a collection containing <21>\n" +
+          "  Actual: <[2, 45, 34, 23, 7, 5, 3]>\n" +
+          "\n" +
+          "On fail message: An additional information to find the cause of the error");
+
+        when().
+               get("/lotto").
+        then().
+               onFailMessage("An additional information to find the cause of the error").
+               body("lotto.lottoId", lessThan(2)).
+               body("lotto.winning-numbers", hasItem(21));
     }
 
     @Test public void

--- a/rest-assured/src/main/java/io/restassured/internal/ValidatableResponseOptionsImpl.java
+++ b/rest-assured/src/main/java/io/restassured/internal/ValidatableResponseOptionsImpl.java
@@ -410,6 +410,11 @@ public abstract class ValidatableResponseOptionsImpl<T extends ValidatableRespon
         return (T) this;
     }
 
+    public T onFailMessage(String message) {
+        responseSpec.onFailMessage(message);
+        return (T) this;
+    }
+
     public abstract R originalResponse();
 
     private Matcher<?> getMatcherFromResponseAwareMatcher(ResponseAwareMatcher<R> responseAwareMatcher) {

--- a/rest-assured/src/main/java/io/restassured/response/ValidatableResponseOptions.java
+++ b/rest-assured/src/main/java/io/restassured/response/ValidatableResponseOptions.java
@@ -1105,4 +1105,16 @@ public interface ValidatableResponseOptions<T extends ValidatableResponseOptions
      * @return The {@link ValidatableResponse} instance.
      */
     T time(Matcher<Long> matcher, TimeUnit timeUnit);
+
+    /**
+     * Add user message to final mismatch description.
+     * <p/>
+     * This is useful when you need to associate a mismatch description with additional user information. For example, in parallel execution.
+     * <p/>
+     * Note, if you want to add a description for certain matching, not for all, you should use something like
+     * Hamcrest wrapper matcher - {@link org.hamcrest.CoreMatchers#describedAs}.
+     *
+     * @param message The user message
+     */
+    T onFailMessage(String message);
 }


### PR DESCRIPTION
Fix for the #1548

Added method *onFailMessage* into *ValidatableResponseOptions* to add possibility overriding an error message from *then* section:

```java
when().
       get("/lotto").
then().
       onFailMessage("An additional information to find the cause of the error").
       body("lotto.lottoId", lessThan(2));
```

UPD: Here is a [link](https://github.com/rest-assured/rest-assured/wiki/Usage#log-if-validation-fails) to the documentation with mistake which was discussed in the issue topic.