### PR TITLE
fix: remove weird substringing of URL in getPathParamPlaceholders

### DIFF
--- a/rest-assured/src/main/groovy/io/restassured/internal/RequestSpecificationImpl.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/RequestSpecificationImpl.groovy
@@ -2015,7 +2015,7 @@ class RequestSpecificationImpl implements FilterableRequestSpecification, Groovy
   }
 
   List<String> getPathParamPlaceholders() {
-    def uri = getTargetPath(contains(path, "://") ? substringAfter(path, "://") : path)
+    def uri = getTargetPath(path)
     getPlaceholders(uri)
   }
 


### PR DESCRIPTION
This removes the weird substring logic in `getPathParamPlaceholders()`. I am not sure for what reason this was even there in the first place, as `getTargetPath` should handle both absolute and relative URLs.

Also just doing the substringing here is wrong in some cases like:
`/test/{x}/example?returnUrl=https://example.com/callback`