### PR TITLE
Correction, removed the content = string equalization

### DIFF
--- a/rest-assured/src/main/groovy/io/restassured/internal/RestAssuredResponseOptionsGroovyImpl.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/RestAssuredResponseOptionsGroovyImpl.groovy
@@ -155,7 +155,6 @@ class RestAssuredResponseOptionsGroovyImpl {
 
   String print() {
     def string = asString()
-    content = string
     println string
     string
   }


### PR DESCRIPTION
There are situations when the built-in print() function is needed - it is convenient. But due to the presence of a content change to string inside it, format-sensitive data may break. For example, the method can receive as String (in case of an error) so is File, but if there is a file, converting the original content to String led to an error when debagging.