### PR TITLE
Remove the cast of handling Uri template in Spring WebTestClient

### DIFF
--- a/modules/spring-web-test-client/src/main/java/io/restassured/module/webtestclient/internal/WebTestClientRequestSenderImpl.java
+++ b/modules/spring-web-test-client/src/main/java/io/restassured/module/webtestclient/internal/WebTestClientRequestSenderImpl.java
@@ -593,7 +593,7 @@ public class WebTestClientRequestSenderImpl implements WebTestClientRequestSende
 		do {
 			final String paramName = pathParamMatcher.group(1);
 			getPathParamValueFunction.apply(paramName).ifPresent(paramValue ->
-					uriVariables.put(paramName, UriUtils.encode((String) paramValue, Charsets.UTF_8))
+					uriVariables.put(paramName, paramValue)
 			);
 		} while (pathParamMatcher.find());
 


### PR DESCRIPTION
Compared to the code fragment of Spring MockMvc integration module, I remove the cast operation. Please review and suggest the changes. 

fix #1824 
