### PR TITLE
Create scala-extensions module for Scala 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ target
 .settings
 .springBeans
 .idea
+.metals
+.vscode
+.bloop
 classes/
 lib/
 rest-assured-all/dependency-reduced-pom.xml

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,22 @@
+version = "3.7.15"
+runner.dialect = scala3
+maxColumn = 120
+align.preset = most
+align.multiline = false
+continuationIndent.defnSite = 2
+assumeStandardLibraryStripMargin = true
+docstrings.style = Asterisk
+docstrings.wrapMaxColumn = 80
+lineEndings = preserve
+includeCurlyBraceInSelectChains = false
+danglingParentheses.preset = true
+optIn.annotationNewlines = true
+newlines.alwaysBeforeMultilineDef = false
+rewrite.rules = [RedundantBraces]
+
+rewrite.redundantBraces.generalExpressions = false
+rewriteTokens = {
+  "⇒": "=>"
+  "→": "->"
+  "←": "<-"
+}

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -15,7 +15,8 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>rest-assured-parent</artifactId>
         <groupId>io.rest-assured</groupId>
@@ -29,6 +30,7 @@
         <module>json-schema-validator</module>
         <module>spring-mock-mvc</module>
         <module>scala-support</module>
+        <module>scala-extensions</module>
         <module>spring-web-test-client</module>
         <module>spring-commons</module>
         <module>kotlin-extensions</module>

