### PR TITLE
Strip sensitive headers on cross-host redirects

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report security issues privately, not through a public issue or pull request.
+
+The preferred channel is GitHub's private vulnerability reporting. Go to the **Security** tab
+of this repository and click **Report a vulnerability**. That keeps the report, the
+proof-of-concept, and the discussion private while a fix is prepared, and it lets us open a
+draft advisory and coordinate a CVE from the same place.
+
+Please paste the details or link them rather than sending archive attachments.
+
+When you report, include what you have: the affected version, a description of the issue, and
+a self-contained way to reproduce it. We will confirm the problem, work on a fix, and
+coordinate the release. We are happy to credit you in the advisory and the changelog if you
+would like that.
+
+## Supported versions
+
+Security fixes target the latest release line. Please make sure you can reproduce the issue on
+the most recent release before reporting.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Changelog next version
+----------------------
+* Strip sensitive headers (Authorization, Cookie, Proxy-Authorization) when a redirect crosses to a different host, so a token or session isn't leaked to the redirect target. This is on by default and can be turned off with RedirectConfig.stripSensitiveHeadersOnCrossHostRedirect(false). Thanks to the University of Sydney security research team for the report.
+
 Changelog 6.0.1 (2026-07-10)
 ----------------------------
 * Fix a JsonPath denial-of-service where oversized numeric literals in untrusted JSON were parsed into arbitrarily large BigIntegers, an O(n^2) CPU and heap cost. JSON number tokens are now capped at 1000 characters by default, configurable via JsonPathConfig.numberLengthLimit and JsonConfig.numberLengthLimit (a negative value disables the check). Thanks to Brian Lee (PhD security researcher, Georgia Tech SSLab) for the private report.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 Changelog next version
 ----------------------
-* Strip sensitive headers (Authorization, Cookie, Proxy-Authorization) when a redirect crosses to a different host, so a token or session isn't leaked to the redirect target. This is on by default and can be turned off with RedirectConfig.stripSensitiveHeadersOnCrossHostRedirect(false). Thanks to the University of Sydney security research team for the report.
+* Strip sensitive headers (Authorization and Cookie) when a redirect crosses to a different host, so a token or session isn't leaked to the redirect target. This is on by default and can be turned off with RedirectConfig.stripSensitiveHeadersOnCrossHostRedirect(false). Thanks to the University of Sydney security research team for the report.
 
 Changelog 6.0.1 (2026-07-10)
 ----------------------------

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 Changelog next version
 ----------------------
-* Strip sensitive headers (Authorization and Cookie) when a redirect crosses to a different host, so a token or session isn't leaked to the redirect target. This is on by default and can be turned off with RedirectConfig.stripSensitiveHeadersOnCrossHostRedirect(false). Thanks to the University of Sydney security research team for the report.
+* Strip sensitive headers (Authorization and Cookie) when a redirect crosses to a different host, so a token or session isn't leaked to the redirect target. This is on by default and can be turned off with RedirectConfig.stripSensitiveHeadersOnCrossHostRedirect(false) (#1873). Thanks to the University of Sydney security research team for the report.
 
 Changelog 6.0.1 (2026-07-10)
 ----------------------------

--- a/rest-assured/src/main/groovy/io/restassured/internal/RequestSpecificationImpl.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/RequestSpecificationImpl.groovy
@@ -1285,6 +1285,9 @@ class RequestSpecificationImpl implements FilterableRequestSpecification, Groovy
 
     authenticationScheme.authenticate(http)
 
+    // Register the cross-host header stripper after authentication so it runs last in the interceptor chain.
+    applyCrossHostRedirectHeaderStripping(http, (restAssuredConfig?.getRedirectConfig() ?: new RedirectConfig()))
+
     if (mayHaveBody(method)) {
       if (hasFormParams() && requestBody != null) {
         throw new IllegalStateException("You can either send form parameters OR body content in $method, not both!")
@@ -1388,8 +1391,6 @@ class RequestSpecificationImpl implements FilterableRequestSpecification, Groovy
         p.setParameter(key, value)
       }
     }
