### PR TITLE
Prevent denial-of-service in JsonPath from oversized JSON numbers

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 Changelog next version
 ----------------------
+* Fix a JsonPath denial-of-service where oversized numeric literals in untrusted JSON were parsed into arbitrarily large BigIntegers, an O(n^2) CPU and heap cost. JSON number tokens are now capped at 1000 characters by default, configurable via JsonPathConfig.numberLengthLimit and JsonConfig.numberLengthLimit (a negative value disables the check). Thanks to Brian Lee (PhD security researcher, Georgia Tech SSLab) for the private report.
 * Use custom Jackson 3 object mapper in JsonPath (#1858) (thanks to gkiel for PR)
 * Fix Spring MockMvc cookie handling with Jakarta-only servlet APIs (fixes #1853)
 

--- a/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/JsonNumberLengthLimitITest.java
+++ b/examples/rest-assured-itest-java/src/test/java/io/restassured/itest/java/JsonNumberLengthLimitITest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.restassured.itest.java;
+
+import io.restassured.RestAssured;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+
+import static io.restassured.RestAssured.config;
+import static io.restassured.RestAssured.given;
+import static io.restassured.config.JsonConfig.jsonConfig;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * Verifies that {@link io.restassured.config.JsonConfig#numberLengthLimit(int)} is wired through the
+ * response-body parsing path (ContentParser to ConfigurableJsonSlurper) used by the {@code body(...)} matchers,
+ * not just the standalone JsonPath API.
+ */
+public class JsonNumberLengthLimitITest {
+
+    // Longer than the default limit (1000) but small enough to parse instantly when the cap is disabled.
+    private static final String OVERSIZED_NUMBER = "9".repeat(2000);
+
+    @AfterEach
+    public void reset() {
+        RestAssured.reset();
+    }
+
+    @Test public void
+    rejects_oversized_response_number_with_the_default_limit() throws Exception {
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(new MockResponse.Builder().code(200)
+                    .addHeader("Content-Type", "application/json")
+                    .body("{\"n\":" + OVERSIZED_NUMBER + "}").build());
+            server.start();
+            String url = "http://localhost:" + server.getPort() + "/";
+
+            assertThatThrownBy(() -> given().when().get(url).then().body("n", notNullValue()))
+                    .hasStackTraceContaining("exceeds the maximum allowed length");
+        }
+    }
+
+    @Test public void
+    accepts_oversized_response_number_when_the_limit_is_disabled() throws Exception {
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(new MockResponse.Builder().code(200)
+                    .addHeader("Content-Type", "application/json")
+                    .body("{\"n\":" + OVERSIZED_NUMBER + "}").build());
+            server.start();
+            String url = "http://localhost:" + server.getPort() + "/";
+
+            given().config(config().jsonConfig(jsonConfig().numberLengthLimit(-1))).
+            when().
+                    get(url).
+            then().
+                    body("n", equalTo(new BigInteger(OVERSIZED_NUMBER)));
+        }
+    }
+}

--- a/json-path/src/main/java/io/restassured/internal/path/json/ConfigurableJsonSlurper.java
+++ b/json-path/src/main/java/io/restassured/internal/path/json/ConfigurableJsonSlurper.java
@@ -20,6 +20,7 @@ import groovy.io.LineColumnReader;
 import groovy.json.JsonException;
 import groovy.json.JsonLexer;
 import groovy.json.JsonToken;
+import io.restassured.path.json.config.JsonPathConfig;
 import io.restassured.path.json.config.JsonPathConfig.NumberReturnType;
 
 import static groovy.json.JsonTokenType.*;
@@ -61,7 +62,7 @@ public class ConfigurableJsonSlurper {
       if (text.length() > numberLengthLimit) {
         throw new JsonException("JSON number length (" + text.length()
                 + " chars) exceeds the maximum allowed length of " + numberLengthLimit
-                + " chars. Raise or disable it via JsonPathConfig/JsonConfig.numberLengthLimit(int).");
+                + " chars. Raise or disable it via JsonPathConfig.numberLengthLimit(int).");
       }
     }
 