--- a/modules/scala-extensions/pom.xml
+++ b/modules/scala-extensions/pom.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0"?>
+<!--
+~ Copyright 2024 the original author or authors.
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~        http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.rest-assured</groupId>
+        <artifactId>modules</artifactId>
+        <version>5.4.1-SNAPSHOT</version>
+    </parent>
+    <artifactId>scala-extensions</artifactId>
+    <version>5.4.1-SNAPSHOT</version>
+    <name>scala-extensions</name>
+    <url>http://maven.apache.org</url>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <scala-maven-plugin.version>4.8.1</scala-maven-plugin.version>
+        <scala.version>3.3.1</scala.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala3-library_3</artifactId>
+            <version>${scala.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <version>5.4.1-SNAPSHOT</version>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+    <build>
+        <sourceDirectory>src/main/scala</sourceDirectory>
+        <testSourceDirectory>src/test/scala</testSourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+                <version>${scala-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <?m2e ignore?>
+                        <id>scala-compile-first</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <?m2e ignore?>
+                        <id>scala-test-compile</id>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <scalaVersion>${scala.version}</scalaVersion>
+                    <args>
+                        <arg>-feature</arg>
+                        <arg>-deprecation</arg>
+                        <arg>-Ysemanticdb</arg>
+                    </args>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/modules/scala-extensions/src/main/scala/io/restassured/module/scala/extensions/RestAssuredScalaExtensions.scala
+++ b/modules/scala-extensions/src/main/scala/io/restassured/module/scala/extensions/RestAssuredScalaExtensions.scala
@@ -1,0 +1,179 @@
+package io.restassured.module.scala.extensions
+
+import scala.util.chaining.*
+import scala.reflect.ClassTag
+import io.restassured.RestAssured.`given`
+import io.restassured.RestAssured.`when`
+import io.restassured.internal.{ResponseSpecificationImpl, ValidatableResponseImpl}
+import io.restassured.response.{ExtractableResponse, Response, ValidatableResponse}
+import io.restassured.specification.{RequestSender, RequestSpecification}
+
+// Main wrappers
+
+/**
+ * A wrapper around [given] that starts building the request part of the test.
+ * E.g.
+ * {{{
+ * Given(_.params("firstName", "John"))
+ *  .When(_.post("/greetXML"))
+ *  .Then(res =>
+ *    res.statusCode(200)
+ *    res.body("greeting.firstName", equalTo("John"))
+ * )
+ * }}}
+ * will send a POST request to "/greetXML" with request parameters
+ * `firstName=John` and `lastName=Doe` and expect that the response body
+ * containing JSON or XML firstName equal to John.
+ *
+ * @return
+ *   A request specification.
+ *
+ * @see
+ *   io.restassured.RestAssured.given
+ */
+def Given(block: RequestSpecification => RequestSpecification): RequestSpecification =
+    `given`().tap(block)
+
+/**
+ * A wrapper around [given] that starts building the request part of the test.
+ * This is an overloaded version of [Given] that does not take any arguments.
+ * E.g.
+ * {{{
+ * Given()
+ *  .When(_.post("/greetXML"))
+ *  .Then(_.statusCode(200))
+ * }}}
+ * will send a POST request to "/greetXML" request parameters and expect that
+ * the statusCode 200.
+ *
+ * @return
+ *   A request specification.
+ *
+ * @see
+ *   io.restassured.RestAssured.given
+ */
+def Given(): RequestSpecification =
+    `given`()
+
+/**
+ * A wrapper around [io.restassured.RestAssured.when] to start building the DSL
+ * expression by sending a request without any parameters or headers etc. E.g.
+ * {{{
+ * Given()
+ *   .When(_.get("/x"))
+ *   .Then(_.body("x.y.z1", equalTo("Z1")))
+ * }}}
+ * Note that if you need to add parameters, headers, cookies or other request
+ * properties use the [[Given()]] method.
+ *
+ * @see
+ *   io.restassured.RestAssured.when
+ * @return
+ *   A request sender interface that let's you call resources on the server
+ */
+extension (spec: RequestSpecification)
+    infix def When(block: RequestSpecification => Response): Response =
+        block(spec.`when`())
+
+/**
+ * A wrapper around [io.restassured.RestAssured.when] to start building the DSL
+ * expression by sending a request without any parameters or headers etc. E.g.
+ * {{{
+ * Given()
+ *   .When(_.get("/x"))
+ *   .Then(_.body("x.y.z1", equalTo("Z1")))
+ * }}}
+ * Note that if you need to add parameters, headers, cookies or other request
+ * properties use the [[Given()]] method.
+ *
+ * @see
+ *   io.restassured.RestAssured.when
+ * @return
+ *   A request sender interface that let's you call resources on the server
+ */
+def When(block: RequestSender => Response): Response =
+    block(`when`())
+
+
+/**
+ * A wrapper around [then] that lets you validate the response.
+ * Usage example:
+ * {{{
+ * Given(_.params("firstName", "John")
+ *  .When(_.post("/greetXML"))
+ *  .Then(_.body("greeting.firstName", equalTo("John")))
+ * }}}
+ *
+ * @return
+ *   A validatable response
+ */
+extension (resp: Response)
+    infix def Then(block: ValidatableResponse => Unit): ValidatableResponse =
+        resp.`then`()
+        .tap(block)
+
+/**
+ * A wrapper around [ExtractableResponse] that lets you validate the response.
+ * Usage example:
+ * {{{
+ * val firstName: String = Given(_.params("firstName", "John")
+ *  .When(_.post("/greetXML"))
+ *  .Then(_.body("greeting.firstName", equalTo("John")))
+ *  .Extract(_.path("greeting.firstName"))
+ * }}}
+ * The above code will send a POST request to "/greetXML" with request parameters
+ * `firstName=John` and `lastName=Doe` and expect that the response body
+ * containing JSON or XML firstName equal to John.
+ * The response is then validated and the firstName is extracted from the response.
+ * The extracted firstName is then returned. The type of the extracted value is
+ * needs to be specified as a type parameter.
+ *
+ * @return
+ *   The extracted value
+ */
+extension [T]( resp: Response )
+    infix def Extract(
+        block: ExtractableResponse[Response] => T
+      )(
+        using ClassTag[T]
+      ): T =
+        val res = resp.`then`().extract().pipe(block)
+        summon[ClassTag[T]].runtimeClass match
+            case cls if cls.isAssignableFrom(res.getClass) => res.asInstanceOf[T]
+            case _                                         => throw new Exception("Unsupported type")
+
+/**
+ * A wrapper around [ValidatableResponse] that lets you validate the response.
+ * Usage example:
+ * {{{
+ * val firstName: String = Given(_.params("firstName", "John")
+ *  .When(_.post("/greetXML"))
+ *  .Then(_.body("greeting.firstName", equalTo("John")))
+ *  .Extract(_.path("greeting.firstName"))
+ * }}}
+ * The above code will send a POST request to "/greetXML" with request parameters
+ * `firstName=John` and `lastName=Doe` and expect that the response body
+ * containing JSON or XML firstName equal to John.
+ * The response is then validated and the firstName is extracted from the response.
+ * The extracted firstName is then returned. The type of the extracted value is
+ * needs to be specified as a type parameter.
+ *
+ * @return
+ *   The extracted value
+ */
+extension [T]( resp: ValidatableResponse )
+    infix def Extract(
+        block: ExtractableResponse[Response] => T
+      )(
+        using ClassTag[T]
+      ): T =
+        val res = resp.extract().pipe(block)
+        summon[ClassTag[T]].runtimeClass match
+            case cls if cls.isAssignableFrom(res.getClass) => res.asInstanceOf[T]
+            case _                                         => throw new Exception("Unsupported type")
+
+// End main wrappers
+
+private def doIfValidatableResponseImpl(fn: ResponseSpecificationImpl => Unit): ValidatableResponse => Unit =
+    resp =>
+        if resp.isInstanceOf[ValidatableResponseImpl] then fn(resp.asInstanceOf[ValidatableResponseImpl].responseSpec)

--- a/modules/scala-extensions/src/main/scala/io/restassured/module/scala/extensions/RestAssuredScalaExtensions.scala
+++ b/modules/scala-extensions/src/main/scala/io/restassured/module/scala/extensions/RestAssuredScalaExtensions.scala
@@ -3,9 +3,8 @@ package io.restassured.module.scala.extensions
 import scala.util.chaining.*
 import scala.reflect.ClassTag
 import io.restassured.RestAssured.`given`
-import io.restassured.RestAssured.`when`
 import io.restassured.response.{ExtractableResponse, Response, ValidatableResponse}
-import io.restassured.specification.{RequestSender, RequestSpecification}
+import io.restassured.specification.RequestSpecification
 import io.restassured.internal.{ValidatableResponseImpl, ResponseSpecificationImpl}
 
 // Main wrappers
@@ -74,25 +73,6 @@ def Given(): RequestSpecification =
 extension (spec: RequestSpecification)
   infix def When(block: RequestSpecification => Response): Response =
     spec.`when`().pipe(block)
-
-/**
- * A wrapper around [io.restassured.RestAssured.when] to start building the DSL
- * expression by sending a request without any parameters or headers etc. E.g.
- * {{{
- * Given()
- *   .When(_.get("/x"))
- *   .Then(_.body("x.y.z1", equalTo("Z1")))
- * }}}
- * Note that if you need to add parameters, headers, cookies or other request
- * properties use the [[Given()]] method.
- *
- * @see
- *   io.restassured.RestAssured.when
- * @return
- *   A request sender interface that let's you call resources on the server
- */
-def When(block: RequestSender => Response): Response =
-  `when`().pipe(block)
 
 /**
  * A wrapper around [then] that lets you validate the response. Usage example:
@@ -170,4 +150,7 @@ extension [T](resp: ValidatableResponse)
 // End main wrappers
 
 private def doIfValidatableResponseImpl(fn: ResponseSpecificationImpl => Unit): ValidatableResponse => Unit =
-  resp => if resp.isInstanceOf[ValidatableResponseImpl] then fn(resp.asInstanceOf[ValidatableResponseImpl].responseSpec)
+  resp =>
+    resp match
+      case resp: ValidatableResponseImpl => fn(resp.responseSpec)
+      case _                             => ()

--- a/modules/scala-extensions/src/test/scala/io/restassured/module/scala/extensions/RestAssuredScalaExtensionsTest.scala
+++ b/modules/scala-extensions/src/test/scala/io/restassured/module/scala/extensions/RestAssuredScalaExtensionsTest.scala
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.restassured.module.scala.extensions
+
+import io.restassured.RestAssured
+import io.restassured.builder.ResponseBuilder
+import io.restassured.filter.Filter
+import io.restassured.http.ContentType.JSON
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.catchThrowable
+import org.hamcrest.Matchers.*
+import org.junit.Before
+import org.junit.Test
+
+class RestAssuredScalaExtensionsTest:
+
+    @Before
+    def `rest assured is configured`: Unit = {
+      RestAssured.filters((_, _, _) => {
+        new ResponseBuilder() .setStatusCode(200) .setContentType(JSON) .setBody("""{ "message" : "Hello World"}""").build()
+      })
+    }
+
+
+    @Test
+    def `rest assured is reset after each test`: Unit =
+        RestAssured.reset()
+
+    @Test
+    def `basic rest assured scala extensions are compilable`: Unit =
+        Given(req =>
+            req.port(7000)
+            req.header("Header", "Header")
+            req.body("hello")
+        )
+        .When(
+            _.put("/the/path")
+        )
+        .Then(res =>
+            res.statusCode(200)
+            res.body("message", equalTo("Hello World"))
+        )
+
+    @Test
+    def `extraction with rest assured scala extensions`: Unit =
+        val message: String = Given(req =>
+            req.port(7000)
+            req.header("Header", "Header")
+            req.body("hello")
+        )
+        .When(
+            _.put("/the/path")
+        )
+        .Extract(
+            _.path("message")
+        )
+        assertThat(message).isEqualTo("Hello World")
+
+    @Test
+    def `extraction after 'then', when path is not used in 'Then',  with rest assured scala extensions`: Unit =
+        val message: String = Given(req =>
+            req.port(7000)
+            req.header("Header", "Header")
+            req.body("hello")
+            req.filter((_, _, _) =>
+                new ResponseBuilder().setStatusCode(200).setContentType(JSON).setBody("""{ "message" : "Hello World"}""").build()
+            )
+        )
+        .When(
+            _.put("/the/path")
+        )
+        .Then(
+            _.statusCode(200)
+        )
+        .Extract(
+            _.path("message")
+        )
+        assertThat(message).isEqualTo("Hello World")
+
+    @Test
+    def `extraction after 'then', when path is used in 'Then',  with rest assured scala extensions`: Unit =
+        val message: String = Given(req =>
+            req.port(7000)
+            req.header("Header", "Header")
+            req.body("hello")
+            req.filter((_, _, _) =>
+                new ResponseBuilder().setStatusCode(200).setContentType(JSON).setBody("""{ "message" : "Hello World"}""").build()
+            )
+        )
+        .When(
+            _.put("/the/path")
+        )
+        .Then(res =>
+            res.statusCode(200)
+            res.body("message", not(emptyOrNullString()))
+        )
+        .Extract(
+            _.path("message")
+        )
+        assertThat(message).isEqualTo("Hello World")
+
+    @Test
+    def `all expectations error messages are included in the error message`: Unit =
+        try {
+            Given(req =>
+                req.port(7000)
+                req.header("Header", "Header")
+                req.body("hello")
+            )
+            .When(
+                _.put("/the/path")
+            )
+            .Then(res =>
+                res.statusCode(400)
+                res.body("message", equalTo("Another World"))
+                res.body("message", equalTo("Brave new world"))
+            )
+        } catch {
+            case e: AssertionError =>
+                assertThat(e).hasMessage(
+                    """1 expectation failed.
+                      |Expected status code <400> but was <200>.
+                      |""".stripMargin)
+        }

--- a/modules/scala-extensions/src/test/scala/io/restassured/module/scala/extensions/RestAssuredScalaExtensionsTest.scala
+++ b/modules/scala-extensions/src/test/scala/io/restassured/module/scala/extensions/RestAssuredScalaExtensionsTest.scala
@@ -21,7 +21,6 @@ import io.restassured.builder.ResponseBuilder
 import io.restassured.filter.Filter
 import io.restassured.http.ContentType.JSON
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.catchThrowable
 import org.hamcrest.Matchers.*
 import org.junit.Before
 import org.junit.Test
@@ -141,7 +140,15 @@ class RestAssuredScalaExtensionsTest:
         )
     } catch {
       case e: AssertionError =>
-        assertThat(e).hasMessage("""1 expectation failed.
+        assertThat(e).hasMessage("""3 expectations failed.
                                    |Expected status code <400> but was <200>.
+                                   |
+                                   |JSON path message doesn't match.
+                                   |Expected: Another World
+                                   |  Actual: Hello World
+                                   |
+                                   |JSON path message doesn't match.
+                                   |Expected: Brave new world
+                                   |  Actual: Hello World
                                    |""".stripMargin)
     }

--- a/modules/scala-extensions/src/test/scala/io/restassured/module/scala/extensions/RestAssuredScalaExtensionsTest.scala
+++ b/modules/scala-extensions/src/test/scala/io/restassured/module/scala/extensions/RestAssuredScalaExtensionsTest.scala
@@ -72,6 +72,22 @@ class RestAssuredScalaExtensionsTest:
     assertThat(message).isEqualTo("Hello World")
 
   @Test
+  def `validation with rest assured scala extensions using ThenAssert returning Unit`: Unit =
+    val result = Given(req =>
+      req.port(7000)
+      req.header("Header", "Header")
+      req.body("hello")
+    )
+      .When(
+        _.put("/the/path")
+      )
+      .ThenAssert(res =>
+        res.statusCode(200)
+        res.body("message", equalTo("Hello World"))
+      )
+    assertThat(result).isEqualTo(())
+
+  @Test
   def `extraction after 'then', when path is not used in 'Then',  with rest assured scala extensions`: Unit =
     val message: String = Given(req =>
       req.port(7000)

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,8 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.sonatype.oss</groupId>
@@ -70,6 +71,7 @@
         <maven-javadoc.version>2.9.1</maven-javadoc.version>
         <surefire.version>2.22.0</surefire.version>
         <kotlin.version>1.9.21</kotlin.version>
+        <scala.version>3.3.1</scala.version>
         <assertj-core.version>3.16.1</assertj-core.version>
         <scribe.version>2.5.3</scribe.version>
         <sundrio.version>0.93.0</sundrio.version>
@@ -470,6 +472,11 @@
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-stdlib-jdk8</artifactId>
                 <version>${kotlin.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.scala-lang</groupId>
+                <artifactId>scala3-interfaces</artifactId>
+                <version>${scala.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.assertj</groupId>


### PR DESCRIPTION
This PR adds a scala-extensions module for a Scala 3 DSL similar to the existing Kotlin DSL. This extension is important since rest-assured is heavily used in Quarkus tests for endpoints and goes along the [Quickstart](https://github.com/carlosedp/scala3-quarkus-quickstart) for Scala 3/Quarkus I've been working on.

There are some points of improvement that could be done before merging (I might need some help):

- [ ] The method `Then` always returns a `ValidatableResponse` so an `Extract` could be chained. It would be great if it could return `Unit` in case there is no `Extract` so there won't be the need to declare the test `def` return type as `Unit` (to be picked-up by JUnit). I added a `ThenAssert` convenience method that uses `Then` but returns `Unit` for simplified usage.
- [ ] The `Extract` method needs the type to be defined in the `val/var` it's been assigned to. Don't know if there's a way around this.
- [x] ~~Extracting an `Int` from json requires specifying the type as a Java `Integer` instead of a Scala `Int`. This generates the error `java.lang.Exception: Unsupported type`.~~   **Solved.**

Let me know any additional requirements to have this in the main Rest-assured tree
This is based on the great work by @gavinray97

There are a couple of Scala code in-tree that I'd like to hear some feedback on how to tackle. Should we keep this module in Scala 3 or should I rewrite in Scala 2.13?

- [ ] Deprecate scala-support module?
- [ ] Update examples/scala-example
- [ ] Update examples/scala-mock-mvc-example
- [ ] Update examples/scalatra-example
- [ ] Update examples/scalatra-webapp