### PR TITLE
remove deprecated Content-Transfer-Encoding from multipart post headers

### DIFF
--- a/rest-assured/src/main/groovy/io/restassured/internal/RequestSpecificationImpl.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/RequestSpecificationImpl.groovy
@@ -1432,15 +1432,15 @@ class RequestSpecificationImpl implements FilterableRequestSpecification, Groovy
         def body = it.contentBody
         def controlName = it.controlName
         def headers = it.headers
-        if (headers.isEmpty()) {
-          entity.addPart(controlName, body)
-        } else {
-          def builder = FormBodyPartBuilder.create(controlName, body)
-          headers.each { name, value ->
-            builder.addField(name, value)
-          }
-          entity.addPart(builder.build())
+        def builder = FormBodyPartBuilder.create(controlName, body)
+        headers.each { name, value ->
+          builder.addField(name, value)
         }
+        def part = builder.build()
+        // note: as of org.apache.httpcomponents:httpmime:4.5.13 FormBodyPartBuilder adds `Content-Transfer-Encoding` header to
+        // each part, causing issues for sides that follow https://datatracker.ietf.org/doc/html/rfc7578#section-4.7
+        part.getHeader().removeFields("Content-Transfer-Encoding")
+        entity.addPart(part)
       }
 
       entity


### PR DESCRIPTION
**motivation:**

This PR fixes a problem I stumbled upon: rest-assured requests are rejected by receiver because of invalid header in multipart post.

According to https://datatracker.ietf.org/doc/html/rfc7578#section-4.7 _senders SHOULD NOT generate any parts with a Content-Transfer-Encoding header field._

**sources:**

* SO issue related directly to rest-assured: https://stackoverflow.com/questions/72868970/javarestassured-remove-content-transfer-encoding-binary-from-multipart-request
* another probable manifestation of the root cause coming from (possibly incorrect usage of) the underlying apache library elsewhere: https://stackoverflow.com/questions/33023370/setting-the-content-transfer-encoding-of-upload-file-in-multi-part-http-request

**compare/contrast:**

cURL 7.68.0 for `-F attachments=@attachment.txt` sends e.g.:
```
Content-Disposition: form-data; name="attachments"; filename="attachment.txt"
Content-Type: text/plain

test
```

rest-assured 5.4.0 for `.multiPart("attachments", new File("attachment.txt"), "text/plain")` without fix sends e.g.:
```
Content-Disposition: form-data; name="attachments"; filename="attachment.txt"
Content-Type: text/plain
Content-Transfer-Encoding: binary

test
```

rest-assured 5.4.0 with this fix sends e.g.:
```
Content-Disposition: form-data; name="attachments"; filename="attachment.txt"
Content-Type: text/plain

test
```