### PR TITLE
Update RequestSpecification.java

### DIFF
--- a/rest-assured/src/main/java/io/restassured/specification/RequestSpecification.java
+++ b/rest-assured/src/main/java/io/restassured/specification/RequestSpecification.java
@@ -842,7 +842,7 @@ public interface RequestSpecification extends RequestSender {
      * <pre>
      * Header first = new Header("headerName1", "headerValue1");
      * Header second = new Header("headerName2", "headerValue2");
-     * Headers headers = new Header(first, second);
+     * Headers headers = new Headers(first, second);
      * given().headers(headers).then().expect().body(equalTo("something")).when().get("/headers");
      * </pre>
      * <p/>


### PR DESCRIPTION
Typo in java doc for specifying request headers using `Headers` class.
Java doc shows calling `Header` class constructor for creating `Headers` class instance. 