### PR TITLE
Provide a method to reset the ThreadLocal in ConfigurableJsonSlurper

### DIFF
--- a/json-path/src/main/groovy/io/restassured/internal/path/json/ConfigurableJsonSlurper.groovy
+++ b/json-path/src/main/groovy/io/restassured/internal/path/json/ConfigurableJsonSlurper.groovy
@@ -189,6 +189,15 @@ class ConfigurableJsonSlurper {
   }
 
   /**
+   * Allows to reset the thread local, which might cause memory leaks in environments with dynamic class loaders.
+   * <p>
+   * Do not use except if you know exactly what you are doing.
+   */
+  static void cleanNumberReturnTypeThreadLocal() {
+    numberReturnType.remove();
+  }
+
+  /**
    * Parses an object from the lexer
    *
    * @param lexer the lexer


### PR DESCRIPTION
This ThreadLocal is static and this is causing issues with environments with dynamic class loaders as it is keeping a reference to the class loader, leading to class loader leaks.

Ideally, we should get rid of the class loader but I understand it's there for compatibility reasons so the next best thing is to provide a way to reset it so that it can be called without having to rely on nasty reflection tricks.

Note: this is related to the RESTAssured-related metaspace leaks we have been observing in Quarkus.