-
-    applyCrossHostRedirectHeaderStripping(http, (restAssuredConfig?.getRedirectConfig() ?: new RedirectConfig()))
   }
 
   private def applyCrossHostRedirectHeaderStripping(HTTPBuilder http, RedirectConfig redirectConfig) {
@@ -1398,6 +1399,8 @@ class RequestSpecificationImpl implements FilterableRequestSpecification, Groovy
     }
     def client = http.client as AbstractHttpClient
     // Remove first so repeated configuration (e.g. a reused HttpClient instance) never stacks duplicates.
+    // Register last (after authentication schemes have added their interceptors) so that an auth interceptor
+    // such as the OAuth/OAuth2 signer cannot re-add Authorization after we have stripped it on a redirect.
     client.removeRequestInterceptorByClass(CrossHostSensitiveHeaderStripper)
     if (redirectConfig.stripsSensitiveHeadersOnCrossHostRedirect()) {
       client.addRequestInterceptor(new CrossHostSensitiveHeaderStripper())

--- a/rest-assured/src/main/groovy/io/restassured/internal/RequestSpecificationImpl.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/RequestSpecificationImpl.groovy
@@ -1388,6 +1388,20 @@ class RequestSpecificationImpl implements FilterableRequestSpecification, Groovy
         p.setParameter(key, value)
       }
     }
