### PR TITLE
Fix PathSupport URL parsing when query parameter contains another URL (#1836)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 Changelog next version
 ----------------------
+* Fix PathSupport throwing MalformedURLException when target URL has no path slash before a query parameter containing another URL (fixes #1836)
 * Strip sensitive headers (Authorization and Cookie) when a redirect crosses to a different host, so a token or session isn't leaked to the redirect target. This is on by default and can be turned off with RedirectConfig.stripSensitiveHeadersOnCrossHostRedirect(false) (#1873). Thanks to the University of Sydney security research team (Liyi Zhou, Ziyue Wang, Strick, Maurice, and Chenchen Yu) for the report.
 
 Changelog 6.0.1 (2026-07-10)

--- a/rest-assured/src/main/groovy/io/restassured/internal/support/PathSupport.groovy
+++ b/rest-assured/src/main/groovy/io/restassured/internal/support/PathSupport.groovy
@@ -44,8 +44,9 @@ class PathSupport {
       return false
     }
 
-    def indexOfFirstSlash = targetUri.indexOf("/");
-    def indexOfScheme = targetUri.indexOf("://");
+    def path = StringUtils.substringBefore(targetUri, "?")
+    def indexOfFirstSlash = path.indexOf("/")
+    def indexOfScheme = path.indexOf("://")
     if (indexOfScheme == -1) {
       // If we didn't find a single :// in the path then we know that the targetUri is not fully-qualified
       return false
@@ -59,14 +60,14 @@ class PathSupport {
     }
 
     def path = StringUtils.substringBefore(targetUri, "?")
-    def indexOfScheme = path.indexOf("://");
+    def indexOfScheme = path.indexOf("://")
     if (indexOfScheme == -1) {
       return StringUtils.startsWith(path, "/") ? path : "/" + path
     }
-    def indexOfPath = StringUtils.indexOf(targetUri, "/", indexOfScheme + 3);
+    def indexOfPath = StringUtils.indexOf(path, "/", indexOfScheme + 3)
     if (indexOfPath == -1) {
       return "/"
     }
-    StringUtils.substringBefore(targetUri.substring(indexOfPath), "?")
+    path.substring(indexOfPath)
   }
 }

--- a/rest-assured/src/test/java/io/restassured/internal/support/PathSupportTest.java
+++ b/rest-assured/src/test/java/io/restassured/internal/support/PathSupportTest.java
@@ -141,4 +141,26 @@ public class PathSupportTest {
         // Then
         assertThat(path, is("/path"));
     }
+
+    @Test public void
+    returns_slash_when_fully_qualified_uri_has_no_path_and_query_param_has_url() {
+        // Given
+        String targetUri = "https://example.com?redirect=https://example.com/callback";
+
+        // When
+        String path = PathSupport.getPath(targetUri);
+
+        // Then
+        assertThat(path, is("/"));
+    }
+
+    @Test public void
+    correctly_identifies_fully_qualified_uri_when_no_path_and_query_param_has_url() {
+        assertThat(PathSupport.isFullyQualified("https://example.com?redirect=https://example.com/callback"), is(true));
+    }
+
+    @Test public void
+    correctly_identifies_non_fully_qualified_uri_when_query_param_has_url() {
+        assertThat(PathSupport.isFullyQualified("example.com?redirect=https://example.com/callback"), is(false));
+    }
 }


### PR DESCRIPTION
## What

Fixes #1836.

Fixes MalformedURLException thrown when a target URL contains another URL in a query parameter without a trailing slash before the query string (e.g. `https://example.com?redirect=https://example.com/callback`).

## Why

In `PathSupport.groovy`, `isFullyQualified(targetUri)` and `getPath(targetUri)` searched for the first path slash `/` after scheme in `targetUri` rather than in `path` (the URL string before `?`).

When `targetUri` had no path slash before `?` (such as `https://example.com?redirect=...`), line 66 of `getPath()` (`StringUtils.indexOf(targetUri, "/", indexOfScheme + 3)`) matched the slash inside the query parameter (`?redirect=https://...`), returning `/example.com/callback` instead of `/`. Similarly, `isFullyQualified("example.com?redirect=https://...")` incorrectly returned `true`.

By scoping the slash search to `path` (the substring before `?`), `getPath()` returns `/` and `isFullyQualified()` accurately determines if `path` itself has a scheme and path.

## Verification

- Added `returns_slash_when_fully_qualified_uri_has_no_path_and_query_param_has_url`, `correctly_identifies_fully_qualified_uri_when_no_path_and_query_param_has_url`, and `correctly_identifies_non_fully_qualified_uri_when_query_param_has_url` to `PathSupportTest`.
- `mvn -pl rest-assured -am test`: all 188 tests in module `rest-assured` pass.
