### PR TITLE
Use Long in maxAge(Matcher<? super Integer> maxAgeMatcher)

### DIFF
--- a/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/CookieITest.java
+++ b/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/CookieITest.java
@@ -67,7 +67,10 @@ public class CookieITest extends WithJetty {
         given()
                 .get("/multiCookie")
                 .then()
-                .cookie("cookie1", detailedCookie().maxAge(1234567L).path(Matchers.notNullValue()));
+                .cookie("cookie1", detailedCookie().maxAge(1234567).path(notNullValue()))
+                .cookie("cookie1", detailedCookie().maxAge(1234567L))
+                .cookie("cookie1", detailedCookie().maxAge(is(1234567L)))
+                .cookie("cookie1", detailedCookie().maxAge(is(greaterThan(1234566L))));
     }
 
     @Test

--- a/rest-assured/src/main/java/io/restassured/matcher/DetailedCookieMatcher.java
+++ b/rest-assured/src/main/java/io/restassured/matcher/DetailedCookieMatcher.java
@@ -196,7 +196,7 @@ public class DetailedCookieMatcher extends CombinableMatcher<Cookie> {
      * @param maxAgeMatcher assertion for max age property
      * @return A {@link DetailedCookieMatcher} instance with and-composed max age property assertion
      */
-    public DetailedCookieMatcher maxAge(Matcher<? super Integer> maxAgeMatcher) {
+    public DetailedCookieMatcher maxAge(Matcher<? super Long> maxAgeMatcher) {
         return new DetailedCookieMatcher(and(Matchers.hasProperty("maxAge", maxAgeMatcher)));
     }
 


### PR DESCRIPTION
Trying to use DetailedCookieMatcher with maxAge(is(greaterThan(1L)) doesn't compile because of the Integer - Long mismatch.

Calling DetailedCookieMatcher's maxAge(is(greaterThan(1)) compiles but fails during the test:

```
java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.Long
```

Fix:

Change

```
    public DetailedCookieMatcher maxAge(Matcher<? super Integer> maxAgeMatcher) {
```
to
```
    public DetailedCookieMatcher maxAge(Matcher<? super Long> maxAgeMatcher) {
```

Then maxAge(is(greaterThan(1L)) compiles and succeeds during the test.

This fix doesn't affect maxAge(is(1)) and maxAge(is(1L)). Both compile but the former keeps failing during tests and test latter keeps succeeding during tests.