### PR TITLE
Change `jakarta.jakartaee-web-api` version

### DIFF
--- a/modules/spring-mock-mvc/pom.xml
+++ b/modules/spring-mock-mvc/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-web-api</artifactId>
-            <version>9.1.0</version>
+            <version>10.0.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/modules/spring-web-test-client-kotlin-extensions/pom.xml
+++ b/modules/spring-web-test-client-kotlin-extensions/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-web-api</artifactId>
-            <version>9.1.0</version>
+            <version>10.0.0</version>
             <scope>optional</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Hi! I looked at [the REST-assured Kotlin Extension documentation](https://github.com/rest-assured/rest-assured/wiki/Kotlin) and found a problem while using the Kotlin Extension, so I uploaded a Pull Request.

I'm trying to develop with Spring Boot version 3.3.1.
The version of `spring-boot-starter-data-jpa` in use here is using Hibernate 6.5.2.Final version.

The problem occurred with `jakarta.persistence.GenerationType`, which started with version 6.2 of Hibernate.

In the `jakarta.jakartaee-web-api:9.1.0` you are currently using, there is a problem that `GenerationType.UUID` is not compatible with Hibernate 6.2 or higher because there is no such value.

So the test will not run with the following error message:

```
Error creating bean with name 'entityManagerFactory' defined in class path resource 
[org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaConfiguration.class]: Class 
jakarta.persistence.GenerationType does not have member field 'jakarta.persistence.GenerationType UUID'
```

![image](https://github.com/user-attachments/assets/25cb9a1f-a13c-42f0-97b9-740c68b5f206)

Therefore, I posted a Pull Request that updates the dependency to `jakarta.jakartaee-web-api:10.0.0`, which includes the `GenerationType.UUID` value.

Please refer to the API documentation here:

-  Current (`jakarta.jakartaee-web-api:9.1.0`): [GenerationType in Web Profile 9.1](https://jakarta.ee/specifications/webprofile/9.1/apidocs/jakarta/persistence/generationtype)
-  Updated (`jakarta.jakartaee-web-api:10.0.0`): [GenerationType in Web Profile 10](https://jakarta.ee/specifications/webprofile/10/apidocs/jakarta/persistence/generationtype)

Additionally, you can refer to the Jakarta Persistence documentation in Hibernate 6.2+: [GenerationType in Jakarta Persistence 3.1](https://jakarta.ee/specifications/persistence/3.1/apidocs/jakarta.persistence/jakarta/persistence/generationtype)