### PR TITLE
issues/537: Remove check for response HTTP status code.

### DIFF
--- a/rest-assured/src/main/java/io/restassured/builder/ResponseBuilder.java
+++ b/rest-assured/src/main/java/io/restassured/builder/ResponseBuilder.java
@@ -210,10 +210,6 @@ public class ResponseBuilder {
     public Response build() {
         final int statusCode = restAssuredResponse.statusCode();
 
-        if (statusCode < 100 || statusCode >= 600) {
-            throw new IllegalArgumentException(format("Status code must be greater than 100 and less than 600, was %d.", statusCode));
-        }
-
         if (StringUtils.isBlank(restAssuredResponse.statusLine())) {
             restAssuredResponse.setStatusLine(restAssuredResponse.statusCode());
         }


### PR DESCRIPTION
Fix [Issue 537](https://github.com/rest-assured/rest-assured/issues/537) by removing the response status code check from the response logging filter code.