### PR TITLE
Add Scala 3 example. Stick to LTS Scala version

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -15,7 +15,8 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>rest-assured-parent</artifactId>
         <groupId>io.rest-assured</groupId>
@@ -34,6 +35,7 @@
         <module>scala-example</module>
         <module>scala-mock-mvc-example</module>
         <module>kotlin-example</module>
+        <module>scala3-example</module>
     </modules>
 
     <profiles>

--- a/examples/scala3-example/pom.xml
+++ b/examples/scala3-example/pom.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2024 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.rest-assured.examples</groupId>
+        <artifactId>example-parent</artifactId>
+        <version>5.5.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>scala3-example</artifactId>
+    <packaging>jar</packaging>
+    <name>Scala 3 Example</name>
+    <description>Scala 3 example of using REST Assured</description>
+
+    <properties>
+        <scala.version>3.3.3</scala.version>
+        <compiler-plugin.version>3.13.0</compiler-plugin.version>
+        <scala-maven-plugin.version>4.9.2</scala-maven-plugin.version>
+    </properties>
+
+    <build>
+        <testSourceDirectory>src/test/scala</testSourceDirectory>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${compiler-plugin.version}</version>
+                <configuration>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+                <version>${scala-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <?m2e ignore?>
+                        <id>scala-compile-first</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <?m2e ignore?>
+                        <id>scala-test-compile</id>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <args>
+                        <arg>-Wunused:all</arg>
+                        <arg>-feature</arg>
+                        <arg>-deprecation</arg>
+                        <arg>-Ysemanticdb</arg>
+                    </args>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.basepom.maven</groupId>
+                <artifactId>duplicate-finder-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala3-library_3</artifactId>
+            <version>${scala.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala3-compiler_3</artifactId>
+            <version>${scala.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <version>5.5.1-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>scala-extensions</artifactId>
+            <version>5.5.1-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>1.7.12</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/examples/scala3-example/src/test/scala/io.restassured.scala/Scala3ITest.scala
+++ b/examples/scala3-example/src/test/scala/io.restassured.scala/Scala3ITest.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.restassured.scala
+
+import io.restassured.module.scala.extensions.*
+import okhttp3.mockwebserver.{MockResponse, MockWebServer}
+import org.hamcrest.CoreMatchers.containsString
+import org.junit.{After, Before, Test}
+
+class Scala3ITest:
+
+  var webServer: MockWebServer = _
+
+  @Before
+  def `Mock web server is initialized`() =
+    webServer = new MockWebServer()
+    webServer.start()
+
+  @After
+  def `Mock web server is shutdown`() =
+    webServer.shutdown()
+
+  @Test
+  def `trying out rest assured in scala`() =
+    val response = new MockResponse
+    response.setBody(""" { "key" : "value" } """)
+    response.setHeader("content-type", "application/json")
+    webServer.enqueue(response)
+
+    Given(_.port(webServer.getPort))
+      .When(req => req.get("/greetJSON"))
+      .ThenAssert(res => // Use ThenAssert as the last method in the chain for a test with validation
+        res.statusCode(200)
+        res.body("key", containsString("value"))
+      )
+
+  @Test
+  def `validating a value and extrating it from the response`() =
+    val response = new MockResponse
+    response.setBody(""" { "key" : "value" } """)
+    response.setHeader("content-type", "application/json")
+    webServer.enqueue(response)
+
+    val value: String = Given(_.port(webServer.getPort))
+      .When(req => req.get("/greetJSON"))
+      .Then(res => // Use Then when you want to chain an Extract method after the validation
+        res.statusCode(200)
+        res.body("key", containsString("value"))
+      )
+      .Extract(_.path("key"))
+
+    assert(value == "value")
+
+  @Test
+  def `extracting a value from a response`() =
+    val response = new MockResponse
+    response.setBody(""" { "key" : "value" } """)
+    response.setHeader("content-type", "application/json")
+    webServer.enqueue(response)
+
+    val value: String = Given(_.port(webServer.getPort))
+      .When(req => req.get("/greetJSON"))
+      .Extract(_.path("key"))
+
+    assert(value == "value")

--- a/modules/scala-extensions/pom.xml
+++ b/modules/scala-extensions/pom.xml
@@ -15,7 +15,8 @@
 ~ limitations under the License.
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.rest-assured</groupId>
@@ -29,7 +30,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <scala-maven-plugin.version>4.9.2</scala-maven-plugin.version>
-        <scala.version>3.4.2</scala.version>
+        <scala.version>3.3.3</scala.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
This PR adds a Scala 3 example and also reverts the build of the scala-extension module to the Scala LTS version (3.3.3) instead of the 3.4 series.