### PR TITLE
Caching the length/size in a variable to avoid repeated calls in loops

### DIFF
--- a/modules/spring-commons/src/main/java/io/restassured/module/spring/commons/HeaderHelper.java
+++ b/modules/spring-commons/src/main/java/io/restassured/module/spring/commons/HeaderHelper.java
@@ -124,7 +124,8 @@ public class HeaderHelper {
             String headerName = header.getName();
             if (headerConfig.shouldOverwriteHeaderWithName(headerName)) {
                 int index = -1;
-                for (int i = 0; i < filteredList.size(); i++) {
+                int filteredListSize = filteredList.size();
+                for (int i = 0; i < filteredListSize; i++) {
                     Header filteredHeader = filteredList.get(i);
                     if (filteredHeader.hasSameNameAs(header)) {
                         index = i;

--- a/modules/spring-mock-mvc/src/main/java/io/restassured/module/mockmvc/util/ReflectionUtil.java
+++ b/modules/spring-mock-mvc/src/main/java/io/restassured/module/mockmvc/util/ReflectionUtil.java
@@ -51,22 +51,25 @@ public class ReflectionUtil {
     }
 
     public static Class<?>[] getArgumentTypes(Object[] arguments) {
-        Class<?>[] argumentTypes = new Class[arguments.length];
-        for (int i = 0; i < arguments.length; i++) {
+        int argumentsLength = arguments.length;
+        Class<?>[] argumentTypes = new Class[argumentsLength];
+        for (int i = 0; i < argumentsLength; i++) {
             argumentTypes[i] = arguments[i].getClass();
         }
         return argumentTypes;
     }
 
     private static Object getVarArgsArguments(Class<?>[] argumentTypes, Object[] arguments) {
-        Class<?> argumentType = argumentTypes[argumentTypes.length - 1];
+        int argumentTypesLength = argumentTypes.length;
+        Class<?> argumentType = argumentTypes[argumentTypesLength - 1];
         if (argumentType.isArray()) {
             argumentType = argumentType.getComponentType();
         }
 
-        int numberOfVarArgParameters = arguments.length - argumentTypes.length + 1;
+        int argumentsLength = arguments.length;
+        int numberOfVarArgParameters = argumentsLength - argumentTypesLength + 1;
         Object varArgsArguments = Array.newInstance(argumentType, numberOfVarArgParameters);
-        for (int j = 0, i = argumentTypes.length - 1; i < arguments.length; i++, j++) {
+        for (int j = 0, i = argumentTypesLength - 1; i < argumentsLength; i++, j++) {
             Array.set(varArgsArguments, j, arguments[i]);
         }
         return varArgsArguments;

--- a/rest-assured-common/src/main/groovy/io/restassured/internal/common/assertion/AssertionSupport.groovy
+++ b/rest-assured-common/src/main/groovy/io/restassured/internal/common/assertion/AssertionSupport.groovy
@@ -29,13 +29,16 @@ class AssertionSupport {
 
   def static escapePath(key, PathFragmentEscaper... pathFragmentEscapers) {
     def pathFragments = key.split("(?<=\\')")
-    for (int i = 0; i < pathFragments.size(); i++) {
+    def pathFragmentsSize = pathFragments.size()
+    for (int i = 0; i < pathFragmentsSize; i++) {
       String pathFragment = pathFragments[i]
       if (!pathFragment?.endsWith("'") || pathFragment?.contains("**")) {
         def dotFragments = pathFragment.split("\\.")
-        for (int k = 0; k < dotFragments.size(); k++) {
+        def dotFragmentsSize = dotFragments.size()
+        for (int k = 0; k < dotFragmentsSize; k++) {
           String dotFragment = dotFragments[k]
-          for (int j = 0; j < pathFragmentEscapers.length; j++) {
+          def pathFragmentEscapersLength = pathFragmentEscapers.length
+          for (int j = 0; j < pathFragmentEscapersLength; j++) {
             def escaper = pathFragmentEscapers[j]
             if (escaper.shouldEscape(dotFragment)) {
               dotFragments[k] = escaper.escape(dotFragments[k].trim())
@@ -135,12 +138,14 @@ class AssertionSupport {
    * Copied from Apache commons lang (String utils)
    */
   private static boolean containsAny(String str, searchChars) {
-    if (str == null || str.length() == 0 || searchChars == null || searchChars.isEmpty()) {
+    def strLength = str.length()
+    if (str == null || strLength == 0 || searchChars == null || searchChars.isEmpty()) {
       return false;
     }
-    for (int i = 0; i < str.length(); i++) {
+    for (int i = 0; i < strLength; i++) {
       char ch = str.charAt(i);
-      for (int j = 0; j < searchChars.size(); j++) {
+      def searchCharsSize = searchChars.size()
+      for (int j = 0; j < searchCharsSize; j++) {
         if (searchChars[j] == ch) {
           return true;
         }

--- a/rest-assured/src/main/groovy/io/restassured/internal/MapCreator.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/MapCreator.groovy
@@ -37,16 +37,17 @@ class MapCreator {
   }
 
   static Map<String, Object> createMapFromObjects(CollisionStrategy collisionStrategy, ... parameters) {
-    if (parameters == null || parameters.length < 2) {
+    def parametersLength = parameters.length
+    if (parameters == null || parametersLength < 2) {
       throw new IllegalArgumentException("You must supply at least one key and one value.")
-    } else if (parameters.length % 2 != 0 && parameters.length % 3 != 0) {
+    } else if (parametersLength % 2 != 0 && parametersLength % 3 != 0) {
       throw new IllegalArgumentException("You must supply the same number of keys as values.")
     }
 
     int step
-    if (parameters.length >= 3 && isRestAssuredArguments(parameters[1]) && parameters[2] instanceof Matcher) {
+    if (parametersLength >= 3 && isRestAssuredArguments(parameters[1]) && parameters[2] instanceof Matcher) {
       step = 3
-    } else if (parameters.length % 2 != 0) {
+    } else if (parametersLength % 2 != 0) {
       throw new IllegalArgumentException("You must supply the same number of keys as values.")
     } else {
       step = 2
@@ -54,7 +55,7 @@ class MapCreator {
 
     boolean argumentsDefined = step == 3
     Map<String, Object> map = new LinkedHashMap<String, Object>()
-    for (int i = 0; i < parameters.length; i += step) {
+    for (int i = 0; i < parametersLength; i += step) {
       def key = parameters[i]
       def args
       def val

--- a/rest-assured/src/main/groovy/io/restassured/internal/RequestSpecificationImpl.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/RequestSpecificationImpl.groovy
@@ -1647,7 +1647,8 @@ class RequestSpecificationImpl implements FilterableRequestSpecification, Groovy
     this.path = path
     if (unnamedPathParams != null) {
       def nullParamIndices = []
-      for (int i = 0; i < unnamedPathParams.length; i++) {
+      def unnamedPathParamsLength = unnamedPathParams.length
+      for (int i = 0; i < unnamedPathParamsLength; i++) {
         if (unnamedPathParams[i] == null) {
           nullParamIndices << i
         }
@@ -1711,13 +1712,14 @@ class RequestSpecificationImpl implements FilterableRequestSpecification, Groovy
   }
 
   void buildUnnamedPathParameterTuples(Object[] unnamedPathParameterValues) {
-    if (unnamedPathParameterValues == null || unnamedPathParameterValues.length == 0) {
+    def unnamedPathParameterValuesLength = unnamedPathParameterValues.length
+    if (unnamedPathParameterValues == null || unnamedPathParameterValuesLength == 0) {
       this.unnamedPathParamsTuples = new ArrayList<Tuple2<String, String>>()
     } else {
       // Undefined placeholders since named path params have precedence over unnamed
       def keys = getUndefinedPathParamPlaceholders()
       List<Tuple2<String, String>> list = new ArrayList<>()
-      for (int i = 0; i < unnamedPathParameterValues.length; i++) {
+      for (int i = 0; i < unnamedPathParameterValuesLength; i++) {
         def val = serializeIfNeeded(unnamedPathParameterValues[i])
         def key = i < keys.size() ? keys.get(i) : null
         list.add(new Tuple2<String, String>(key, val))

--- a/rest-assured/src/main/java/io/restassured/internal/assertion/CookieMatcher.java
+++ b/rest-assured/src/main/java/io/restassured/internal/assertion/CookieMatcher.java
@@ -76,7 +76,8 @@ public class CookieMatcher {
         headerWithCookieList.forEach(it -> {
             String[] cookieStrings = StringUtils.split(it, ";");
             Cookie.Builder cookieBuilder = null;
-            for (int i = 0; i < cookieStrings.length; i++) {
+            int cookieStringsLength = cookieStrings.length;
+            for (int i = 0; i < cookieStringsLength; i++) {
                 String part = cookieStrings[i];
                 if (i == 0) {
                     if (part.contains("=")) {

--- a/rest-assured/src/main/java/io/restassured/internal/print/RequestPrinter.java
+++ b/rest-assured/src/main/java/io/restassured/internal/print/RequestPrinter.java
@@ -203,7 +203,8 @@ public class RequestPrinter {
         if (multiParts.isEmpty()) {
             appendTwoTabs(builder).append(NONE).append(SystemUtils.LINE_SEPARATOR);
         } else {
-            for (int i = 0; i < multiParts.size(); i++) {
+            int multiPartsSize = multiParts.size();
+            for (int i = 0; i < multiPartsSize; i++) {
                 MultiPartSpecification multiPart = multiParts.get(i);
                 if (i == 0) {
                     appendTwoTabs(builder);

--- a/xml-path/src/main/groovy/io/restassured/internal/path/xml/XMLAssertion.groovy
+++ b/xml-path/src/main/groovy/io/restassured/internal/path/xml/XMLAssertion.groovy
@@ -153,10 +153,11 @@ class XMLAssertion implements Assertion {
   }
 
   private def handleList(List result) {
-    if (result.size() == 1 && fragments[-1] != EXPLICIT_LIST_CONVERSION) {
+    def resultSize = result.size()
+    if (resultSize == 1 && fragments[-1] != EXPLICIT_LIST_CONVERSION) {
       return convertToJavaObject(result.get(0))
     } else {
-      for (int i = 0; i < result.size(); i++) {
+      for (int i = 0; i < resultSize; i++) {
         result.set(i, convertToJavaObject(result.get(i)))
       }
     }


### PR DESCRIPTION
Caching the length/size in a variable to avoid repeated calls in loops, which can slightly improve performance and readability.

Motivation and Context
While reading High Performance with Java ([link](https://learning.oreilly.com/library/view/high-performance-with/9781835469736/B21942_03.xhtml#_idParaDest-63)), I came across a useful performance tip: it's recommended to cache the size of a collection before entering a loop, instead of calling .size() in the loop condition.

Instead of:

```
for (int i = 0; i < list.size(); i++) {
    // logic
}
```
Prefer:

```
int size = list.size();
for (int i = 0; i < size; i++) {
    // logic
}
```
