### PR TITLE
Fix #1707: SVG file upload - fatal error :1:1: content is not allowed in prolog

### DIFF
--- a/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/MockMvcMultipartTest.java
+++ b/modules/spring-mock-mvc/src/test/java/io/restassured/module/mockmvc/MockMvcMultipartTest.java
@@ -18,6 +18,10 @@ package io.restassured.module.mockmvc;
 
 import io.restassured.module.mockmvc.http.MultipartController;
 import org.junit.Test;
+import org.springframework.http.MediaType;
+import org.springframework.util.ResourceUtils;
+
+import java.io.File;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.equalTo;
@@ -31,6 +35,45 @@ public class MockMvcMultipartTest {
         RestAssuredMockMvc.given()
                 .standaloneSetup(new MultipartController())
                 .multiPart("file", "Test")
+                .when()
+                .post("/files/{type}", (Object[]) "type".split("\\|"))
+                .then()
+                .log().all()
+                .time(lessThan(3L), SECONDS)
+                .expect(status().is2xxSuccessful())
+                .body("type", equalTo("type"))
+                .body("name", equalTo("file"));
+    }
+
+
+    @Test
+    public void can_use_multipart_with_jsonFile() throws Exception{
+        File xml = ResourceUtils.getFile("classpath:multipart.xml");
+
+        RestAssuredMockMvc.given()
+                .standaloneSetup(new MultipartController())
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .multiPart("file", xml, MediaType.APPLICATION_XML_VALUE)
+                .log().all()
+                .when()
+                .post("/files/{type}", (Object[]) "type".split("\\|"))
+                .then()
+                .log().all()
+                .time(lessThan(3L), SECONDS)
+                .expect(status().is2xxSuccessful())
+                .body("type", equalTo("type"))
+                .body("name", equalTo("file"));
+    }
+
+    @Test
+    public void can_use_multipart_with_xmlJson() throws Exception{
+        File json = ResourceUtils.getFile("classpath:multipart.json");
+
+        RestAssuredMockMvc.given()
+                .standaloneSetup(new MultipartController())
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .multiPart("file", json, MediaType.APPLICATION_JSON_VALUE)
+                .log().all()
                 .when()
                 .post("/files/{type}", (Object[]) "type".split("\\|"))
                 .then()

--- a/modules/spring-mock-mvc/src/test/resources/multipart.json
+++ b/modules/spring-mock-mvc/src/test/resources/multipart.json
@@ -1,0 +1,14 @@
+{
+  "catalog": {
+    "book": [
+      {
+        "id": "bk101",
+        "author": "Gambardella, Matthew",
+        "title": "XML Developer's Guide",
+        "genre": "Computer",
+        "price": 44.95,
+        "publish_date": "2000-10-01"
+      }
+    ]
+  }
+}

--- a/modules/spring-mock-mvc/src/test/resources/multipart.xml
+++ b/modules/spring-mock-mvc/src/test/resources/multipart.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<catalog>
+    <book id="bk101">
+        <author>Gambardella, Matthew</author>
+        <title>XML Developer's Guide</title>
+        <genre>Computer</genre>
+        <price>44.95</price>
+        <publish_date>2000-10-01</publish_date>
+    </book>
+</catalog>

--- a/rest-assured/src/main/groovy/io/restassured/internal/support/Prettifier.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/support/Prettifier.groovy
@@ -52,7 +52,19 @@ class Prettifier {
     prettify(responseAsString, parser)
   }
 
-  String prettify(String body, Parser parser) {
+  String prettify(Object content, Parser parser) {
+    if (content == null) {
+      return "";
+    }
+
+    if (content instanceof File) {
+      return prettifyBy(new String(content.readBytes()), parser)
+    }
+
+    return prettifyBy(content.toString(), parser);
+  }
+
+  private String prettifyBy(String body, Parser parser) {
     String prettifiedBody
     try {
       switch (parser) {

--- a/rest-assured/src/main/java/io/restassured/internal/print/RequestPrinter.java
+++ b/rest-assured/src/main/java/io/restassured/internal/print/RequestPrinter.java
@@ -233,7 +233,7 @@ public class RequestPrinter {
                     appendFourTabs(builder.append(SystemUtils.LINE_SEPARATOR)).append("<inputstream>");
                 } else {
                     Parser parser = Parser.fromContentType(multiPart.getMimeType());
-                    String prettified = new Prettifier().prettify(multiPart.getContent().toString(), parser);
+                    String prettified = new Prettifier().prettify(multiPart.getContent(), parser);
                     String prettifiedIndented = StringUtils.replace(prettified, SystemUtils.LINE_SEPARATOR, SystemUtils.LINE_SEPARATOR + TAB + TAB + TAB + TAB);
                     appendFourTabs(builder.append(SystemUtils.LINE_SEPARATOR)).append(prettifiedIndented);
                 }

--- a/rest-assured/src/test/java/io/restassured/internal/support/PrettifierTest.java
+++ b/rest-assured/src/test/java/io/restassured/internal/support/PrettifierTest.java
@@ -1,0 +1,106 @@
+package io.restassured.internal.support;
+
+import io.restassured.parsing.Parser;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static junit.framework.TestCase.assertEquals;
+
+public class PrettifierTest {
+
+    private File jsonFile;
+    private File xmlFile;
+    private final String resultJson = "{\n" +
+            "    \"catalog\": {\n" +
+            "        \"book\": [\n" +
+            "            {\n" +
+            "                \"id\": \"bk101\",\n" +
+            "                \"author\": \"Gambardella, Matthew\",\n" +
+            "                \"title\": \"XML Developer's Guide\",\n" +
+            "                \"genre\": \"Computer\",\n" +
+            "                \"price\": 44.95,\n" +
+            "                \"publish_date\": \"2000-10-01\"\n" +
+            "            }\n" +
+            "        ]\n" +
+            "    }\n" +
+            "}";
+
+    private final String resultXml = "<catalog>\n" +
+            "  <book id=\"bk101\">\n" +
+            "    <author>Gambardella, Matthew</author>\n" +
+            "    <title>XML Developer's Guide</title>\n" +
+            "    <genre>Computer</genre>\n" +
+            "    <price>44.95</price>\n" +
+            "    <publish_date>2000-10-01</publish_date>\n" +
+            "  </book>\n" +
+            "</catalog>";
+
+
+    @Before
+    public void
+    setup() throws IOException {
+        jsonFile = getFile("multipart.json");
+        xmlFile = getFile("multipart.xml");
+    }
+
+    @Test
+    public void
+    jsonPrettify() {
+        String prettify = new Prettifier().prettify(jsonFile, Parser.JSON);
+
+        assertEquals(prettify, resultJson);
+    }
+
+    @Test
+    public void
+    xml_prettify() {
+        String prettify = new Prettifier().prettify(xmlFile, Parser.XML);
+
+        assertEquals(prettify, resultXml);
+    }
+
+    @Test
+    public void
+    json_prettify() {
+        String prettify = new Prettifier().prettify(jsonFile, Parser.JSON);
+
+        assertEquals(prettify, resultJson);
+    }
+
+    @Test
+    public void
+    empty_data() {
+        String prettify = new Prettifier().prettify("", Parser.XML);
+
+        assertEquals(prettify, "");
+    }
+
+    @Test
+    public void
+    json_string_data() throws IOException {
+        String jsonData = new String(Files.readAllBytes(Paths.get(jsonFile.getPath())));
+
+        String prettify = new Prettifier().prettify(jsonData, Parser.JSON);
+
+        assertEquals(prettify, resultJson);
+    }
+
+    @Test
+    public void
+    xml_string_data() throws IOException {
+        String xmlData = new String(Files.readAllBytes(Paths.get(xmlFile.getPath())));
+
+        String prettify = new Prettifier().prettify(xmlData, Parser.XML);
+
+        assertEquals(prettify, resultXml);
+    }
+
+    private File getFile(String path) throws IOException {
+        return new File(getClass().getClassLoader().getResource(path).getFile());
+    }
+}

--- a/rest-assured/src/test/resources/multipart.json
+++ b/rest-assured/src/test/resources/multipart.json
@@ -1,0 +1,14 @@
+{
+  "catalog": {
+    "book": [
+      {
+        "id": "bk101",
+        "author": "Gambardella, Matthew",
+        "title": "XML Developer's Guide",
+        "genre": "Computer",
+        "price": 44.95,
+        "publish_date": "2000-10-01"
+      }
+    ]
+  }
+}

--- a/rest-assured/src/test/resources/multipart.xml
+++ b/rest-assured/src/test/resources/multipart.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<catalog>
+    <book id="bk101">
+        <author>Gambardella, Matthew</author>
+        <title>XML Developer's Guide</title>
+        <genre>Computer</genre>
+        <price>44.95</price>
+        <publish_date>2000-10-01</publish_date>
+    </book>
+</catalog>


### PR DESCRIPTION
Fix #1707: SVG file upload - fatal error :1:1: content is not allowed in prolog


## Cause
When you execute the syntax below

```java
File xml = ResourceUtils.getFile("classpath:multipart.xml");
RestAssuredMockMvc.given()
        .standaloneSetup(new MultipartController())
        .contentType(MediaType.MULTIPART_FORM_DATA)
        .multiPart("file", xml, MediaType.APPLICATION_XML_VALUE)
```


![image](https://github.com/rest-assured/rest-assured/assets/26699273/f26e4ecb-0310-43ed-a629-eceae8642061)

As you can see in the image, 'getContent()' is a file class type, so when we got the data, we did a File.toString and got an error because it contained the path data to the file, not the actual XML file content.

## Resolve
The file contents were read and processed for parsing.