### PR TITLE
fix(ResponseBuilder): stop resetting ResponseParserRegistrar during build()

### DIFF
--- a/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/LoggingITest.java
+++ b/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/LoggingITest.java
@@ -400,6 +400,47 @@ public class LoggingITest extends WithJetty {
     }
 
     @Test
+    public void ensureResponseLoggerUsesRegisteredCustomParserWhenValidatingBody() {
+        RestAssured.registerParser("application/x-custom-content-type", JSON);
+        try {
+            final StringWriter writer = new StringWriter();
+            final PrintStream captor = new PrintStream(new WriterOutputStream(writer), true);
+
+            final ScalatraObject object = new ScalatraObject();
+            object.setHello("Hello world");
+            given()
+                .filters(new ResponseLoggingFilter(captor))
+                .config(RestAssured.config()
+                    .encoderConfig(encoderConfig().encodeContentTypeAs(
+                        "application/x-custom-content-type",
+                        ContentType.JSON
+                    )))
+                .contentType("application/x-custom-content-type")
+                .body(object)
+            .expect()
+                .defaultParser(JSON)
+            .when()
+                .post("/reflect")
+            .then()
+                .body("hello", equalTo("Hello world"));
+
+            assertThat(
+                writer.toString(), equalTo(String.format(
+                    "HTTP/1.1 200 OK\n" +
+                    "Content-Type: application/x-custom-content-type; charset=%s\n" +
+                    "Content-Length: 23\n" +
+                    "Server: Jetty(9.4.34.v20201102)\n" +
+                    "\n" +
+                    "{\"hello\":\"Hello world\"}\n",
+                    RestAssured.config().getEncoderConfig().defaultContentCharset()
+                ))
+            );
+        } finally {
+            RestAssured.unregisterParser("application/x-custom-content-type");
+        }
+    }
+
+    @Test
     public void logEverythingResponseUsingLogSpec() {
         final StringWriter writer = new StringWriter();
         final PrintStream captor = new PrintStream(new WriterOutputStream(writer), true);

--- a/rest-assured/src/main/java/io/restassured/builder/ResponseBuilder.java
+++ b/rest-assured/src/main/java/io/restassured/builder/ResponseBuilder.java
@@ -218,7 +218,10 @@ public class ResponseBuilder {
         if (restAssuredResponse.getConfig() == null) {
             restAssuredResponse.setConfig(RestAssuredConfig.config());
         }
-        restAssuredResponse.setRpr(new ResponseParserRegistrar());
+
+        if (restAssuredResponse.getRpr() == null) {
+            restAssuredResponse.setRpr(new ResponseParserRegistrar());
+        }
         return restAssuredResponse;
     }
 

--- a/rest-assured/src/main/java/io/restassured/filter/log/StatusCodeBasedLoggingFilter.java
+++ b/rest-assured/src/main/java/io/restassured/filter/log/StatusCodeBasedLoggingFilter.java
@@ -131,7 +131,10 @@ class StatusCodeBasedLoggingFilter implements Filter {
      */
     private Response cloneResponseIfNeeded(Response response, byte[] responseAsString) {
         if (responseAsString != null && response instanceof RestAssuredResponseImpl && !((RestAssuredResponseImpl) response).getHasExpectations()) {
-            final Response build = new ResponseBuilder().clone(response).setBody(responseAsString).build();
+            final Response build = new ResponseBuilder()
+                .clone(response)
+                .setBody(responseAsString)
+                .build();
             ((RestAssuredResponseImpl) build).setHasExpectations(true);
             return build;
         }


### PR DESCRIPTION
Fixes #1759, #1505, #1207 & #978