### PR TITLE
Implement optionalQueryParam Following Discussion in #1751

### DIFF
--- a/modules/spring-mock-mvc/src/main/java/io/restassured/module/mockmvc/internal/MockMvcRequestSpecificationImpl.java
+++ b/modules/spring-mock-mvc/src/main/java/io/restassured/module/mockmvc/internal/MockMvcRequestSpecificationImpl.java
@@ -300,6 +300,15 @@ public class MockMvcRequestSpecificationImpl implements MockMvcRequestSpecificat
     }
 
     @Override
+    public MockMvcRequestSpecification optionalQueryParam(String parameterName, Object parameterValue) {
+        notNull(parameterName, "parameterName");
+        if (parameterValue != null) {
+            return queryParam(parameterName, parameterValue);
+        }
+        return this;
+    }
+
+    @Override
     public MockMvcRequestSpecification pathParams(String firstParameterName, Object firstParameterValue, Object... parameterNameValuePairs) {
         notNull(firstParameterName, "firstParameterName");
         notNull(firstParameterValue, "firstParameterValue");

--- a/modules/spring-mock-mvc/src/main/java/io/restassured/module/mockmvc/specification/MockMvcRequestSpecification.java
+++ b/modules/spring-mock-mvc/src/main/java/io/restassured/module/mockmvc/specification/MockMvcRequestSpecification.java
@@ -16,6 +16,7 @@
 
 package io.restassured.module.mockmvc.specification;
 
+import io.restassured.config.SessionConfig;
 import io.restassured.http.*;
 import io.restassured.mapper.ObjectMapper;
 import io.restassured.mapper.ObjectMapperType;
@@ -358,6 +359,16 @@ public interface MockMvcRequestSpecification extends MockMvcRequestSender {
      * @return The request specification
      */
     MockMvcRequestSpecification queryParam(String parameterName, Collection<?> parameterValues);
+
+    /**
+     * Adds an optional query parameter to the request if the parameter value is not {@code null}.
+     * The parameter name must not be null and must pass the {@code notNull} validation.
+     *
+     * @param parameterName   The parameter name
+     * @param parameterValue The value of the query parameter as an object. If this value is {@code null}, no query parameter is added.
+     *                       If not null, the query parameter is added with the given parameter name and value.
+     */
+    MockMvcRequestSpecification optionalQueryParam(String parameterName, Object parameterValue);
 
     /**
      * Specify the path parameters that'll be sent with the request.

--- a/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/QueryParamTest.java
+++ b/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/QueryParamTest.java
@@ -51,5 +51,31 @@ public class QueryParamTest {
                 body("_link", equalTo("http://localhost/queryParam?name=John&message=Good!"));
     }
 
+    @Test
+    public void optional_query_param() throws Exception {
+        RestAssuredMockMvc.given().
+                standaloneSetup(new QueryParamController()).
+                optionalQueryParam("name", "John").
+                optionalQueryParam("message", "Good!").
+        when().
+                get("/queryParam").
+        then().log().all().
+                body("name", equalTo("Hello, John!")).
+                body("message", equalTo("Good!")).
+                body("_link", equalTo("http://localhost/queryParam?name=John&message=Good!"));
+    }
+
+    @Test
+    public void optional_query_param_message_is_null() throws Exception {
+        RestAssuredMockMvc.given().
+                standaloneSetup(new QueryParamController()).
+                optionalQueryParam("name", "John").
+                optionalQueryParam("message", null).
+        when().
+                get("/queryParam").
+        then().log().all().
+                statusCode(400);
+    }
+
 // @formatter:on
 }


### PR DESCRIPTION
This PR introduces the `optionalQueryParam` method to the `MockMvcRequestSpecification` class, as discussed in issue #1751. 

## Implementation Details
The `optionalQueryParam` method enhances request building by conditionally adding query parameters:

- **When the QueryParam value is null:** No query parameter is added to the request.
- **When the QueryParam value is not null:** The query parameter is added with the specified name and value.

## Discussion Reference
This implementation follows the specifications and considerations discussed in issue #1751, aiming to address the need for optional query parameters in our request handling logic.

## Testing
Tests have been added to verify that the `optionalQueryParam` method behaves as expected, ensuring that parameters are correctly added only when their values are not null.