### PR TITLE
Updating commons-lang3 3.18.0 -- scalatra-example pom.xml

### DIFF
--- a/examples/scalatra-example/pom.xml
+++ b/examples/scalatra-example/pom.xml
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.16.0</version>
+            <version>3.18.0</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Updating the Apache commons-lang3 version in the scalatra-example pom.xml to address 

[CVE-2025-48924](https://www.cve.org/CVERecord?id=CVE-2025-48924)

I am basing the need for this off of #1802 and #1357 which has updates to the dependencies in both locations, not just the one file from #1828 