### PR TITLE
Fix nested properties navigation over a list of objects in JsonPath (#1879)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 Changelog next version
 ----------------------
+* Fix JsonPath returning null or Groovy meta-data for a nested "properties" navigation over a list of objects (e.g. items.properties.properties.x) on Groovy 5, because the list spread result was a plain list instead of the proxy list that carries the "properties" workaround forward (fixes #1879)
 * Strip sensitive headers (Authorization and Cookie) when a redirect crosses to a different host, so a token or session isn't leaked to the redirect target. This is on by default and can be turned off with RedirectConfig.stripSensitiveHeadersOnCrossHostRedirect(false) (#1873). Thanks to the University of Sydney security research team (Liyi Zhou, Ziyue Wang, Strick, Maurice, and Chenchen Yu) for the report.
 
 Changelog 6.0.1 (2026-07-10)

--- a/json-path/src/main/java/io/restassured/internal/path/json/Groovy5JsonSlurperWorkarounds.java
+++ b/json-path/src/main/java/io/restassured/internal/path/json/Groovy5JsonSlurperWorkarounds.java
@@ -57,13 +57,17 @@ class Groovy5JsonSlurperWorkarounds {
       if (!isEmpty() && get(0) instanceof Map<?, ?> entry0 && entry0.containsKey(PROPERTIES)) {
         // Groovy 4–style JSON behaviour:
         // [map, map].properties -> [map['properties'], ...]
-        return stream().map(elem -> {
+        // Collect into a ProxyArray (not a plain List) so that a further "properties" hop on the
+        // spread result keeps navigating the JSON field instead of leaking Groovy meta-data.
+        ProxyArray spread = new ProxyArray();
+        for (Object elem : this) {
           if (elem instanceof Map<?, ?> map && map.containsKey(PROPERTIES)) {
-            return map.get(PROPERTIES);
+            spread.add(map.get(PROPERTIES));
           } else {
-            return null;
+            spread.add(null);
           }
-        }).toList();
+        }
+        return spread;
       }
       return null;
     }

--- a/json-path/src/test/java/io/restassured/path/json/JsonPathTest.java
+++ b/json-path/src/test/java/io/restassured/path/json/JsonPathTest.java
@@ -787,6 +787,22 @@ public class JsonPathTest {
     }
 
     @Test public void
+    spreads_nested_properties_over_a_list_of_objects() {
+        // items.properties.x (single spread) and properties.properties.x (nested map) both work;
+        // the nested list form must too. The list "properties" spread result must stay a proxy list
+        // so the second "properties" hop navigates the JSON field, not Groovy meta-data (issue #1879).
+        String json = """
+                {
+                   "items":[
+                      { "properties": { "properties": { "gridId": 6 } } },
+                      { "properties": { "properties": { "gridId": 7 } } }
+                   ]
+                }""";
+        JsonPath jsonPath = new JsonPath(json);
+        assertThat(jsonPath.getList("items.properties.properties.gridId", Integer.class), contains(6, 7));
+    }
+
+    @Test public void
     can_manually_escape_class_property() {
         // Given
         String json = "{\n" +


### PR DESCRIPTION
## What

Fixes #1879.

On Groovy 5, `JsonPath` navigation of the form `items.properties.properties.gridId` (a nested `properties` field over a list of objects) returned `null` or leaked Groovy meta-data such as `{class, empty}` instead of the JSON values.

## Why

`Groovy5JsonSlurperWorkarounds.ProxyArray.getProperties()` spreads a list of objects onto their `"properties"` field, but it collected the result with `stream().map(...).toList()`, producing a plain immutable `List`. A subsequent `.properties` hop on that result therefore hit Groovy meta-properties again (the very thing the workaround exists to block), so the second navigation broke.

The fix collects the spread into a `ProxyArray` so the workaround is carried forward across chained `"properties"` navigations. This is independent of the element-gate change in #1878 (which only decides *which* elements are spread, not the *type* of the spread result) and applies identically to the current and post-#1878 versions of the method.

## Verification

- Added `spreads_nested_properties_over_a_list_of_objects` to `JsonPathTest`. It FAILS on unmodified `master` (`Expected iterable containing [<6>, <7>] but no item was <6>`) and PASSES with the fix.
- `mvn -pl json-path -am verify` (JDK 17): `JsonPathTest` 74/74 green, full json-path module 102/102 green.
