### PR TITLE
Fix 1746: JsonPath: wrong result and exception when jsonPath partly evaluates to string/boolean/number

### DIFF
--- a/json-path/src/main/groovy/io/restassured/internal/path/json/JSONAssertion.groovy
+++ b/json-path/src/main/groovy/io/restassured/internal/path/json/JSONAssertion.groovy
@@ -45,9 +45,14 @@ class JSONAssertion implements Assertion {
         }
         result = eval(root, object, expr)
       } catch (MissingPropertyException e) {
-        // This means that a param was used that was not defined
-        String error = String.format("The parameter \"%s\" was used but not defined. Define parameters using the JsonPath.params(...) function", e.property)
-        throw new IllegalArgumentException(error, e)
+        def message = e.getMessage();
+        // detect missed property on script-level. This should be defined by user as param
+        if (message != null && (message.startsWith("No such property:") && message.endsWith("for class: Script1"))) {
+          String error = String.format("The parameter \"%s\" was used but not defined. Define parameters using the JsonPath.param(...) function", e.property)
+          throw new IllegalArgumentException(error, e)
+        }
+        // return null if exception occurred for property from json path, see #1746
+        return null
       } catch (Exception e) {
         // Check if exception is due to a missing property
         if (e instanceof NullPointerException){

--- a/json-path/src/test/java/io/restassured/path/json/JsonPathTest.java
+++ b/json-path/src/test/java/io/restassured/path/json/JsonPathTest.java
@@ -30,6 +30,8 @@ import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
 
 public class JsonPathTest {
 
@@ -803,4 +805,80 @@ public class JsonPathTest {
         // Then   no exception should be thrown
         assertThat(jsonPath.getString("root.items[0]"), is(nullValue()));
     }
+
+
+    /** Tests #1746 is fixed plus additional verifications to ensure we did not break existing behavior */
+    @Test public void
+    returns_null_for_absent_json_keys(){
+
+        // ------- Given
+        String json = "{\"root\": {" +
+                      "    \"nKey\": null," +
+                      "    \"iKey\": 1," +
+                      "    \"fKey\": 1.1," +
+                      "    \"sKey\": \"ss\"," +
+                      "    \"bKey\": true," +
+
+                      "    \"array\"  : [{" +
+                      "        \"nKey\": null," +
+                      "        \"iKey\": 1," +
+                      "        \"fKey\": 1.1," +
+                      "        \"sKey\": \"ss\"," +
+                      "        \"bKey\": true" +
+                      "        }]," +
+                      "    \"arrEmpty\"  : []" +
+                      "    }" +
+                      "}";
+        // ------ When
+        JsonPath jsonPath = JsonPath.from(json);
+
+        // ------ Then
+
+        // test pre-#1746 behavior for objects
+        assertThat(jsonPath.get("root.absentKey"), is(nullValue()));
+        assertThat(jsonPath.get("root.nKey.absentKey"), is(nullValue()));
+
+        // Test the #1746: change "IllegalArgumentException" to null when root.xKey has ifsb type in json
+        // ifsb == int/float/string/boolean
+        assertThat(jsonPath.get("root.iKey.absentKey"), is(nullValue()));
+        assertThat(jsonPath.get("root.fKey.absentKey"), is(nullValue()));
+        assertThat(jsonPath.get("root.sKey.absentKey"), is(nullValue()));
+        assertThat(jsonPath.get("root.bKey.absentKey"), is(nullValue()));
+
+        // Test the #1746, for items inside arrays:
+        // Note that we cannot return [] here because of library design to use Groovy for processing
+        // But 'null'  is better than pre-#1746 "IllegalArgumentException"
+        assertThat(jsonPath.get("root.array.iKey.absentKey"), is(nullValue()));
+        assertThat(jsonPath.get("root.array.fKey.absentKey"), is(nullValue()));
+        assertThat(jsonPath.get("root.array.sKey.absentKey"), is(nullValue()));
+        assertThat(jsonPath.get("root.array.bKey.absentKey"), is(nullValue()));
+
+        // test pre-#1746 behavior for arrays:
+        assertThat(jsonPath.get("root.array.absentKey"), allOf(hasSize(1), contains((Object)null)));  // [null]
+        assertThat(jsonPath.get("root.array.nKey.absentKey"), is(empty()));  // []
+        assertThat(jsonPath.get("root.arrEmpty.absentKey"), is(empty()));    // []
+
+    }
+
+
+    /** Test that fix #1746 did not break exception about parameters */
+    @Test public void
+    exception_should_be_thrown_for_undefined_script_parameters(){
+
+        // Given
+        JsonPath jsonPath = JsonPath.from("{}");
+
+        Exception actualException = null;
+        //When
+        try{
+            jsonPath/*.param("myParameter", "xx")*/.get("$==myParameter");
+        }catch (IllegalArgumentException e){actualException = e;}
+
+        //Then
+        assertThat(actualException, is(notNullValue()));
+        assertThat(actualException.getMessage(),
+                   equalTo("The parameter \"myParameter\" was used but not defined. Define parameters using the " +
+                           "JsonPath.param(...) function"));
+    }
+
 }


### PR DESCRIPTION
Closes #1746