@@ -80,6 +81,10 @@ public class ConfigurableJsonSlurper {
       result = new BigInteger(result.toString());
     }
     return result;
+  }
+
+  public ConfigurableJsonSlurper(NumberReturnType numberReturnType) {
+    this(numberReturnType, JsonPathConfig.DEFAULT_NUMBER_LENGTH_LIMIT);
   }
 
   public ConfigurableJsonSlurper(NumberReturnType numberReturnType, int numberLengthLimit) {

--- a/json-path/src/main/java/io/restassured/internal/path/json/ConfigurableJsonSlurper.java
+++ b/json-path/src/main/java/io/restassured/internal/path/json/ConfigurableJsonSlurper.java
@@ -53,8 +53,18 @@ import java.util.Map;
  */
 public class ConfigurableJsonSlurper {
   private final NumberReturnType numberReturnType;
+  private final int numberLengthLimit;
 
   private Object getValue(JsonToken token) {
+    if (numberLengthLimit >= 0 && token.getType() == NUMBER) {
+      String text = token.getText();
+      if (text.length() > numberLengthLimit) {
+        throw new JsonException("JSON number length (" + text.length()
+                + " chars) exceeds the maximum allowed length of " + numberLengthLimit
+                + " chars. Raise or disable it via JsonPathConfig/JsonConfig.numberLengthLimit(int).");
+      }
+    }
+
     Object result = token.getValue();
 
     if (numberReturnType.isFloatOrDouble() && result instanceof BigDecimal decimal) {
@@ -72,8 +82,9 @@ public class ConfigurableJsonSlurper {
     return result;
   }
 
-  public ConfigurableJsonSlurper(NumberReturnType numberReturnType) {
+  public ConfigurableJsonSlurper(NumberReturnType numberReturnType, int numberLengthLimit) {
     this.numberReturnType = numberReturnType;
+    this.numberLengthLimit = numberLengthLimit;
   }
 
   /**

--- a/json-path/src/main/java/io/restassured/path/json/JsonPath.java
+++ b/json-path/src/main/java/io/restassured/path/json/JsonPath.java
@@ -1025,7 +1025,7 @@ public class JsonPath {
 
     private ConfigurableJsonSlurper createConfigurableJsonSlurper() {
         JsonPathConfig cfg = getJsonPathConfig();
-        return new ConfigurableJsonSlurper(cfg.numberReturnType());
+        return new ConfigurableJsonSlurper(cfg.numberReturnType(), cfg.numberLengthLimit());
     }
 
     private JsonPathConfig getJsonPathConfig() {

--- a/json-path/src/main/java/io/restassured/path/json/config/JsonPathConfig.java
+++ b/json-path/src/main/java/io/restassured/path/json/config/JsonPathConfig.java
@@ -167,10 +167,10 @@ public class JsonPathConfig {
     /**
      * Specifies the maximum allowed length (in characters) of a JSON number token. Number tokens longer than this
      * are rejected before being converted to a number, guarding against CPU/heap exhaustion when constructing
-     * arbitrarily large numbers (such as {@link java.math.BigInteger}) from untrusted JSON. A negative value
-     * disables the check. Defaults to {@link #DEFAULT_NUMBER_LENGTH_LIMIT}.
+     * arbitrarily large numbers (such as {@link java.math.BigInteger}) from untrusted JSON. A value of {@code 0}
+     * rejects every number, and a negative value disables the check. Defaults to {@link #DEFAULT_NUMBER_LENGTH_LIMIT}.
      *
-     * @param numberLengthLimit The maximum number token length, or a negative value to disable the check.
+     * @param numberLengthLimit The maximum number token length, {@code 0} to reject all numbers, or a negative value to disable the check.
      * @return A new instance of JsonPathConfig with the given configuration
      */
     public JsonPathConfig numberLengthLimit(int numberLengthLimit) {

--- a/json-path/src/main/java/io/restassured/path/json/config/JsonPathConfig.java
+++ b/json-path/src/main/java/io/restassured/path/json/config/JsonPathConfig.java
@@ -34,7 +34,16 @@ import static io.restassured.path.json.config.JsonPathConfig.NumberReturnType.FL
  */
 public class JsonPathConfig {
 
+    /**
+     * The default maximum length (in characters) of a JSON number token. Tokens longer than this
+     * are rejected before being converted to a number. This guards against CPU/heap exhaustion when
+     * constructing arbitrarily large numbers (e.g. {@link java.math.BigInteger}) from untrusted input.
+     * The value matches Jackson's {@code StreamReadConstraints} default.
+     */
+    public static final int DEFAULT_NUMBER_LENGTH_LIMIT = 1000;
+
     private final NumberReturnType numberReturnType;
+    private final int numberLengthLimit;
     private final JsonPathObjectDeserializer defaultDeserializer;
     private final JsonParserType defaultParserType;
     private final GsonObjectMapperFactory gsonObjectMapperFactory;
@@ -54,7 +63,7 @@ public class JsonPathConfig {
     public JsonPathConfig(JsonPathConfig config) {
         this(config.numberReturnType(), config.defaultParserType(), config.gsonObjectMapperFactory(), config.jackson1ObjectMapperFactory(),
                 config.jackson2ObjectMapperFactory(), config.jackson3ObjectMapperFactory(), config.johnzonObjectMapperFactory(), config.jsonbObjectMapperFactory(),
-                config.defaultDeserializer(), config.charset());
+                config.defaultDeserializer(), config.charset(), config.numberLengthLimit());
     }
 
     /**
@@ -63,7 +72,7 @@ public class JsonPathConfig {
     public JsonPathConfig() {
         this(FLOAT_AND_DOUBLE, null, newGsonObjectMapperFactoryOrNullIfNotInClasspath(), newJackson1ObjectMapperFactoryOrNullIfNotInClasspath(),
                 newJackson2ObjectMapperFactoryOrNullIfNotInClasspath(), newJackson3ObjectMapperFactoryOrNullIfNotInClasspath(),
-                newJohnzonObjectMapperFactoryOrNullIfNotInClasspath(), newYassinObjectMapperFactoryOrNullIfNotInClasspath(), null, defaultCharset());
+                newJohnzonObjectMapperFactoryOrNullIfNotInClasspath(), newYassinObjectMapperFactoryOrNullIfNotInClasspath(), null, defaultCharset(), DEFAULT_NUMBER_LENGTH_LIMIT);
     }
 
 
@@ -73,7 +82,7 @@ public class JsonPathConfig {
     public JsonPathConfig(NumberReturnType numberReturnType) {
         this(numberReturnType, null, newGsonObjectMapperFactoryOrNullIfNotInClasspath(), newJackson1ObjectMapperFactoryOrNullIfNotInClasspath(),
                 newJackson2ObjectMapperFactoryOrNullIfNotInClasspath(), newJackson3ObjectMapperFactoryOrNullIfNotInClasspath(),
-                newJohnzonObjectMapperFactoryOrNullIfNotInClasspath(), newYassinObjectMapperFactoryOrNullIfNotInClasspath(), null, defaultCharset());
+                newJohnzonObjectMapperFactoryOrNullIfNotInClasspath(), newYassinObjectMapperFactoryOrNullIfNotInClasspath(), null, defaultCharset(), DEFAULT_NUMBER_LENGTH_LIMIT);
 
     }
 
@@ -83,19 +92,20 @@ public class JsonPathConfig {
     public JsonPathConfig(String defaultCharset) {
         this(FLOAT_AND_DOUBLE, null, newGsonObjectMapperFactoryOrNullIfNotInClasspath(), newJackson1ObjectMapperFactoryOrNullIfNotInClasspath(),
                 newJackson2ObjectMapperFactoryOrNullIfNotInClasspath(), newJackson3ObjectMapperFactoryOrNullIfNotInClasspath(),
-                newJohnzonObjectMapperFactoryOrNullIfNotInClasspath(), newYassinObjectMapperFactoryOrNullIfNotInClasspath(), null, defaultCharset);
+                newJohnzonObjectMapperFactoryOrNullIfNotInClasspath(), newYassinObjectMapperFactoryOrNullIfNotInClasspath(), null, defaultCharset, DEFAULT_NUMBER_LENGTH_LIMIT);
 
     }
 
     private JsonPathConfig(NumberReturnType numberReturnType, JsonParserType parserType, GsonObjectMapperFactory gsonObjectMapperFactory,
                            Jackson1ObjectMapperFactory jackson1ObjectMapperFactory, Jackson2ObjectMapperFactory jackson2ObjectMapperFactory,
                            Jackson3ObjectMapperFactory jackson3ObjectMapperFactory, JohnzonObjectMapperFactory johnzonObjectMapperFactory,
-                           JsonbObjectMapperFactory jsonbObjectMapperFactory, JsonPathObjectDeserializer defaultDeserializer, String charset) {
+                           JsonbObjectMapperFactory jsonbObjectMapperFactory, JsonPathObjectDeserializer defaultDeserializer, String charset, int numberLengthLimit) {
         if (numberReturnType == null) throw new IllegalArgumentException("numberReturnType cannot be null");
         charset = StringUtils.trimToNull(charset);
         if (charset == null) throw new IllegalArgumentException("Charset cannot be empty");
         this.charset = charset;
         this.numberReturnType = numberReturnType;
+        this.numberLengthLimit = numberLengthLimit;
         this.defaultDeserializer = defaultDeserializer;
         this.defaultParserType = parserType;
         this.gsonObjectMapperFactory = gsonObjectMapperFactory;
@@ -123,7 +133,7 @@ public class JsonPathConfig {
     public JsonPathConfig charset(String charset) {
         return new JsonPathConfig(numberReturnType, defaultParserType, gsonObjectMapperFactory,
                 jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, jackson3ObjectMapperFactory,
-                johnzonObjectMapperFactory, jsonbObjectMapperFactory, defaultDeserializer, charset);
+                johnzonObjectMapperFactory, jsonbObjectMapperFactory, defaultDeserializer, charset, numberLengthLimit);
     }
 
 
@@ -140,11 +150,33 @@ public class JsonPathConfig {
     public JsonPathConfig numberReturnType(NumberReturnType numberReturnType) {
         return new JsonPathConfig(numberReturnType, defaultParserType, gsonObjectMapperFactory,
                 jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, jackson3ObjectMapperFactory,
-                johnzonObjectMapperFactory, jsonbObjectMapperFactory, defaultDeserializer, charset);
+                johnzonObjectMapperFactory, jsonbObjectMapperFactory, defaultDeserializer, charset, numberLengthLimit);
     }
 
     public boolean shouldRepresentJsonNumbersAsBigDecimal() {
         return numberReturnType() == BIG_DECIMAL;
+    }
+
+    /**
+     * @return The maximum allowed length (in characters) of a JSON number token, or a negative value if unlimited.
+     */
+    public int numberLengthLimit() {
+        return numberLengthLimit;
+    }
+
+    /**
+     * Specifies the maximum allowed length (in characters) of a JSON number token. Number tokens longer than this
+     * are rejected before being converted to a number, guarding against CPU/heap exhaustion when constructing
+     * arbitrarily large numbers (such as {@link java.math.BigInteger}) from untrusted JSON. A negative value
+     * disables the check. Defaults to {@link #DEFAULT_NUMBER_LENGTH_LIMIT}.
+     *
+     * @param numberLengthLimit The maximum number token length, or a negative value to disable the check.
+     * @return A new instance of JsonPathConfig with the given configuration
+     */
+    public JsonPathConfig numberLengthLimit(int numberLengthLimit) {
+        return new JsonPathConfig(numberReturnType, defaultParserType, gsonObjectMapperFactory,
+                jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, jackson3ObjectMapperFactory,
+                johnzonObjectMapperFactory, jsonbObjectMapperFactory, defaultDeserializer, charset, numberLengthLimit);
     }
 
     public JsonParserType defaultParserType() {
@@ -187,7 +219,7 @@ public class JsonPathConfig {
     public JsonPathConfig defaultParserType(JsonParserType defaultParserType) {
         return new JsonPathConfig(numberReturnType, defaultParserType, gsonObjectMapperFactory,
                 jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, jackson3ObjectMapperFactory,
-                johnzonObjectMapperFactory, jsonbObjectMapperFactory, defaultDeserializer, charset);
+                johnzonObjectMapperFactory, jsonbObjectMapperFactory, defaultDeserializer, charset, numberLengthLimit);
     }
 
     public JsonPathObjectDeserializer defaultDeserializer() {
@@ -206,7 +238,7 @@ public class JsonPathConfig {
     public JsonPathConfig defaultObjectDeserializer(JsonPathObjectDeserializer defaultObjectDeserializer) {
         return new JsonPathConfig(numberReturnType, null, gsonObjectMapperFactory, jackson1ObjectMapperFactory,
                 jackson2ObjectMapperFactory, jackson3ObjectMapperFactory, johnzonObjectMapperFactory,
-                jsonbObjectMapperFactory, defaultObjectDeserializer, charset);
+                jsonbObjectMapperFactory, defaultObjectDeserializer, charset, numberLengthLimit);
     }
 
     public GsonObjectMapperFactory gsonObjectMapperFactory() {
@@ -221,7 +253,7 @@ public class JsonPathConfig {
     public JsonPathConfig gsonObjectMapperFactory(GsonObjectMapperFactory gsonObjectMapperFactory) {
         return new JsonPathConfig(numberReturnType, defaultParserType, gsonObjectMapperFactory,
                 jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, jackson3ObjectMapperFactory,
-                johnzonObjectMapperFactory, jsonbObjectMapperFactory, defaultDeserializer, charset);
+                johnzonObjectMapperFactory, jsonbObjectMapperFactory, defaultDeserializer, charset, numberLengthLimit);
     }
 
     public Jackson1ObjectMapperFactory jackson1ObjectMapperFactory() {
@@ -236,7 +268,7 @@ public class JsonPathConfig {
     public JsonPathConfig jackson1ObjectMapperFactory(Jackson1ObjectMapperFactory jackson1ObjectMapperFactory) {
         return new JsonPathConfig(numberReturnType, defaultParserType, gsonObjectMapperFactory,
                 jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, jackson3ObjectMapperFactory,
-                johnzonObjectMapperFactory, jsonbObjectMapperFactory, defaultDeserializer, charset);
+                johnzonObjectMapperFactory, jsonbObjectMapperFactory, defaultDeserializer, charset, numberLengthLimit);
     }
 
     public Jackson2ObjectMapperFactory jackson2ObjectMapperFactory() {
@@ -255,7 +287,7 @@ public class JsonPathConfig {
     public JsonPathConfig jackson2ObjectMapperFactory(Jackson2ObjectMapperFactory jackson2ObjectMapperFactory) {
         return new JsonPathConfig(numberReturnType, defaultParserType, gsonObjectMapperFactory,
                 jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, jackson3ObjectMapperFactory,
-                johnzonObjectMapperFactory, jsonbObjectMapperFactory, defaultDeserializer, charset);
+                johnzonObjectMapperFactory, jsonbObjectMapperFactory, defaultDeserializer, charset, numberLengthLimit);
     }
 
     public Jackson3ObjectMapperFactory jackson3ObjectMapperFactory() {
@@ -270,7 +302,7 @@ public class JsonPathConfig {
     public JsonPathConfig jackson3ObjectMapperFactory(Jackson3ObjectMapperFactory jackson3ObjectMapperFactory) {
         return new JsonPathConfig(numberReturnType, defaultParserType, gsonObjectMapperFactory,
             jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, jackson3ObjectMapperFactory,
-            johnzonObjectMapperFactory, jsonbObjectMapperFactory, defaultDeserializer, charset);
+            johnzonObjectMapperFactory, jsonbObjectMapperFactory, defaultDeserializer, charset, numberLengthLimit);
     }
 
     public JsonbObjectMapperFactory jsonbObjectMapperFactory() {
@@ -285,7 +317,7 @@ public class JsonPathConfig {
     public JsonPathConfig jsonbObjectMapperFactory(JsonbObjectMapperFactory jsonbObjectMapperFactory) {
         return new JsonPathConfig(numberReturnType, defaultParserType, gsonObjectMapperFactory,
                 jackson1ObjectMapperFactory, jackson2ObjectMapperFactory, jackson3ObjectMapperFactory,
-                johnzonObjectMapperFactory, jsonbObjectMapperFactory, defaultDeserializer, charset);
+                johnzonObjectMapperFactory, jsonbObjectMapperFactory, defaultDeserializer, charset, numberLengthLimit);
     }
 
     /**

--- a/json-path/src/test/java/io/restassured/path/json/JsonPathNumberLengthLimitTest.java
+++ b/json-path/src/test/java/io/restassured/path/json/JsonPathNumberLengthLimitTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.restassured.path.json;
+
+import io.restassured.path.json.config.JsonPathConfig;
+import io.restassured.path.json.exception.JsonPathException;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.time.Duration;
+
+import static io.restassured.path.json.config.JsonPathConfig.DEFAULT_NUMBER_LENGTH_LIMIT;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+public class JsonPathNumberLengthLimitTest {
+
+    @Test public void
+    rejects_integer_number_that_exceeds_the_default_length_limit() {
+        // Given a number far larger than the default limit (131072 digits, the size from the original report,
+        // constructing a BigInteger from it would otherwise peg a CPU core for hundreds of milliseconds)
+        final String json = "{\"n\":" + "9".repeat(131_072) + "}";
+        final JsonPath jsonPath = new JsonPath(json);
+
+        // When / Then it is rejected quickly, before any expensive number construction runs
+        assertTimeoutPreemptively(Duration.ofSeconds(2), () -> {
+            JsonPathException exception = assertThrows(JsonPathException.class, () -> jsonPath.get("n"));
+            assertThat(exception.getCause().getMessage(), containsString("exceeds the maximum allowed length"));
+        });
+    }
+
+    @Test public void
+    rejects_decimal_number_that_exceeds_the_default_length_limit() {
+        // Given
+        final String json = "{\"n\":" + "9".repeat(50_000) + ".5}";
+        final JsonPath jsonPath = new JsonPath(json);
+
+        // When / Then
+        assertThrows(JsonPathException.class, () -> jsonPath.get("n"));
+    }
+
+    @Test public void
+    accepts_number_at_the_default_length_limit() {
+        // Given a number exactly at the default limit
+        final String number = "9".repeat(DEFAULT_NUMBER_LENGTH_LIMIT);
+        final JsonPath jsonPath = new JsonPath("{\"n\":" + number + "}")
+                .using(new JsonPathConfig().numberReturnType(JsonPathConfig.NumberReturnType.BIG_INTEGER));
+
+        // When
+        BigInteger n = jsonPath.get("n");
+
+        // Then
+        assertThat(n, equalTo(new BigInteger(number)));
+    }
+
+    @Test public void
+    accepts_oversized_number_when_the_limit_is_raised() {
+        // Given a limit large enough to admit the number
+        final String number = "9".repeat(5000);
+        final JsonPath jsonPath = new JsonPath("{\"n\":" + number + "}")
+                .using(new JsonPathConfig()
+                        .numberReturnType(JsonPathConfig.NumberReturnType.BIG_INTEGER)
+                        .numberLengthLimit(10_000));
+
+        // When
+        BigInteger n = jsonPath.get("n");
+
+        // Then
+        assertThat(n, equalTo(new BigInteger(number)));
+    }
+
+    @Test public void
+    accepts_oversized_number_when_the_limit_is_disabled() {
+        // Given a negative limit which disables the check
+        final String number = "9".repeat(5000);
+        final JsonPath jsonPath = new JsonPath("{\"n\":" + number + "}")
+                .using(new JsonPathConfig()
+                        .numberReturnType(JsonPathConfig.NumberReturnType.BIG_INTEGER)
+                        .numberLengthLimit(-1));
+
+        // When
+        BigInteger n = jsonPath.get("n");
+
+        // Then
+        assertThat(n, equalTo(new BigInteger(number)));
+    }
+}

--- a/json-path/src/test/java/io/restassured/path/json/JsonPathNumberLengthLimitTest.java
+++ b/json-path/src/test/java/io/restassured/path/json/JsonPathNumberLengthLimitTest.java
@@ -52,8 +52,9 @@ public class JsonPathNumberLengthLimitTest {
         final String json = "{\"n\":" + "9".repeat(50_000) + ".5}";
         final JsonPath jsonPath = new JsonPath(json);
 
-        // When / Then
-        assertThrows(JsonPathException.class, () -> jsonPath.get("n"));
+        // When / Then it is rejected quickly, before any expensive BigDecimal construction runs
+        assertTimeoutPreemptively(Duration.ofSeconds(2),
+                () -> assertThrows(JsonPathException.class, () -> jsonPath.get("n")));
     }
 
     @Test public void

--- a/rest-assured/src/main/groovy/io/restassured/internal/ContentParser.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/ContentParser.groovy
@@ -37,7 +37,7 @@ class ContentParser {
     } else {
       switch (parser) {
         case JSON:
-          def slurper = new ConfigurableJsonSlurper(config.getJsonConfig().numberReturnType())
+          def slurper = new ConfigurableJsonSlurper(config.getJsonConfig().numberReturnType(), config.getJsonConfig().numberLengthLimit())
           if (parseAsString) {
             content = slurper.parseText(response.asString())
           } else {

--- a/rest-assured/src/main/java/io/restassured/config/JsonConfig.java
+++ b/rest-assured/src/main/java/io/restassured/config/JsonConfig.java
@@ -28,7 +28,7 @@ public class JsonConfig implements Config {
     private final boolean isUserDefined;
 
     /**
-     * Create a new instance of XmlConfig without any features and that is namespace unaware.
+     * Create a new instance of JsonConfig with the default settings.
      */
     public JsonConfig() {
         this(JsonPathConfig.NumberReturnType.FLOAT_AND_DOUBLE, JsonPathConfig.DEFAULT_NUMBER_LENGTH_LIMIT, false);

--- a/rest-assured/src/main/java/io/restassured/config/JsonConfig.java
+++ b/rest-assured/src/main/java/io/restassured/config/JsonConfig.java
@@ -24,22 +24,28 @@ import org.apache.commons.lang3.Validate;
  */
 public class JsonConfig implements Config {
     private final JsonPathConfig.NumberReturnType numberReturnType;
+    private final int numberLengthLimit;
     private final boolean isUserDefined;
 
     /**
      * Create a new instance of XmlConfig without any features and that is namespace unaware.
      */
     public JsonConfig() {
-        this(JsonPathConfig.NumberReturnType.FLOAT_AND_DOUBLE, false);
+        this(JsonPathConfig.NumberReturnType.FLOAT_AND_DOUBLE, JsonPathConfig.DEFAULT_NUMBER_LENGTH_LIMIT, false);
     }
 
     public JsonConfig(JsonPathConfig.NumberReturnType numberReturnType) {
-        this(numberReturnType, true);
+        this(numberReturnType, JsonPathConfig.DEFAULT_NUMBER_LENGTH_LIMIT, true);
     }
 
     public JsonConfig(JsonPathConfig.NumberReturnType numberReturnType, boolean isUserDefined) {
+        this(numberReturnType, JsonPathConfig.DEFAULT_NUMBER_LENGTH_LIMIT, isUserDefined);
+    }
+
+    private JsonConfig(JsonPathConfig.NumberReturnType numberReturnType, int numberLengthLimit, boolean isUserDefined) {
         Validate.notNull(numberReturnType, "numberReturnType cannot be null");
         this.numberReturnType = numberReturnType;
+        this.numberLengthLimit = numberLengthLimit;
         this.isUserDefined = isUserDefined;
     }
 
@@ -52,13 +58,33 @@ public class JsonConfig implements Config {
     }
 
     /**
+     * @return The maximum allowed length (in characters) of a JSON number token, or a negative value if unlimited.
+     */
+    public int numberLengthLimit() {
+        return numberLengthLimit;
+    }
+
+    /**
      * Specifies if JSON parsing should use floats and doubles or BigDecimals to represent Json numbers.
      *
      * @param numberReturnType The choice.
      * @return A new instance of JsonConfig with the given configuration
      */
     public JsonConfig numberReturnType(JsonPathConfig.NumberReturnType numberReturnType) {
-        return new JsonConfig(numberReturnType, true);
+        return new JsonConfig(numberReturnType, numberLengthLimit, true);
+    }
+
+    /**
+     * Specifies the maximum allowed length (in characters) of a JSON number token. Number tokens longer than this
+     * are rejected before being converted to a number, guarding against CPU/heap exhaustion when constructing
+     * arbitrarily large numbers (such as {@link java.math.BigInteger}) from untrusted JSON. A negative value
+     * disables the check. Defaults to {@link JsonPathConfig#DEFAULT_NUMBER_LENGTH_LIMIT}.
+     *
+     * @param numberLengthLimit The maximum number token length, or a negative value to disable the check.
+     * @return A new instance of JsonConfig with the given configuration
+     */
+    public JsonConfig numberLengthLimit(int numberLengthLimit) {
+        return new JsonConfig(numberReturnType, numberLengthLimit, true);
     }
 
     /**

--- a/rest-assured/src/main/java/io/restassured/config/JsonConfig.java
+++ b/rest-assured/src/main/java/io/restassured/config/JsonConfig.java
@@ -77,10 +77,10 @@ public class JsonConfig implements Config {
     /**
      * Specifies the maximum allowed length (in characters) of a JSON number token. Number tokens longer than this
      * are rejected before being converted to a number, guarding against CPU/heap exhaustion when constructing
-     * arbitrarily large numbers (such as {@link java.math.BigInteger}) from untrusted JSON. A negative value
-     * disables the check. Defaults to {@link JsonPathConfig#DEFAULT_NUMBER_LENGTH_LIMIT}.
+     * arbitrarily large numbers (such as {@link java.math.BigInteger}) from untrusted JSON. A value of {@code 0}
+     * rejects every number, and a negative value disables the check. Defaults to {@link JsonPathConfig#DEFAULT_NUMBER_LENGTH_LIMIT}.
      *
-     * @param numberLengthLimit The maximum number token length, or a negative value to disable the check.
+     * @param numberLengthLimit The maximum number token length, {@code 0} to reject all numbers, or a negative value to disable the check.
      * @return A new instance of JsonConfig with the given configuration
      */
     public JsonConfig numberLengthLimit(int numberLengthLimit) {


### PR DESCRIPTION
JsonPath navigates JSON with a fork of Groovy's `JsonSlurper`, so a JSON number with a huge number of digits was turned straight into a `java.math.BigInteger` with no length limit. Building a `BigInteger` from a decimal string is O(n^2), so one oversized number is enough to burn a lot of CPU. On JDK 21 a 131072-digit number takes around 389 ms on a single core (about 3 parses per second), which makes it a cheap denial-of-service against anything that runs JsonPath over untrusted JSON.

This caps the length of a JSON number token before the expensive conversion runs, reading the already-lexed token text so it short-circuits before any `BigInteger` work. The default is 1000 characters, matching Jackson's `StreamReadConstraints` default, and it is configurable through `JsonPathConfig.numberLengthLimit` and `JsonConfig.numberLengthLimit` (a negative value disables the check).

Reported privately by Brian Lee (Georgia Tech SSLab).
