### PR TITLE
Promote large-magnitude negative JSON numbers to double in JsonPath

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 Changelog next version
 ----------------------
+* Fix JsonPath returning -Infinity for finite negative JSON numbers whose magnitude exceeds Float.MAX_VALUE under the default FLOAT_AND_DOUBLE number configuration. The float/double selection compared the signed value against Float.MAX_VALUE, so any such negative number fell into the float branch and overflowed; it now compares the magnitude and promotes to double regardless of sign (fixes #1874). Thanks to haskiindahouse for the report.
 * Strip sensitive headers (Authorization and Cookie) when a redirect crosses to a different host, so a token or session isn't leaked to the redirect target. This is on by default and can be turned off with RedirectConfig.stripSensitiveHeadersOnCrossHostRedirect(false) (#1873). Thanks to the University of Sydney security research team (Liyi Zhou, Ziyue Wang, Strick, Maurice, and Chenchen Yu) for the report.
 
 Changelog 6.0.1 (2026-07-10)

--- a/json-path/src/main/java/io/restassured/internal/path/json/ConfigurableJsonSlurper.java
+++ b/json-path/src/main/java/io/restassured/internal/path/json/ConfigurableJsonSlurper.java
@@ -71,7 +71,7 @@ public class ConfigurableJsonSlurper {
     if (numberReturnType.isFloatOrDouble() && result instanceof BigDecimal decimal) {
       // Convert big decimal to float or double
       if (numberReturnType == NumberReturnType.DOUBLE
-              || decimal.compareTo(BigDecimal.valueOf(Float.MAX_VALUE)) > 0) {
+              || decimal.abs().compareTo(BigDecimal.valueOf(Float.MAX_VALUE)) > 0) {
         result = decimal.doubleValue();
       } else {
         result = decimal.floatValue();

--- a/json-path/src/test/java/io/restassured/path/json/JsonPathNumberTest.java
+++ b/json-path/src/test/java/io/restassured/path/json/JsonPathNumberTest.java
@@ -109,6 +109,23 @@ public class JsonPathNumberTest {
     }
 
     @Test public void
+    json_path_returns_finite_double_for_large_negative_number_with_default_config() {
+        // Given
+        final JsonPath jsonPath = new JsonPath("{\"pos\": 1e40, \"neg\": -1e40}")
+                .using(new JsonPathConfig().numberReturnType(JsonPathConfig.NumberReturnType.FLOAT_AND_DOUBLE));
+
+        // When
+        Object pos = jsonPath.get("pos");
+        Object neg = jsonPath.get("neg");
+
+        // Then
+        // A magnitude above Float.MAX_VALUE must promote to double regardless of sign, so the
+        // finite value survives instead of overflowing to +/-Infinity in the float branch.
+        assertThat(pos, equalTo(1.0E40));
+        assertThat(neg, equalTo(-1.0E40));
+    }
+
+    @Test public void
     json_path_returns_big_integer_for_primitive_number_when_configured_accordingly() {
         // Given
         final JsonPath jsonPath = new JsonPath(


### PR DESCRIPTION
## What

Fixes #1874. Under the default `FLOAT_AND_DOUBLE` number configuration, `JsonPath.get(path)` returned `-Infinity` for a finite negative JSON number whose magnitude exceeds `Float.MAX_VALUE` (e.g. `-1e40`), while its positive twin (`1e40`) was returned correctly as a `double`.

## Why

`ConfigurableJsonSlurper` selected between `float` and `double` with a sign-blind upper-bound test:

```java
if (numberReturnType == NumberReturnType.DOUBLE
        || decimal.compareTo(BigDecimal.valueOf(Float.MAX_VALUE)) > 0) {
    result = decimal.doubleValue();
} else {
    result = decimal.floatValue(); // overflows to +/-Infinity for |x| > Float.MAX_VALUE
}
```

Any negative `BigDecimal` compares below `Float.MAX_VALUE`, so a large-magnitude negative number always fell into the `float` branch, where `BigDecimal.floatValue()` overflows to `Float.NEGATIVE_INFINITY`. The fix compares the magnitude (`decimal.abs()`), so the promotion to `double` is symmetric for both signs.

## How verified

- Added a regression test in `JsonPathNumberTest` (`{"pos": 1e40, "neg": -1e40}` under the default config): it fails on `master` (`neg` was `-InfinityF`) and passes with the fix (`neg` is `-1.0E40`, symmetric with `pos`).
- `mvn -pl json-path test` on Temurin/Corretto 17 (the CI JDK): 102/102 green.
- Changelog entry added under `Changelog next version`, crediting the reporter.

One-line behavior change plus one regression test.
