### PR TITLE
fix: GZIP becomes gzıp for Turkish environments

### DIFF
--- a/rest-assured/src/main/java/io/restassured/internal/http/ContentEncoding.java
+++ b/rest-assured/src/main/java/io/restassured/internal/http/ContentEncoding.java
@@ -19,6 +19,7 @@ package io.restassured.internal.http;
 import org.apache.http.*;
 import org.apache.http.protocol.HttpContext;
 
+import java.util.Locale;
 import java.io.IOException;
 
 /**
@@ -51,7 +52,7 @@ public abstract class ContentEncoding {
 
 		/** Prints the value as it should appear in an HTTP header */
 		@Override public String toString() {
-			return this.name().toLowerCase();
+			return this.name().toLowerCase(Locale.ENGLISH);
 		}
 	}
 	


### PR DESCRIPTION
"GZIP".toLowerCase() -> gzıp in Turkish.
This causes gz1p to be sent until httpclient 4.5.9 and gz?p since 4.5.10 due to httpcore 4.4.12 upgrade. This causes error for some header-sensitive servers.

Thx @frknpg