+
+    applyCrossHostRedirectHeaderStripping(http, (restAssuredConfig?.getRedirectConfig() ?: new RedirectConfig()))
+  }
+
+  private def applyCrossHostRedirectHeaderStripping(HTTPBuilder http, RedirectConfig redirectConfig) {
+    if (!(http.client instanceof AbstractHttpClient)) {
+      return
+    }
+    def client = http.client as AbstractHttpClient
+    // Remove first so repeated configuration (e.g. a reused HttpClient instance) never stacks duplicates.
+    client.removeRequestInterceptorByClass(CrossHostSensitiveHeaderStripper)
+    if (redirectConfig.stripsSensitiveHeadersOnCrossHostRedirect()) {
+      client.addRequestInterceptor(new CrossHostSensitiveHeaderStripper())
+    }
   }
 
   private def applyContentDecoders(HTTPBuilder httpBuilder, List<DecoderConfig.ContentDecoder> contentDecoders) {

--- a/rest-assured/src/main/java/io/restassured/config/RedirectConfig.java
+++ b/rest-assured/src/main/java/io/restassured/config/RedirectConfig.java
@@ -110,10 +110,11 @@ public class RedirectConfig implements Config {
     }
 
     /**
-     * Configure whether REST Assured should strip sensitive headers (<code>Authorization</code>, <code>Cookie</code> and
-     * <code>Proxy-Authorization</code>) when a redirect crosses to a different host, so that a credential or session is not
-     * leaked to the redirect target. The target is considered a different host when its scheme, host or port differs from
-     * the first (original) request in the redirect chain. Enabled by default.
+     * Configure whether REST Assured should strip sensitive headers (<code>Authorization</code> and <code>Cookie</code>)
+     * when a redirect crosses to a different host, so that a credential or session is not leaked to the redirect target.
+     * The target is considered a different host when its scheme, host or port differs from the first (original) request
+     * in the redirect chain. <code>Proxy-Authorization</code> is not stripped, since it authenticates to the proxy rather
+     * than the target host. Enabled by default.
      *
      * @param value <code>true</code> if sensitive headers should be stripped on a cross-host redirect, <code>false</code> to forward them as before.
      * @return An updated RedirectConfig

--- a/rest-assured/src/main/java/io/restassured/config/RedirectConfig.java
+++ b/rest-assured/src/main/java/io/restassured/config/RedirectConfig.java
@@ -28,6 +28,7 @@ public class RedirectConfig implements Config {
     private final boolean allowCircularRedirects;
     private final boolean rejectRelativeRedirect;
     private final int maxRedirects;
+    private final boolean stripSensitiveHeadersOnCrossHostRedirect;
     private final boolean isUserConfigured;
 
     /**
@@ -37,10 +38,11 @@ public class RedirectConfig implements Config {
      * <li>allowCircularRedirects = false</li>
      * <li>rejectRelativeRedirect = false</li>
      * <li>maxRedirects = 100 </li>
+     * <li>stripSensitiveHeadersOnCrossHostRedirect = true </li>
      * </ol>
      */
     public RedirectConfig() {
-        this(true, false, false, 100, false);
+        this(true, false, false, 100, true, false);
     }
 
     /**
@@ -53,15 +55,17 @@ public class RedirectConfig implements Config {
      */
     public RedirectConfig(boolean followRedirects, boolean allowCircularRedirects,
                           boolean rejectRelativeRedirect, int maxRedirects) {
-        this(followRedirects, allowCircularRedirects, rejectRelativeRedirect, maxRedirects, true);
+        this(followRedirects, allowCircularRedirects, rejectRelativeRedirect, maxRedirects, true, true);
     }
 
     private RedirectConfig(boolean followRedirects, boolean allowCircularRedirects,
-                           boolean rejectRelativeRedirect, int maxRedirects, boolean isUserConfigured) {
+                           boolean rejectRelativeRedirect, int maxRedirects,
+                           boolean stripSensitiveHeadersOnCrossHostRedirect, boolean isUserConfigured) {
         this.followRedirects = followRedirects;
         this.allowCircularRedirects = allowCircularRedirects;
         this.rejectRelativeRedirect = rejectRelativeRedirect;
         this.maxRedirects = maxRedirects;
+        this.stripSensitiveHeadersOnCrossHostRedirect = stripSensitiveHeadersOnCrossHostRedirect;
         this.isUserConfigured = isUserConfigured;
     }
 
@@ -72,7 +76,7 @@ public class RedirectConfig implements Config {
      * @return An updated RedirectConfig
      */
     public RedirectConfig followRedirects(boolean value) {
-        return new RedirectConfig(value, allowCircularRedirects, rejectRelativeRedirect, maxRedirects, true);
+        return new RedirectConfig(value, allowCircularRedirects, rejectRelativeRedirect, maxRedirects, stripSensitiveHeadersOnCrossHostRedirect, true);
     }
 
     /**
@@ -82,7 +86,7 @@ public class RedirectConfig implements Config {
      * @return An updated RedirectConfig
      */
     public RedirectConfig allowCircularRedirects(boolean value) {
-        return new RedirectConfig(followRedirects, value, rejectRelativeRedirect, maxRedirects, true);
+        return new RedirectConfig(followRedirects, value, rejectRelativeRedirect, maxRedirects, stripSensitiveHeadersOnCrossHostRedirect, true);
     }
 
     /**
@@ -92,7 +96,7 @@ public class RedirectConfig implements Config {
      * @return An updated RedirectConfig
      */
     public RedirectConfig rejectRelativeRedirect(boolean value) {
-        return new RedirectConfig(followRedirects, allowCircularRedirects, value, maxRedirects, true);
+        return new RedirectConfig(followRedirects, allowCircularRedirects, value, maxRedirects, stripSensitiveHeadersOnCrossHostRedirect, true);
     }
 
     /**
@@ -102,7 +106,20 @@ public class RedirectConfig implements Config {
      * @return An updated RedirectConfig
      */
     public RedirectConfig maxRedirects(int value) {
-        return new RedirectConfig(followRedirects, allowCircularRedirects, rejectRelativeRedirect, value, true);
+        return new RedirectConfig(followRedirects, allowCircularRedirects, rejectRelativeRedirect, value, stripSensitiveHeadersOnCrossHostRedirect, true);
+    }
+
+    /**
+     * Configure whether REST Assured should strip sensitive headers (<code>Authorization</code>, <code>Cookie</code> and
+     * <code>Proxy-Authorization</code>) when a redirect crosses to a different host, so that a credential or session is not
+     * leaked to the redirect target. The target is considered a different host when its scheme, host or port differs from
+     * the request being redirected. Enabled by default.
+     *
+     * @param value <code>true</code> if sensitive headers should be stripped on a cross-host redirect, <code>false</code> to forward them as before.
+     * @return An updated RedirectConfig
+     */
+    public RedirectConfig stripSensitiveHeadersOnCrossHostRedirect(boolean value) {
+        return new RedirectConfig(followRedirects, allowCircularRedirects, rejectRelativeRedirect, maxRedirects, value, true);
     }
 
     /**
@@ -138,6 +155,13 @@ public class RedirectConfig implements Config {
      */
     public int maxRedirects() {
         return maxRedirects;
+    }
+
+    /**
+     * @return <code>true</code> if configured to strip sensitive headers on a cross-host redirect
+     */
+    public boolean stripsSensitiveHeadersOnCrossHostRedirect() {
+        return stripSensitiveHeadersOnCrossHostRedirect;
     }
 
     /**

--- a/rest-assured/src/main/java/io/restassured/config/RedirectConfig.java
+++ b/rest-assured/src/main/java/io/restassured/config/RedirectConfig.java
@@ -113,7 +113,7 @@ public class RedirectConfig implements Config {
      * Configure whether REST Assured should strip sensitive headers (<code>Authorization</code>, <code>Cookie</code> and
      * <code>Proxy-Authorization</code>) when a redirect crosses to a different host, so that a credential or session is not
      * leaked to the redirect target. The target is considered a different host when its scheme, host or port differs from
-     * the request being redirected. Enabled by default.
+     * the first (original) request in the redirect chain. Enabled by default.
      *
      * @param value <code>true</code> if sensitive headers should be stripped on a cross-host redirect, <code>false</code> to forward them as before.
      * @return An updated RedirectConfig

--- a/rest-assured/src/main/java/io/restassured/internal/http/CrossHostSensitiveHeaderStripper.java
+++ b/rest-assured/src/main/java/io/restassured/internal/http/CrossHostSensitiveHeaderStripper.java
@@ -23,9 +23,13 @@ import org.apache.http.protocol.HttpContext;
 import org.apache.http.protocol.HttpCoreContext;
 
 /**
- * Strips credential-bearing headers (<code>Authorization</code>, <code>Cookie</code>, <code>Proxy-Authorization</code>)
- * from a request whose target host differs from the host of the original request in the same execution. This prevents a
- * redirect that crosses to a different origin from leaking the caller's token or session to that origin.
+ * Strips origin-scoped credential headers (<code>Authorization</code> and <code>Cookie</code>) from a request whose
+ * target host differs from the host of the original request in the same execution. This prevents a redirect that crosses
+ * to a different origin from leaking the caller's token or session to that origin.
+ * <p>
+ * <code>Proxy-Authorization</code> is deliberately not stripped: it authenticates to the proxy, which does not change
+ * when a redirect crosses to a different target host, and HttpClient re-adds it per request from the configured
+ * credentials, so stripping it would break authenticated-proxy setups without preventing any origin leak.
  * <p>
  * Apache HttpClient 4.5's request director copies the original request headers onto the redirected request after the
  * {@link org.apache.http.client.RedirectStrategy} runs, so the stripping has to happen on the outgoing request itself.
@@ -35,7 +39,7 @@ import org.apache.http.protocol.HttpCoreContext;
 public class CrossHostSensitiveHeaderStripper implements HttpRequestInterceptor {
 
     private static final String ORIGIN_HOST_ATTRIBUTE = "rest-assured.origin-host";
-    private static final String[] SENSITIVE_HEADERS = {"Authorization", "Cookie", "Proxy-Authorization"};
+    private static final String[] SENSITIVE_HEADERS = {"Authorization", "Cookie"};
 
     @Override
     public void process(HttpRequest request, HttpContext context) {

--- a/rest-assured/src/main/java/io/restassured/internal/http/CrossHostSensitiveHeaderStripper.java
+++ b/rest-assured/src/main/java/io/restassured/internal/http/CrossHostSensitiveHeaderStripper.java
@@ -60,7 +60,24 @@ public class CrossHostSensitiveHeaderStripper implements HttpRequestInterceptor 
 
     private static boolean isCrossOrigin(HttpHost origin, HttpHost current) {
         return !origin.getHostName().equalsIgnoreCase(current.getHostName())
-                || origin.getPort() != current.getPort()
-                || !origin.getSchemeName().equalsIgnoreCase(current.getSchemeName());
+                || !origin.getSchemeName().equalsIgnoreCase(current.getSchemeName())
+                || effectivePort(origin) != effectivePort(current);
+    }
+
+    // HttpHost.getPort() is -1 when the URL omits the port; resolve it to the scheme default so that,
+    // for example, http://example.com and http://example.com:80 are treated as the same origin.
+    private static int effectivePort(HttpHost host) {
+        int port = host.getPort();
+        if (port != -1) {
+            return port;
+        }
+        String scheme = host.getSchemeName();
+        if ("https".equalsIgnoreCase(scheme)) {
+            return 443;
+        }
+        if ("http".equalsIgnoreCase(scheme)) {
+            return 80;
+        }
+        return -1;
     }
 }

--- a/rest-assured/src/main/java/io/restassured/internal/http/CrossHostSensitiveHeaderStripper.java
+++ b/rest-assured/src/main/java/io/restassured/internal/http/CrossHostSensitiveHeaderStripper.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.restassured.internal.http;
+
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.protocol.HttpCoreContext;
+
+/**
+ * Strips credential-bearing headers (<code>Authorization</code>, <code>Cookie</code>, <code>Proxy-Authorization</code>)
+ * from a request whose target host differs from the host of the original request in the same execution. This prevents a
+ * redirect that crosses to a different origin from leaking the caller's token or session to that origin.
+ * <p>
+ * Apache HttpClient 4.5's request director copies the original request headers onto the redirected request after the
+ * {@link org.apache.http.client.RedirectStrategy} runs, so the stripping has to happen on the outgoing request itself.
+ * This interceptor runs for every request in the redirect chain and compares the current target host against the origin
+ * host recorded on the first request in the same {@link HttpContext}. HttpClient 5.5 added equivalent behavior natively.
+ */
+public class CrossHostSensitiveHeaderStripper implements HttpRequestInterceptor {
+
+    private static final String ORIGIN_HOST_ATTRIBUTE = "rest-assured.origin-host";
+    private static final String[] SENSITIVE_HEADERS = {"Authorization", "Cookie", "Proxy-Authorization"};
+
+    @Override
+    public void process(HttpRequest request, HttpContext context) {
+        HttpHost currentHost = (HttpHost) context.getAttribute(HttpCoreContext.HTTP_TARGET_HOST);
+        if (currentHost == null) {
+            return;
+        }
+
+        HttpHost originHost = (HttpHost) context.getAttribute(ORIGIN_HOST_ATTRIBUTE);
+        if (originHost == null) {
+            // First request in this execution defines the origin; nothing to strip yet.
+            context.setAttribute(ORIGIN_HOST_ATTRIBUTE, currentHost);
+            return;
+        }
+
+        if (isCrossOrigin(originHost, currentHost)) {
+            for (String header : SENSITIVE_HEADERS) {
+                request.removeHeaders(header);
+            }
+        }
+    }
+
+    private static boolean isCrossOrigin(HttpHost origin, HttpHost current) {
+        return !origin.getHostName().equalsIgnoreCase(current.getHostName())
+                || origin.getPort() != current.getPort()
+                || !origin.getSchemeName().equalsIgnoreCase(current.getSchemeName());
+    }
+}

--- a/rest-assured/src/test/java/io/restassured/RedirectSensitiveHeaderStrippingTest.java
+++ b/rest-assured/src/test/java/io/restassured/RedirectSensitiveHeaderStrippingTest.java
@@ -64,6 +64,28 @@ class RedirectSensitiveHeaderStrippingTest {
     }
 
     @Test
+    void stripsAuthInterceptorInjectedHeaderOnCrossHostRedirect() throws Exception {
+        // OAuth signs the request through an OAuthSigner request interceptor that sets Authorization. The stripper
+        // must run after it, otherwise the signer re-adds the header on the redirected request.
+        Headers leaked = new Headers();
+        HttpServer sink = sinkServer(leaked);
+        HttpServer origin = redirectingServer("http://127.0.0.1:" + sink.getAddress().getPort() + "/leak");
+        try {
+            given().
+                    auth().oauth("consumerKey", "consumerSecret", "accessToken", "secretToken").
+            when().
+                    get("http://127.0.0.1:" + origin.getAddress().getPort() + "/start").
+            then().
+                    statusCode(200);
+
+            assertThat(leaked.authorization.get()).isNull();
+        } finally {
+            origin.stop(0);
+            sink.stop(0);
+        }
+    }
+
+    @Test
     void keepsSensitiveHeadersOnSameHostRedirect() throws Exception {
         Headers received = new Headers();
         HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);

--- a/rest-assured/src/test/java/io/restassured/RedirectSensitiveHeaderStrippingTest.java
+++ b/rest-assured/src/test/java/io/restassured/RedirectSensitiveHeaderStrippingTest.java
@@ -48,6 +48,7 @@ class RedirectSensitiveHeaderStrippingTest {
             given().
                     header("Authorization", "Bearer secret").
                     header("Cookie", "session=cookie").
+                    header("Proxy-Authorization", "Basic proxy").
             when().
                     get("http://127.0.0.1:" + origin.getAddress().getPort() + "/start").
             then().
@@ -55,6 +56,7 @@ class RedirectSensitiveHeaderStrippingTest {
 
             assertThat(leaked.authorization.get()).isNull();
             assertThat(leaked.cookie.get()).isNull();
+            assertThat(leaked.proxyAuthorization.get()).isNull();
         } finally {
             origin.stop(0);
             sink.stop(0);
@@ -73,6 +75,7 @@ class RedirectSensitiveHeaderStrippingTest {
         server.createContext("/target", exchange -> {
             received.authorization.set(exchange.getRequestHeaders().getFirst("Authorization"));
             received.cookie.set(exchange.getRequestHeaders().getFirst("Cookie"));
+            received.proxyAuthorization.set(exchange.getRequestHeaders().getFirst("Proxy-Authorization"));
             send(exchange, "ok");
         });
         server.start();
@@ -80,6 +83,7 @@ class RedirectSensitiveHeaderStrippingTest {
             given().
                     header("Authorization", "Bearer secret").
                     header("Cookie", "session=cookie").
+                    header("Proxy-Authorization", "Basic proxy").
             when().
                     get("http://127.0.0.1:" + server.getAddress().getPort() + "/start").
             then().
@@ -87,6 +91,7 @@ class RedirectSensitiveHeaderStrippingTest {
 
             assertThat(received.authorization.get()).isEqualTo("Bearer secret");
             assertThat(received.cookie.get()).isEqualTo("session=cookie");
+            assertThat(received.proxyAuthorization.get()).isEqualTo("Basic proxy");
         } finally {
             server.stop(0);
         }
@@ -102,6 +107,7 @@ class RedirectSensitiveHeaderStrippingTest {
                     config(config().redirect(redirectConfig().stripSensitiveHeadersOnCrossHostRedirect(false))).
                     header("Authorization", "Bearer secret").
                     header("Cookie", "session=cookie").
+                    header("Proxy-Authorization", "Basic proxy").
             when().
                     get("http://127.0.0.1:" + origin.getAddress().getPort() + "/start").
             then().
@@ -109,6 +115,7 @@ class RedirectSensitiveHeaderStrippingTest {
 
             assertThat(leaked.authorization.get()).isEqualTo("Bearer secret");
             assertThat(leaked.cookie.get()).isEqualTo("session=cookie");
+            assertThat(leaked.proxyAuthorization.get()).isEqualTo("Basic proxy");
         } finally {
             origin.stop(0);
             sink.stop(0);
@@ -120,6 +127,7 @@ class RedirectSensitiveHeaderStrippingTest {
         sink.createContext("/leak", exchange -> {
             captured.authorization.set(exchange.getRequestHeaders().getFirst("Authorization"));
             captured.cookie.set(exchange.getRequestHeaders().getFirst("Cookie"));
+            captured.proxyAuthorization.set(exchange.getRequestHeaders().getFirst("Proxy-Authorization"));
             send(exchange, "ok");
         });
         sink.start();
@@ -148,5 +156,6 @@ class RedirectSensitiveHeaderStrippingTest {
     private static final class Headers {
         final AtomicReference<String> authorization = new AtomicReference<>();
         final AtomicReference<String> cookie = new AtomicReference<>();
+        final AtomicReference<String> proxyAuthorization = new AtomicReference<>();
     }
 }

--- a/rest-assured/src/test/java/io/restassured/RedirectSensitiveHeaderStrippingTest.java
+++ b/rest-assured/src/test/java/io/restassured/RedirectSensitiveHeaderStrippingTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.restassured;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.restassured.RestAssured.config;
+import static io.restassured.RestAssured.given;
+import static io.restassured.config.RedirectConfig.redirectConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RedirectSensitiveHeaderStrippingTest {
+
+    @AfterEach
+    public void reset() {
+        RestAssured.reset();
+    }
+
+    @Test
+    void stripsSensitiveHeadersOnCrossHostRedirectByDefault() throws Exception {
+        Headers leaked = new Headers();
+        HttpServer sink = sinkServer(leaked);
+        HttpServer origin = redirectingServer("http://127.0.0.1:" + sink.getAddress().getPort() + "/leak");
+        try {
+            given().
+                    header("Authorization", "Bearer secret").
+                    header("Cookie", "session=cookie").
+            when().
+                    get("http://localhost:" + origin.getAddress().getPort() + "/start").
+            then().
+                    statusCode(200);
+
+            assertThat(leaked.authorization.get()).isNull();
+            assertThat(leaked.cookie.get()).isNull();
+        } finally {
+            origin.stop(0);
+            sink.stop(0);
+        }
+    }
+
+    @Test
+    void keepsSensitiveHeadersOnSameHostRedirect() throws Exception {
+        Headers received = new Headers();
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/start", exchange -> {
+            exchange.getResponseHeaders().set("Location", "/target");
+            exchange.sendResponseHeaders(302, -1);
+            exchange.close();
+        });
+        server.createContext("/target", exchange -> {
+            received.authorization.set(exchange.getRequestHeaders().getFirst("Authorization"));
+            received.cookie.set(exchange.getRequestHeaders().getFirst("Cookie"));
+            send(exchange, "ok");
+        });
+        server.start();
+        try {
+            given().
+                    header("Authorization", "Bearer secret").
+                    header("Cookie", "session=cookie").
+            when().
+                    get("http://127.0.0.1:" + server.getAddress().getPort() + "/start").
+            then().
+                    statusCode(200);
+
+            assertThat(received.authorization.get()).isEqualTo("Bearer secret");
+            assertThat(received.cookie.get()).isEqualTo("session=cookie");
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void forwardsSensitiveHeadersOnCrossHostRedirectWhenStrippingIsDisabled() throws Exception {
+        Headers leaked = new Headers();
+        HttpServer sink = sinkServer(leaked);
+        HttpServer origin = redirectingServer("http://127.0.0.1:" + sink.getAddress().getPort() + "/leak");
+        try {
+            given().
+                    config(config().redirect(redirectConfig().stripSensitiveHeadersOnCrossHostRedirect(false))).
+                    header("Authorization", "Bearer secret").
+                    header("Cookie", "session=cookie").
+            when().
+                    get("http://localhost:" + origin.getAddress().getPort() + "/start").
+            then().
+                    statusCode(200);
+
+            assertThat(leaked.authorization.get()).isEqualTo("Bearer secret");
+            assertThat(leaked.cookie.get()).isEqualTo("session=cookie");
+        } finally {
+            origin.stop(0);
+            sink.stop(0);
+        }
+    }
+
+    private static HttpServer sinkServer(Headers captured) throws IOException {
+        HttpServer sink = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        sink.createContext("/leak", exchange -> {
+            captured.authorization.set(exchange.getRequestHeaders().getFirst("Authorization"));
+            captured.cookie.set(exchange.getRequestHeaders().getFirst("Cookie"));
+            send(exchange, "ok");
+        });
+        sink.start();
+        return sink;
+    }
+
+    private static HttpServer redirectingServer(String location) throws IOException {
+        HttpServer origin = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        origin.createContext("/start", exchange -> {
+            exchange.getResponseHeaders().set("Location", location);
+            exchange.sendResponseHeaders(302, -1);
+            exchange.close();
+        });
+        origin.start();
+        return origin;
+    }
+
+    private static void send(HttpExchange exchange, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.sendResponseHeaders(200, bytes.length);
+        try (OutputStream output = exchange.getResponseBody()) {
+            output.write(bytes);
+        }
+    }
+
+    private static final class Headers {
+        final AtomicReference<String> authorization = new AtomicReference<>();
+        final AtomicReference<String> cookie = new AtomicReference<>();
+    }
+}

--- a/rest-assured/src/test/java/io/restassured/RedirectSensitiveHeaderStrippingTest.java
+++ b/rest-assured/src/test/java/io/restassured/RedirectSensitiveHeaderStrippingTest.java
@@ -49,7 +49,7 @@ class RedirectSensitiveHeaderStrippingTest {
                     header("Authorization", "Bearer secret").
                     header("Cookie", "session=cookie").
             when().
-                    get("http://localhost:" + origin.getAddress().getPort() + "/start").
+                    get("http://127.0.0.1:" + origin.getAddress().getPort() + "/start").
             then().
                     statusCode(200);
 
@@ -103,7 +103,7 @@ class RedirectSensitiveHeaderStrippingTest {
                     header("Authorization", "Bearer secret").
                     header("Cookie", "session=cookie").
             when().
-                    get("http://localhost:" + origin.getAddress().getPort() + "/start").
+                    get("http://127.0.0.1:" + origin.getAddress().getPort() + "/start").
             then().
                     statusCode(200);
 

--- a/rest-assured/src/test/java/io/restassured/RedirectSensitiveHeaderStrippingTest.java
+++ b/rest-assured/src/test/java/io/restassured/RedirectSensitiveHeaderStrippingTest.java
@@ -56,7 +56,8 @@ class RedirectSensitiveHeaderStrippingTest {
 
             assertThat(leaked.authorization.get()).isNull();
             assertThat(leaked.cookie.get()).isNull();
-            assertThat(leaked.proxyAuthorization.get()).isNull();
+            // Proxy-Authorization authenticates to the proxy, which does not change on a redirect, so it is preserved.
+            assertThat(leaked.proxyAuthorization.get()).isEqualTo("Basic proxy");
         } finally {
             origin.stop(0);
             sink.stop(0);


### PR DESCRIPTION
Redirects are followed by default, and caller headers are handed to Apache HttpClient 4.5.13, which (unlike HttpClient 5.5) doesn't strip sensitive headers when a redirect crosses to a different host. So a malicious or compromised endpoint under test can harvest the caller's `Authorization` token or `Cookie` by replying with a cross-host `Location`. For a test tool the threat model is narrow (the endpoint under test has to be attacker-controlled), so this is defense-in-depth hardening rather than a critical bug.

The fix adds a request interceptor that strips `Authorization` and `Cookie` when the request's target origin (scheme, host or port) differs from the origin of the first request in the same execution. HttpClient 4.5's request director re-copies the original headers onto the redirect after the `RedirectStrategy` runs, so the stripping happens on the outgoing request instead of in a redirect strategy. It mirrors what HttpClient 5.5 does natively, and the same class of issue fixed in curl (CVE-2022-27774) and requests (CVE-2018-18074).

On by default, and you can turn it off with `RedirectConfig.stripSensitiveHeadersOnCrossHostRedirect(false)`. It applies to REST Assured's Apache HttpClient (any `AbstractHttpClient`, which includes the default one). A fully custom client that isn't an `AbstractHttpClient` is left untouched.

This also adds a `SECURITY.md` pointing at GitHub private vulnerability reporting, since the repo didn't have one.

Reported by the University of Sydney security research team.
