### PR TITLE
Spread properties over object lists even when the first element lacks it

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 Changelog next version
 ----------------------
+* Fix JsonPath "properties" spread over a list of objects returning null when the first element lacks a "properties" key (e.g. a GeoJSON feature carrying only a geometry), a regression from the Groovy 5 migration (fixes #1875)
 * Strip sensitive headers (Authorization and Cookie) when a redirect crosses to a different host, so a token or session isn't leaked to the redirect target. This is on by default and can be turned off with RedirectConfig.stripSensitiveHeadersOnCrossHostRedirect(false) (#1873). Thanks to the University of Sydney security research team (Liyi Zhou, Ziyue Wang, Strick, Maurice, and Chenchen Yu) for the report.
 
 Changelog 6.0.1 (2026-07-10)

--- a/json-path/src/main/java/io/restassured/internal/path/json/Groovy5JsonSlurperWorkarounds.java
+++ b/json-path/src/main/java/io/restassured/internal/path/json/Groovy5JsonSlurperWorkarounds.java
@@ -54,9 +54,13 @@ class Groovy5JsonSlurperWorkarounds {
     private static final long serialVersionUID = 1L;
 
     public Object getProperties() {
-      if (!isEmpty() && get(0) instanceof Map<?, ?> entry0 && entry0.containsKey(PROPERTIES)) {
+      if (!isEmpty() && stream().anyMatch(elem -> elem instanceof Map<?, ?> map && map.containsKey(PROPERTIES))) {
         // Groovy 4–style JSON behaviour:
         // [map, map].properties -> [map['properties'], ...]
+        // Any element carrying a "properties" key marks this as a JSON-field spread rather than a
+        // meta-property access. Gating on element [0] alone dropped the whole spread when the first
+        // element happened to lack "properties" (e.g. a GeoJSON feature with only a geometry), even
+        // though feature order is not guaranteed and later elements did carry it.
         return stream().map(elem -> {
           if (elem instanceof Map<?, ?> map && map.containsKey(PROPERTIES)) {
             return map.get(PROPERTIES);

--- a/json-path/src/test/java/io/restassured/path/json/JsonPathTest.java
+++ b/json-path/src/test/java/io/restassured/path/json/JsonPathTest.java
@@ -828,6 +828,16 @@ public class JsonPathTest {
 
         // Then the spread yields the values of the features that do carry "properties" instead of null
         assertThat(jsonPath.getList("features.properties.gridId", Integer.class), hasItems(6, 7));
+
+        // hasItems above only proves the surviving values are present; it cannot distinguish
+        // [null, 6, 7] from [6, 7]. Assert features.properties directly so the positional-null
+        // contract is pinned: the properties-less first feature must keep its slot as a leading
+        // null rather than being dropped, leaving a 3-element list of [null, {gridId=6}, {gridId=7}].
+        List<Map<String, Object>> propertiesByFeature = jsonPath.getList("features.properties");
+        assertThat(propertiesByFeature, hasSize(3));
+        assertThat(propertiesByFeature.get(0), is(nullValue()));
+        assertThat(propertiesByFeature.get(1), hasEntry("gridId", (Object) 6));
+        assertThat(propertiesByFeature.get(2), hasEntry("gridId", (Object) 7));
     }
 
     @Test public void

--- a/json-path/src/test/java/io/restassured/path/json/JsonPathTest.java
+++ b/json-path/src/test/java/io/restassured/path/json/JsonPathTest.java
@@ -787,6 +787,50 @@ public class JsonPathTest {
     }
 
     @Test public void
+    spreads_properties_over_list_of_objects_even_when_the_first_element_lacks_the_properties_key() {
+        // Given a GeoJSON-style FeatureCollection whose FIRST feature has no "properties".
+        // GeoJSON permits an absent "properties" and does not guarantee feature order, so a leading
+        // feature without "properties" must not wipe the whole spread (issue #1875).
+        String json = """
+                {
+                   "features":[
+                      {
+                         "type":"Feature",
+                         "geometry":{
+                            "type":"Point",
+                            "coordinates":[19.883992823270653, 50.02026203045478]
+                         }
+                      },
+                      {
+                         "type":"Feature",
+                         "geometry":{
+                            "type":"Point",
+                            "coordinates":[19.901266347582094, 50.07074684071764]
+                         },
+                         "properties":{
+                            "gridId":6
+                         }
+                      },
+                      {
+                         "type":"Feature",
+                         "geometry":{
+                            "type":"Point",
+                            "coordinates":[19.912345678901234, 50.11223344556677]
+                         },
+                         "properties":{
+                            "gridId":7
+                         }
+                      }
+                   ]
+                }""";
+        // When
+        JsonPath jsonPath = new JsonPath(json);
+
+        // Then the spread yields the values of the features that do carry "properties" instead of null
+        assertThat(jsonPath.getList("features.properties.gridId", Integer.class), hasItems(6, 7));
+    }
+
+    @Test public void
     can_manually_escape_class_property() {
         // Given
         String json = "{\n" +


### PR DESCRIPTION
## What & why

`features.properties` on a list of objects returns `null` when the first element has no `properties` key. This is a 6.0.0 regression from the Groovy 5 migration workarounds: `Groovy5JsonSlurperWorkarounds.getProperties()` gates the whole spread on element `[0]` containing the key. In GeoJSON FeatureCollections a feature may legally omit `properties` and feature order carries no guarantees, so a leading geometry-only feature wiped the entire spread.

## Fix

Detect the JSON-field spread by checking whether **any** element carries the key (`stream().anyMatch(...)`) instead of only element `[0]`, restoring the Groovy 4 behaviour the workaround exists to preserve.

## Tests

- New `JsonPathTest#spreads_properties_over_list_of_objects_even_when_the_first_element_lacks_the_properties_key`: GeoJSON-style collection whose first feature has no `properties`. Verified it fails on current master (reproduces #1875) and passes with the fix.
- Full `json-path` module test suite green locally.
- `changelog.txt` entry added under "next version".

Fixes #1875
