### PR TITLE
Properly resolve HTTP methods

### DIFF
--- a/modules/spring-mock-mvc/src/main/java/io/restassured/module/mockmvc/internal/MockMvcRequestSenderImpl.java
+++ b/modules/spring-mock-mvc/src/main/java/io/restassured/module/mockmvc/internal/MockMvcRequestSenderImpl.java
@@ -852,10 +852,6 @@ class MockMvcRequestSenderImpl implements MockMvcRequestSender, MockMvcRequestAs
 
     private HttpMethod toValidHttpMethod(String method) {
         String httpMethodAsString = notNull(trimToNull(method), "HTTP Method");
-        HttpMethod httpMethod = HttpMethod.resolve(httpMethodAsString.toUpperCase());
-        if (httpMethod == null) {
-            throw new IllegalArgumentException("HTTP method '" + method + "' is not supported by MockMvc");
-        }
-        return httpMethod;
+        return HttpMethod.valueOf(httpMethodAsString.toUpperCase());
     }
 }


### PR DESCRIPTION
On Spring Framework 5 `HttpMethod` is an enum type that exposes a `resolve(java.lang.String)` method that matches the String value passed with the enum value while handling null values gracefully. However, in the context of `toValidHttpMethod(java.lang.String)`, there is a previous assertion that ensures `null` will not be passed moving forward. Hence, using enum's native `valueOf` directly seems like a good idea.

Furthermore, Spring Framework 6.0 marked `HttpMethod#resolve(java.lang.String)` as deprecated for removal, and starting from Spring Framework 6.1 this API element no longer exists. This change is currently causing issues (#1760) with latest Spring Framework and Spring Boot versions.

This commit replaces the use of this method with the equivalent `HttpMethod#valueOf(java.lang.String)`.

Closes #1760.