### PR TITLE
Revert "fix: remove weird substringing of URL in getPathParamPlaceholders"

### DIFF
--- a/rest-assured/src/main/groovy/io/restassured/internal/RequestSpecificationImpl.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/RequestSpecificationImpl.groovy
@@ -2102,7 +2102,7 @@ class RequestSpecificationImpl implements FilterableRequestSpecification, Groovy
   }
 
   List<String> getPathParamPlaceholders() {
-    def uri = getTargetPath(path)
+    def uri = getTargetPath(contains(path, "://") ? substringAfter(path, "://") : path)
     getPlaceholders(uri)
   }
 


### PR DESCRIPTION
Reverts rest-assured/rest-assured#1837

This test fails on my machine after this PR:

```
[ERROR]   PathParamITest.throwsIllegalArgumentExceptionWhenTooManyPathParametersAreUsed:343 
Expecting message to be:                                                                                                                                                                                                                                                                  
  "Invalid number of path parameters. Expected 1, was 2. Redundant path parameters are: ikk."                                                                                                                                                                                             
but was:                                                                                                                                                                                                                                                                                  
  "Invalid number of path parameters. Expected 0, was 2. Redundant path parameters are: ikk."                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                          
Throwable that failed the check:                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                          
java.lang.IllegalArgumentException: Invalid number of path parameters. Expected 0, was 2. Redundant path parameters are: ikk.                        
```

This should be fixed. And also, a test would be nice to demonstrate that the issue has actually been resolved.